### PR TITLE
[Yjs Apps] Initial state being lost with multiple users on board

### DIFF
--- a/webstack/apps/homebase/src/main.ts
+++ b/webstack/apps/homebase/src/main.ts
@@ -184,9 +184,8 @@ async function startServer() {
   });
 
   // Websocket API for YJS
+  // It handles disconnects so no need to handle on close
   yjsWebSocketServer.on('connection', (socket: WebSocket, _request: IncomingMessage, args: any) => {
-    // Show number of connections on the server
-    // console.log('YJS> connections', yjsWebSocketServer.clients.size);
     YUtils.setupWSConnection(socket, _request, args);
   });
 


### PR DESCRIPTION
The initial state for Yjs will be lost if multiple people are on the board, due to us only syncing with database when only one user on board.

Fix looks like this: 

```typescript
    const users = provider.awareness.getStates();
    const count = users.size;

    // Sync current ydoc with that is saved in the database
    const syncStateWithDatabase = () => {
      // Clear any existing lines
      yText.delete(0, yText.length);
      // Set the lines from the database
      yText.insert(0, s.text);
    };

    // If I am the only one here according to Yjs, then sync with database
    if (count == 1) {
      syncStateWithDatabase();
    } else if (count > 1 && props._createdBy === user?._id) {
      // There are other users here and I created this app.
      // Is this app less than 5 seconds old...this feels hacky
      const now = await serverTime();
      const created = props._createdAt;
      // Then we need to sync with database due to Yjs not being able to catch the initial state
      if (now.epoch - created < 5000) {
        // I created this
        syncStateWithDatabase();
      }
    }
```