### PR TITLE
[Backend] fastapi images

### DIFF
--- a/deployment/docker-compose-amd64.yml
+++ b/deployment/docker-compose-amd64.yml
@@ -55,7 +55,7 @@ services:
       jupyter:
         condition: service_healthy
   fastapi:
-    image: "sage3/fastapi:amd64"
+    image: "ghcr.io/mahdi-b/sagekernelserver:amd64"
     ports:
       - "127.0.0.1:8000:8000"
     environment:

--- a/deployment/docker-compose-arm64.yml
+++ b/deployment/docker-compose-arm64.yml
@@ -55,7 +55,7 @@ services:
       jupyter:
         condition: service_healthy
   fastapi:
-    image: "sage3/fastapi:arm64"
+    image: "ghcr.io/mahdi-b/sagekernelserver:arm64"
     ports:
       - "127.0.0.1:8000:8000"
     environment:

--- a/deployment/docker-compose-backend.yml
+++ b/deployment/docker-compose-backend.yml
@@ -17,7 +17,7 @@ services:
       - ./configurations/fluentd/log:/fluentd/log
       - ./configurations/fluentd/conf:/fluentd/etc
   fastapi:
-    image: "sage3/fastapi:latest"
+    image: "ghcr.io/mahdi-b/sagekernelserver:latest"
     ports:
       - "127.0.0.1:8000:8000"
     environment:


### PR DESCRIPTION
 - switch the fastapi docker images to sagekernelserver repo on github
 - arch specific in production
 - dev pulls the multi-arch image we can build on laptops
