### PR TITLE
clean up

### DIFF
--- a/webstack/apps/webapp/src/app/components/Board/Background/Background.tsx
+++ b/webstack/apps/webapp/src/app/components/Board/Background/Background.tsx
@@ -562,6 +562,7 @@ export function Background(props: BackgroundProps) {
         return false;
       };
     }
+
     setLassoMode(isShiftPressed);
   }, [isShiftPressed]);
 

--- a/webstack/apps/webapp/src/app/components/Board/Background/Lasso/Lasso.tsx
+++ b/webstack/apps/webapp/src/app/components/Board/Background/Lasso/Lasso.tsx
@@ -6,26 +6,10 @@
  *
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-
-// Yjs Imports
-import * as Y from 'yjs';
-import { WebsocketProvider } from 'y-websocket';
+import { useEffect, useState } from 'react';
 
 // SAGE Imports
-import {
-  useAppStore,
-  useBoardStore,
-  useCursorBoardPosition,
-  useHexColor,
-  useHotkeys,
-  useKeyPress,
-  useUIStore,
-  useUser,
-} from '@sage3/frontend';
-import { Rnd } from 'react-rnd';
-import { Box, useColorModeValue } from '@chakra-ui/react';
-import { App } from '@sage3/applications/schema';
+import { useAppStore, useCursorBoardPosition, useHexColor, useKeyPress, useUIStore } from '@sage3/frontend';
 
 type LassoProps = {
   boardId: string;
@@ -40,16 +24,16 @@ type BoxProps = {
 };
 
 export function Lasso(props: LassoProps) {
-  //board state
+  // Board state
   const boardWidth = useUIStore((state) => state.boardWidth);
   const boardHeight = useUIStore((state) => state.boardHeight);
 
-  //Laso mode apps & Selected apps
+  // Lasso mode apps & Selected apps
   const lassoMode = useUIStore((state) => state.lassoMode);
   const selectedApps = useUIStore((state) => state.selectedApps);
   const clearSelectedApps = useUIStore((state) => state.clearSelectedApps);
 
-  //Mouse Positions
+  // Mouse Positions
   const [mousedown, setMouseDown] = useState(false);
   const userCursor = useCursorBoardPosition();
   const [last_mousex, set_last_mousex] = useState(0);
@@ -57,20 +41,20 @@ export function Lasso(props: LassoProps) {
   const [mousex, set_mousex] = useState(0);
   const [mousey, set_mousey] = useState(0);
 
-  //State of cursor
+  // State of cursor
   const [isDragging, setIsDragging] = useState(false);
 
-  //key press
+  // Key press
   const spacebarPressed = useKeyPress(' ');
 
   useEffect(() => {
-    //handle if let go shift before mouse up, clear the rectangle
+    // Handle if let go shift before mouse up, clear the rectangle
     if (!lassoMode && mousedown === true) {
       mouseUp();
     }
   }, [lassoMode]);
 
-  //get initial position
+  // Get initial position
   const mouseDown = () => {
     const position = userCursor.position;
     set_last_mousex(position.x);
@@ -80,14 +64,14 @@ export function Lasso(props: LassoProps) {
 
   const mouseUp = () => {
     setMouseDown(false);
-    //Deelect all aps
+    // Deselect all aps
     if (!isDragging) {
       clearSelectedApps();
     }
     setIsDragging(false);
   };
 
-  //get last position
+  // Get last position
   const mouseMove = () => {
     const position = userCursor.position;
     setIsDragging(true);
@@ -122,35 +106,35 @@ export function Lasso(props: LassoProps) {
   );
 }
 
-//Box for selecting apps
+// Box for selecting apps
 const DrawBox = (props: BoxProps) => {
-  //get the left side of the box
+  // Get the left side of the box
   const rx = props.mousex < props.last_mousex ? props.mousex : props.last_mousex;
-  //calculate for right side
+  // Calculate for right side
   const width = Math.abs(props.mousex - props.last_mousex);
 
-  //get the top of the box
+  // Get the top of the box
   const ry = props.mousey < props.last_mousey ? props.mousey : props.last_mousey;
-  //calculate for bottom
+  // Calculate for bottom
   const height = Math.abs(props.mousey - props.last_mousey);
 
-  //app store
+  // App store
   const boardApps = useAppStore((state) => state.apps);
 
-  //ui store
+  // UI store
   const scale = useUIStore((state) => state.scale);
   const clearSelectedApps = useUIStore((state) => state.clearSelectedApps);
   const setSelectedApps = useUIStore((state) => state.setSelectedApps);
   const selectedAppId = useUIStore((state) => state.selectedAppId);
   const setSelectedApp = useUIStore((state) => state.setSelectedApp);
 
-  //used only to update store once # of selected apps change
+  // Used only to update store once # of selected apps change
   const [localSelctedApps, setLocalSelectedApps] = useState<string[]>([]);
 
-  //color
+  // Color state
   const strokeColor = useHexColor('teal');
 
-  //clear slected apps
+  // Clear slected apps
   useEffect(() => {
     clearSelectedApps();
   }, []);
@@ -165,10 +149,10 @@ const DrawBox = (props: BoxProps) => {
         app.data.position.x + app.data.size.width < rx + width &&
         app.data.position.y + app.data.size.height < ry + height
       ) {
-        //add apps as they are envoloped in box area
+        // Add apps as they are envoloped in box area
         if (!localSelctedApps.includes(app._id)) setLocalSelectedApps((prev) => [...prev, app._id]);
       } else {
-        //remove apps if not in box area
+        // Remove apps if not in box area
         if (localSelctedApps.includes(app._id)) {
           const newArray = localSelctedApps;
           const index = newArray.indexOf(app._id);
@@ -180,30 +164,28 @@ const DrawBox = (props: BoxProps) => {
   }, [width, height, rx, ry, localSelctedApps, boardApps]);
 
   useEffect(() => {
-    //if app is selected while starting lasso mode, clear app that is selected
+    // If app is selected while starting lasso mode, clear app that is selected
     if (selectedAppId.length) {
       setSelectedApp('');
     }
-    //only update UI store when local state changes
+    // Only update UI store when local state changes
     setSelectedApps(localSelctedApps);
   }, [localSelctedApps]);
 
   return (
-    <>
-      <rect
-        style={{
-          strokeWidth: 6 / scale,
-          strokeDasharray: 10 / scale,
-          stroke: strokeColor,
-          fill: strokeColor,
-          fillOpacity: 0.15,
-          zIndex: 0,
-        }}
-        x={rx}
-        y={ry}
-        height={height}
-        width={width}
-      />
-    </>
+    <rect
+      style={{
+        strokeWidth: 6 / scale,
+        strokeDasharray: 10 / scale,
+        stroke: strokeColor,
+        fill: strokeColor,
+        fillOpacity: 0.15,
+        zIndex: 0,
+      }}
+      x={rx}
+      y={ry}
+      height={height}
+      width={width}
+    />
   );
 };

--- a/webstack/libs/applications/src/lib/components/AppWindow.tsx
+++ b/webstack/libs/applications/src/lib/components/AppWindow.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { DraggableData, Position, ResizableDelta, Rnd } from 'react-rnd';
+import { DraggableData, Position, ResizableDelta, Rnd, RndDragEvent } from 'react-rnd';
 import { Box, useToast, Text, Spinner, useColorModeValue } from '@chakra-ui/react';
 import { keyframes } from '@emotion/react';
 
@@ -126,7 +126,7 @@ export function AppWindow(props: WindowProps) {
   }
 
   // When the window is being dragged
-  function handleDrag(_e: any, data: DraggableData) {
+  function handleDrag(_e: RndDragEvent, data: DraggableData) {
     setAppWasDragged(true);
     if (isGrouped) {
       const dx = data.x - props.app.data.position.x;
@@ -136,7 +136,7 @@ export function AppWindow(props: WindowProps) {
   }
 
   // Handle when the app is finished being dragged
-  function handleDragStop(_e: any, data: DraggableData) {
+  function handleDragStop(_e: RndDragEvent, data: DraggableData) {
     let x = data.x;
     let y = data.y;
     x = Math.round(x / gridSize) * gridSize;
@@ -226,7 +226,7 @@ export function AppWindow(props: WindowProps) {
     }
   }, [props.app.data.raised]);
 
-  function handleAppClick(e: any) {
+  function handleAppClick(e: MouseEvent) {
     e.stopPropagation();
     bringForward();
     // Set the selected app in the UI store

--- a/webstack/libs/frontend/src/lib/stores/ui.ts
+++ b/webstack/libs/frontend/src/lib/stores/ui.ts
@@ -13,7 +13,6 @@ import create from 'zustand';
 import { mountStoreDevtool } from 'simple-zustand-devtools';
 import { App } from '@sage3/applications/schema';
 import { SAGEColors } from '@sage3/shared';
-import { Tracing } from 'trace_events';
 import { Position } from '@sage3/shared/types';
 
 // Zoom limits, from 30% to 400%


### PR DESCRIPTION
* Removed YJs
* Fixed comments
* Removed unnecessary <></>
* toolbar item for lasso will be implemented later. I was thinking a context menu for grouped apps
* Fixed "any" in event handlers
* Trace_events was imported by mistake

Discussions for next meeting
* Break up UI store
* document.onselectstart. 
I added this because when I did a shift+click, it triggered an event to highlight everything on the board. 
When everything is highlighted, I cannot drag apps because it thinks I am copying and pasting items on the board. 
To solve this issue, I disable the event all together. 
But the issue about disabling the event all together is that shift+click does not work on apps (IE: selecting pieces of text on a stickie note). 
 