### PR TITLE
context menu attmpets to position itself onscreen when near edge

### DIFF
--- a/webstack/libs/frontend/src/lib/ui/components/context-menu/context-menu.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/context-menu/context-menu.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useColorModeValue } from '@chakra-ui/react';
 
 import './style.scss';


### PR DESCRIPTION
#376 

The ContextMenu and BoardContextMenu files kinda confused me.

This does position position it correctly, but kinda hacky. 

Ignores where to position the app from the quick apps selection. It opens app in the upper left hand corner of the context menu.