### PR TITLE
[Client] Update to electron 25

### DIFF
--- a/webstack/clients/electron/electron.js
+++ b/webstack/clients/electron/electron.js
@@ -633,11 +633,21 @@ function createWindow() {
     //   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36';
   });
 
-  // Probably not used anymore
   app.on('web-contents-created', function (webContentsCreatedEvent, contents) {
     if (contents.getType() === 'webview') {
-      contents.on('new-window', function (newWindowEvent, url) {
-        newWindowEvent.preventDefault();
+      // OLD API
+      // contents.on('new-window', function (newWindowEvent, url) {
+      //   console.log('Webview> New window', url);
+      //   newWindowEvent.preventDefault();
+      // });
+
+      // NEW API
+      contents.on('dom-ready', () => {
+        // Block creating new windows from webviews
+        // TODO: tell the renderer to create another webview
+        contents.setWindowOpenHandler((details) => {
+          return { action: 'deny' };
+        });
       });
 
       // Block automatic download from webviews

--- a/webstack/clients/electron/package.json
+++ b/webstack/clients/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SAGE3",
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.30",
   "description": "Electron-based SAGE3 client",
   "main": "electron.js",
   "repository": {

--- a/webstack/clients/electron/package.json
+++ b/webstack/clients/electron/package.json
@@ -17,7 +17,7 @@
     "uuid": "8.3.0"
   },
   "devDependencies": {
-    "electron": "24.1.2",
+    "electron": "^25.0.1",
     "electron-notarize": "^1",
     "electron-packager": "latest"
   },

--- a/webstack/clients/electron/yarn.lock
+++ b/webstack/clients/electron/yarn.lock
@@ -615,10 +615,10 @@ electron-winstaller@latest:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@24.1.2:
-  version "24.1.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-24.1.2.tgz#8dd0b4928a08236be4791d39535d1d35cc05f04b"
-  integrity sha512-V0isWbyLYiXrSCcB4lrSVhS/U56NFGfuqHyc+yEPkyhhvY+h4F85cYGdEiZlXp6XjHT+/CLHmw0ltK54g9lvDw==
+electron@^25.0.1:
+  version "25.0.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-25.0.1.tgz#19b28fa9f2a0575c5ba49b4d53343240b1515b09"
+  integrity sha512-YD3xCrH01LiPeLlG90DWgMXJK69UxY4NiXKqXT12HOiXLqEaKrLWap+CiiS7J7SWUXz+4XOItQI8g1dtG7zkkA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"

--- a/webstack/libs/applications/src/lib/apps/Stickie/Stickie.tsx
+++ b/webstack/libs/applications/src/lib/apps/Stickie/Stickie.tsx
@@ -172,6 +172,10 @@ function AppComponent(props: App): JSX.Element {
           readOnly={locked} // Only the creator can edit
           zIndex={1}
           name={'stickie' + props._id}
+          css={{
+            // Balance the text, improve text layouts
+            textWrap: "balance"
+          }}
         />
         {locked && (
           <Box position="absolute" right="1" bottom="0" transformOrigin="bottom right" zIndex={2}>


### PR DESCRIPTION
 - it blocks ctrl/apple + click to create new webviews.
 - For now, drag a link from webview to board to create new webviews.