### PR TITLE
Use a single queue of message for rooms , boards and apps

### DIFF
--- a/foresight/utils/sage_communication.py
+++ b/foresight/utils/sage_communication.py
@@ -51,6 +51,9 @@ class SageCommunication(Borg):
         self.socket = SageWebsocket()
         self.socket.run()
 
+    def get_queue(self):
+        return self.socket.get_queue()
+
     def send_app_update(self, app_id, data):
         """
         :param app_id:


### PR DESCRIPTION
 - inside sage proxy
 - there was 3 queues but there were processed in sequence with an active busy loop
 - now blocking single queue
 - I don't think it reduces multi-processing
 - No busy loop, so 0% cpu at idle