### PR TITLE
Added ZIndex ordering by using Sort on _updatedAt

### DIFF
--- a/webstack/apps/webapp/src/app/pages/Board.tsx
+++ b/webstack/apps/webapp/src/app/pages/Board.tsx
@@ -230,8 +230,8 @@ export function BoardPage() {
           dragHandleClassName={'board-handle'}
           scale={scale}
         >
-          {/* Apps */}
-          {apps.map((app) => {
+          {/* Apps - SORT is to zIndex order them */}
+          {apps.sort((a, b) => a._updatedAt - b._updatedAt).map((app) => {
             const Component = Applications[app.data.type];
             return <Component key={app._id} {...app}></Component>;
           })}

--- a/webstack/libs/applications/src/lib/components/AppWindow.tsx
+++ b/webstack/libs/applications/src/lib/components/AppWindow.tsx
@@ -98,14 +98,22 @@ export function AppWindow(props: WindowProps) {
     update(props.app._id, { minimized: !minimized });
   }
 
+  // Bring to front function
+  // Have to set something to trigger an update. 
+  function bringToFront() {
+    update(props.app._id, { name: props.app.data.name });
+  }
+
   return (
     <Rnd
       bounds="parent"
       dragHandleClassName={'handle'}
       size={{ width: size.width, height: `${minimized ? titleBarHeight : size.height + titleBarHeight}px` }} // Add the height of the titlebar to give the app the full size.
       position={pos}
+      onResizeStart={bringToFront}
       onDragStop={handleDragStop}
       onResizeStop={handleResizeStop}
+      onClick={bringToFront}
       style={{
         boxShadow: `${minimized ? '' : '0 4px 16px rgba(0,0,0,0.2)'}`,
         backgroundColor: `${minimized ? 'transparent' : 'gray'}`,


### PR DESCRIPTION
This was almost too easy.

Had to add the function below to the AppWindow.
It gets called on "onClick" and "onResize" of AppWindow. 
This is to allow the app to be brought forward on a window click or resize start.
We have to "update" something to trigger the _updateAt update. So I just reset the app's name to itself.

Let me know if this is too ugly.

`// /libs/applications/src/lib/components/AppWindow.tsx`
`// LINE 100`
```  
// Bring app to front function
// Have to set something to trigger an update. 
function bringToFront() {
  update(props.app._id, { name: props.app.data.name });
}
```