### PR TITLE
Restored onClick functionality to board controller panel for touch users

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Panel.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Panel.tsx
@@ -89,7 +89,8 @@ export function IconButtonPanel(props: IconButtonPanelProps) {
           onClick={props.onClick}
           isDisabled={props.isDisabled}
           _hover={{ color: props.isActive ? iconHoverColor : iconColor, transform: 'scale(1.15)' }}
-          {...longPressEvent}
+          // onContextMenu={props.onLongPress ? props.onLongPress : () => { }} // Uncomment for Alternative solution to longPressEvent
+          {...longPressEvent} // if onContextMenu is uncommented; you should comment me
         />
       </Tooltip>
     </Box>
@@ -392,12 +393,16 @@ const useLongPress = (callback: (e: TouchEvent | MouseEvent) => void) => {
 
   const start = useCallback(
     (event: TouchEvent | MouseEvent) => {
-      // prevent ghost click on mobile devices
-      if (isPreventDefault && event.target) {
-        event.target.addEventListener('touchend', preventDefault, { passive: false });
-        target.current = event.target;
+      // prevent ghost click on mobile devices, only if long click was triggered
+      // Error prone: Long click will not stop propagation of onClick;
+      //              only currently works because the popup releases the cursor (for mouse)
+      const preventTouchClick = () => {
+        if (isPreventDefault && event.target) {
+          event.target.addEventListener('touchend', preventDefault, { passive: false });
+          target.current = event.target;
+        }
       }
-      timeout.current = setTimeout(() => callback(event), delay);
+      timeout.current = setTimeout(() => {callback(event); preventTouchClick();}, delay);
     },
     [callback, delay, isPreventDefault]
   );

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Panel.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Panel.tsx
@@ -89,8 +89,8 @@ export function IconButtonPanel(props: IconButtonPanelProps) {
           onClick={props.onClick}
           isDisabled={props.isDisabled}
           _hover={{ color: props.isActive ? iconHoverColor : iconColor, transform: 'scale(1.15)' }}
-          // onContextMenu={props.onLongPress ? props.onLongPress : () => { }} // Uncomment for Alternative solution to longPressEvent
-          {...longPressEvent} // if onContextMenu is uncommented; you should comment me
+          // onContextMenu={props.onLongPress ? props.onLongPress : () => { }} // Uncomment for alternative solution to longPressEvent
+          {...longPressEvent} // if onContextMenu is uncommented, you should comment me
         />
       </Tooltip>
     </Box>
@@ -394,8 +394,8 @@ const useLongPress = (callback: (e: TouchEvent | MouseEvent) => void) => {
   const start = useCallback(
     (event: TouchEvent | MouseEvent) => {
       // prevent ghost click on mobile devices, only if long click was triggered
-      // Error prone: Long click will not stop propagation of onClick;
-      //              only currently works because the popup releases the cursor (for mouse)
+      // Warning: LongPRess may not stop propagation of onClick for all function calls;
+      //          only currently works because the popup (modal) releases the cursor (for mouse)
       const preventTouchClick = () => {
         if (isPreventDefault && event.target) {
           event.target.addEventListener('touchend', preventDefault, { passive: false });


### PR DESCRIPTION
## Fixes:
- restored touch onClick functionality, bug was due to ```preventdefault()``` being called prior to knowing if the user has longPressed.
- ```preventdefault()``` now only triggers after longPress's ```callback(event)``` triggers

## Additional Information:
The usage of longPress in this instance may cause additional bugs. 
![image](https://github.com/user-attachments/assets/c38165c6-7b2b-4d70-ae9a-3c2eb3f2ccf3)
- Regarding the Back button in the Controller (top panel); there are rare observed instances where the popup does not release the mouse down and can causes propagation to the onClick function.
  - Non-popup long press does not prevent propagation to onClick
- **_Proposed alternative solution_** provided in line 92-93 is to use onContextMenu instead.  This allows for right clicking with mouse and long press with touch.

