### PR TITLE
Pasting images via Clipboard

### DIFF
--- a/webstack/libs/frontend/src/lib/ui/components/paste-handler/paste-handler.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/paste-handler/paste-handler.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from 'react';
 import { useToast, useDisclosure, Popover, Portal, PopoverContent, PopoverHeader, PopoverBody, Button, Center } from '@chakra-ui/react';
 
 import { initialValues } from '@sage3/applications/initialValues';
-import { isValidURL, setupApp, processContentURL, truncateWithEllipsis } from '@sage3/frontend';
+import { isValidURL, setupApp, processContentURL, truncateWithEllipsis, useFiles } from '@sage3/frontend';
 import { useUser, useAuth, useAppStore, useCursorBoardPosition, useUIStore } from '@sage3/frontend';
 import { stringContainsCode } from '@sage3/shared';
 
@@ -43,6 +43,8 @@ export const PasteHandler = (props: PasteProps): JSX.Element => {
   // Popover
   const { isOpen: popIsOpen, onOpen: popOnOpen, onClose: popOnClose } = useDisclosure();
   const [dropCursor, setDropCursor] = useState({ x: 0, y: 0 });
+  // hooks
+  const { uploadFiles, openAppForFile, uploadInProgress } = useFiles();
 
   useEffect(() => {
     if (!user) return;
@@ -71,74 +73,25 @@ export const PasteHandler = (props: PasteProps): JSX.Element => {
       const yDrop = cursorPosition.y;
       setDropCursor({ x: mousePosition.x, y: mousePosition.y });
 
-      // Open webview if url, otherwise, open a sticky
+      // Upload files from clipboard
       if (event.clipboardData?.files) {
         if (event.clipboardData.files.length > 0) {
-          // Iterate over all pasted files.
-          Array.from(event.clipboardData.files).forEach(async (file) => {
-            if (file.type.startsWith('image/')) {
-              // Images not supported yet
-              toast({
-                title: 'Copy/Paste Handler',
-                description: 'Image clipboard not supported yet',
-                status: 'error',
-                duration: 2 * 1000,
-                isClosable: true,
-              });
+          try {
+            if (!uploadInProgress) {
+              toast.closeAll();
 
-              // Works but slow
-              // For images, create an image and append it to the `body`.
-              // const reader = new FileReader();
-              // reader.readAsDataURL(file);
-              // reader.onloadend = function () {
-              //   const base64data = reader.result;
-              //   if (base64data && typeof base64data === 'string') {
-              //     if (base64data.length < 100000) {
-              //       // it's a base64 image
-              //       createApp({
-              //         title: file.name,
-              //         roomId: props.roomId,
-              //         boardId: props.boardId,
-              //         position: { x: xDrop, y: yDrop, z: 0 },
-              //         size: { width: 800, height: 600, depth: 0 },
-              //         rotation: { x: 0, y: 0, z: 0 },
-              //         type: 'ImageViewer',
-              //         state: { ...(initialValues['ImageViewer'] as AppState), assetid: base64data },
-              //         raised: true,
-              //         pinned: false,
-              //         dragging: false,
-              //       });
-              //     }
-              //   }
-              // };
-            } else if (file.type.startsWith('text/')) {
-              // Read the text
-              const textcontent = await file.text();
-              // Create a new stickie with the text
-              createApp({
-                title: truncateWithEllipsis(textcontent, 20),
-                roomId: props.roomId,
-                boardId: props.boardId,
-                position: { x: xDrop, y: yDrop, z: 0 },
-                size: { width: 400, height: 400, depth: 0 },
-                rotation: { x: 0, y: 0, z: 0 },
-                type: 'Stickie',
-                state: { ...initialValues['Stickie'], text: textcontent, fontSize: 24, color: user.data.color || 'yellow' },
-                raised: true,
-                dragging: false,
-                pinned: false,
-              });
+              uploadFiles(Array.from(event.clipboardData.files), xDrop, yDrop, props.roomId, props.boardId);
             } else {
-              // Not supported file format
               toast({
-                title: 'Copy/Paste Handler',
-                description: 'File format not supported yet',
-                status: 'error',
-                duration: 2 * 1000,
+                title: "Upload in progress - Please wait",
+                status: "warning",
+                duration: 4000,
                 isClosable: true,
-              });
+              })
             }
-          });
+          } catch (error) {
+            console.log('Error> uploading files', error);
+          }
         }
       }
 

--- a/webstack/libs/frontend/src/lib/ui/components/paste-handler/paste-handler.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/paste-handler/paste-handler.tsx
@@ -83,11 +83,11 @@ export const PasteHandler = (props: PasteProps): JSX.Element => {
               uploadFiles(Array.from(event.clipboardData.files), xDrop, yDrop, props.roomId, props.boardId);
             } else {
               toast({
-                title: "Upload in progress - Please wait",
-                status: "warning",
+                title: 'Upload in progress - Please wait',
+                status: 'warning',
                 duration: 4000,
                 isClosable: true,
-              })
+              });
             }
           } catch (error) {
             console.log('Error> uploading files', error);

--- a/webstack/libs/shared/src/lib/utils/mime-utils.ts
+++ b/webstack/libs/shared/src/lib/utils/mime-utils.ts
@@ -324,7 +324,7 @@ export function isMD(mimeType: string): boolean {
  * @returns {boolean}
  */
 export function isPython(mimeType: string): boolean {
-  return mimeType === 'application/python';
+  return mimeType === 'application/python' || mimeType === 'text/x-python-script';
 }
 
 /**


### PR DESCRIPTION
## Dev Environment
- M1 Mac
- MacOS Sonoma 14.4.1
- Google Chrome Version 124.0.6367.61 (Official Build) (arm64)

## PR Purpose
Enable users to paste images from clipboard.

## PR Description
- Used the existing `useFiles()` hook to enable clipboard pasting in `paste-handler.tsx`
- Tested pasting images and it seems to work in the browser (see video below). Unsure if it will work in Electron, would like to test.
- Added `text/x-python-script` to the Python mime checker `isPython()` in `mime-utils.ts`. Noticed that when a Python file is copied to clipboard, its type is `text/x-python-script` on my system.

https://github.com/SAGE-3/next/assets/82340101/55802995-0587-4d1a-ace3-637ac73d67f7

