### PR TITLE
[UI] switch the operation of the 'back' button

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Controller/Controller.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Controller/Controller.tsx
@@ -47,11 +47,11 @@ export function Controller(props: ControllerProps) {
   const { toHome, back } = useRouteNav();
   function handleHomeClick(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
     if (event.shiftKey) {
+      // Just go back to the previous room
+      back();
+    } else {
       // Back to the homepage with the room id
       toHome(props.roomId);
-    } else {
-      // Just go back to the previous page
-      back();
     }
   }
 
@@ -92,7 +92,8 @@ export function Controller(props: ControllerProps) {
           icon={<MdArrowBack />}
           isActive={false}
           onClick={handleHomeClick}
-          description={`Navigate back (Shift+Click to go back to ${room?.data.name})`}
+          // description={`Navigate back (Shift+Click to go back to ${room?.data.name})`}
+          description={`Back to ${room?.data.name} (Shift+Click to go back to previous board)`}
         />
 
         <IconButtonPanel icon={<MdGroups />} description="Users" isActive={users?.show} onClick={() => handleShowPanel(users)} />


### PR DESCRIPTION
Since a lot of confusion:
- regular click : back to room
- shift-click : back to previous page (i.e. board when using a board link)

![Screenshot 2023-09-29 at 9 37 28 PM](https://github.com/SAGE-3/next/assets/5595452/7c964e39-e5ed-4e43-b5d0-3d6bd8f5e506)
