### PR TITLE
[Presence] Various Fixes

### DIFF
--- a/webstack/apps/homebase/src/api/routers/custom/subscription.ts
+++ b/webstack/apps/homebase/src/api/routers/custom/subscription.ts
@@ -99,6 +99,8 @@ export async function subscriptionWSRouter(
       break;
     }
     case 'UNSUB': {
+      // Attempt to remove the subscription from presence. It might not be for presence but have to check to avoid memory leak
+      PresenceThrottle.removeClient(message.id);
       // Unsubscribe Message
       cache.delete(message.id);
       break;

--- a/webstack/libs/backend/src/lib/utils/presence.ts
+++ b/webstack/libs/backend/src/lib/utils/presence.ts
@@ -28,12 +28,12 @@ export class SAGEPresence {
 
     this._socket.on('close', () => {
       console.log(`Presence> ${this._userId} disconnected.`);
-      this.removePresence();
+      this.setOffline();
     });
 
     this._socket.on('error', () => {
       console.log(`Presence> ${this._userId} disconnected.`);
-      this.removePresence();
+      this.setOffline();
     });
   }
 

--- a/webstack/libs/frontend/src/lib/stores/presence.ts
+++ b/webstack/libs/frontend/src/lib/stores/presence.ts
@@ -65,7 +65,7 @@ const PresenceStore = createVanilla<PresenceState>((set, get) => {
     },
     update: async (id: string, updates: Partial<PresenceSchema>) => {
       // const res = await SocketAPI.sendRESTMessage(`/presence/${id}`, 'PUT', updates);
-      const res = await SocketAPI.sendRESTMessage('/presence/' + id, 'PUT', updates);
+      const res = await SocketAPI.sendRESTMessage('/presence/' + id, 'PUT', { ...updates, status: 'online' });
       if (!res.success) {
         set({ error: res.message });
       }


### PR DESCRIPTION
Situation where user is signed in from multiple locations:
- Cursor and Viewport should update with whatever the last update it received, no matter the sign in location
- When the user signed out of one location the other location's presence got blocked and would require a hard client refresh to fix
- User updates (color, client type, name) were not being populated to other sign in location. Fix with a subscription to your own User Doc incase you change from another location.

Memory leak fix in PresenceThrottle
