### PR TITLE
Changed Long Press functionality to useContextMenu for board controller panel

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Controller/Controller.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Controller/Controller.tsx
@@ -101,7 +101,7 @@ export function Controller(props: ControllerProps) {
             isActive={false}
             onClick={handleHomeClick}
             onLongPress={popOnOpen}
-            description={`Back to ${room?.data.name} (Long-press for more options)`}
+            description={`Back to ${room?.data.name} (Right-click for more options)`}
           />
           <PopoverContent fontSize={'sm'} width={"200px"} style={{ top: 70, left: 35 }}>
             <PopoverArrow />

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Panel.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Panel.tsx
@@ -89,8 +89,8 @@ export function IconButtonPanel(props: IconButtonPanelProps) {
           onClick={props.onClick}
           isDisabled={props.isDisabled}
           _hover={{ color: props.isActive ? iconHoverColor : iconColor, transform: 'scale(1.15)' }}
-          // onContextMenu={props.onLongPress ? props.onLongPress : () => { }} // Uncomment for alternative solution to longPressEvent
-          {...longPressEvent} // if onContextMenu is uncommented, you should comment me
+          onContextMenu={props.onLongPress ? props.onLongPress : () => { }} // Uncomment for alternative solution to longPressEvent
+          // {...longPressEvent} // if onContextMeqnu is uncommented, you should comment me
         />
       </Tooltip>
     </Box>

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Panel.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Panel.tsx
@@ -90,7 +90,7 @@ export function IconButtonPanel(props: IconButtonPanelProps) {
           isDisabled={props.isDisabled}
           _hover={{ color: props.isActive ? iconHoverColor : iconColor, transform: 'scale(1.15)' }}
           onContextMenu={props.onLongPress ? props.onLongPress : () => { }} // Uncomment for alternative solution to longPressEvent
-          // {...longPressEvent} // if onContextMeqnu is uncommented, you should comment me
+          // {...longPressEvent} // if onContextMenu is uncommented, you should comment me
         />
       </Tooltip>
     </Box>


### PR DESCRIPTION
## Info:
After I modified longPress behavior to allow touch users to interact with the MainMenu for Boards (see here:  [https://github.com/SAGE-3/next/pull/981](https://github.com/SAGE-3/next/pull/981)).
I swapped to another device and noticed longPress inconsistent/ breaking behaviors.

## Fix/Changes:
![image](https://github.com/user-attachments/assets/31eadb2c-2388-4c5b-902c-253ad24fc045)
- Changed to onContextMenu instead
  - Desktop Users: Instead of long press, right click is used instead
  - Touch Users: long press remains the same
- More information can be found here: [https://github.com/SAGE-3/next/pull/981](https://github.com/SAGE-3/next/pull/981)
