### PR TITLE
[Controls] Incremental Clean-up and Minor Improvements

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
@@ -49,7 +49,6 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
   // The fabled isMac const
   const isMac = useMemo(() => /(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent), []);
 
-  // const movementAltMode = useKeyPress(' ');
   const movementTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const movementZoomSafetyTimeoutRef = useRef<number | null>(null);
 

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
@@ -31,6 +31,7 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
   const boardWidth = useUIStore((state) => state.boardWidth);
   const boardHeight = useUIStore((state) => state.boardHeight);
   const selectedApp = useUIStore((state) => state.selectedAppId);
+  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
   const setBoardPosition = useUIStore((state) => state.setBoardPosition);
   const boardPosition = useUIStore((state) => state.boardPosition);
   const boardLocked = useUIStore((state) => state.boardLocked);
@@ -112,8 +113,10 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
     // Target.id was done because of the following assumption: using ids is faster than using classList.contains(...)
     if (target.id === 'board') {
       setStartedDragOn('board');
+      setSelectedApp('');
     } else if ([target.id === 'lasso', target.id === 'whiteboard'].some((condition) => condition)) {
       setStartedDragOn('board-actions');
+      setSelectedApp('');
     } else if (target.classList.contains('handle')) {
       setStartedDragOn('app');
     } else if (target.classList.contains('app-window-resize-handle')) {
@@ -142,8 +145,10 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
       setStartedDragOn('app-resize');
     } else if (checkValidIds(['board'])) {
       setStartedDragOn('board');
+      setSelectedApp('');
     } else if (checkValidIds(['lasso', 'whiteboard'])) {
       setStartedDragOn('board-actions');
+      setSelectedApp('');
     } else {
       setStartedDragOn('other');
     }
@@ -171,9 +176,6 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
       if (boardLocked) {
         return;
       }
-      if (selectedApp) {
-        return;
-      }
 
       // This is a workable solution to have a psudeo onWheelStart-like behaviour
       // Note that if someone is wheeling on the board and then quickly wheels on a panel, the board will move
@@ -184,6 +186,10 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
         }
         return prev;
       });
+
+      if (selectedApp) {
+        return;
+      }
 
       setStartedDragOn((draggedOn) => {
         if (draggedOn === 'other') {

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
@@ -45,7 +45,8 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
     { x: 0, y: 0 },
     { x: 0, y: 0 },
   ]);
-  const [, setStartedDragOn] = useState<'board' | 'board-actions' | 'app' | 'app-resize' | 'other'>('other'); // Used to differentiate between board drag and app deselect
+  // Used to differentiate between board drag and app deselect
+  const [, setStartedDragOn] = useState<'board' | 'board-actions' | 'app' | 'app-resize' | 'other'>('other');
 
   // The fabled isMac const
   const isMac = useMemo(() => /(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent), []);

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
@@ -191,13 +191,10 @@ export function Background(props: BackgroundProps) {
 
   // Deselect Application by clicking on board
   function handleDeselect() {
-    if (selectedApp) {
-      setSelectedApp('');
-    }
-
-    if (setSelectedAppsIds.length > 0) {
-      setSelectedAppsIds([]);
-    }
+    setSelectedApp('');
+    // Maybe people would want to use lasso tool and then switch to hand to move
+    // then go back to lasso more
+    // setSelectedAppsIds([]);
   }
 
   return (
@@ -206,8 +203,9 @@ export function Background(props: BackgroundProps) {
       width="100%"
       height="100%"
       backgroundSize={'100px 100px'}
-      bgImage={`linear-gradient(to right, ${gridColor} ${1 / scale}px, transparent ${1 / scale
-        }px), linear-gradient(to bottom, ${gridColor} ${1 / scale}px, transparent ${1 / scale}px);`}
+      bgImage={`linear-gradient(to right, ${gridColor} ${1 / scale}px, transparent ${
+        1 / scale
+      }px), linear-gradient(to bottom, ${gridColor} ${1 / scale}px, transparent ${1 / scale}px);`}
       id="board"
       userSelect={'none'}
       draggable={false}
@@ -219,7 +217,7 @@ export function Background(props: BackgroundProps) {
       }}
       // Drag and drop event handlers
       {...dragProps}
-      onClick={handleDeselect}
+      onPointerDown={handleDeselect}
     >
       <HelpModal onClose={helpOnClose} isOpen={helpIsOpen}></HelpModal>
       {renderContent()}

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
@@ -61,10 +61,8 @@ export function Background(props: BackgroundProps) {
   const setBoardPosition = useUIStore((state) => state.setBoardPosition);
   const boardPosition = useUIStore((state) => state.boardPosition);
   const selectedAppId = useUIStore((state) => state.selectedAppId);
-  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
-  const setSelectedAppsIds = useUIStore((state) => state.setSelectedAppsIds);
-  const selectedApp = useUIStore((state) => state.selectedAppId);
   const boardSynced = useUIStore((state) => state.boardSynced);
+
   // Chakra Color Mode for grid color
   const gc = useColorModeValue('gray.100', 'gray.700');
   const gridColor = useHexColor(gc);

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
@@ -193,9 +193,8 @@ export function Background(props: BackgroundProps) {
       width="100%"
       height="100%"
       backgroundSize={'100px 100px'}
-      bgImage={`linear-gradient(to right, ${gridColor} ${1 / scale}px, transparent ${
-        1 / scale
-      }px), linear-gradient(to bottom, ${gridColor} ${1 / scale}px, transparent ${1 / scale}px);`}
+      bgImage={`linear-gradient(to right, ${gridColor} ${1 / scale}px, transparent ${1 / scale
+        }px), linear-gradient(to bottom, ${gridColor} ${1 / scale}px, transparent ${1 / scale}px);`}
       id="board"
       userSelect={'none'}
       draggable={false}
@@ -207,8 +206,8 @@ export function Background(props: BackgroundProps) {
       }}
       // Drag and drop event handlers
       {...dragProps}
-      // Note to future devs, handledeselect behaviour move to BackgroundLayer.tsx
-      // onPointerDown={handleDeselect}
+    // Note to future devs, handledeselect behaviour move to BackgroundLayer.tsx
+    // onPointerDown={handleDeselect}
     >
       <HelpModal onClose={helpOnClose} isOpen={helpIsOpen}></HelpModal>
       {renderContent()}

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
@@ -189,14 +189,6 @@ export function Background(props: BackgroundProps) {
     { dependencies: [] }
   );
 
-  // Deselect Application by clicking on board
-  function handleDeselect() {
-    setSelectedApp('');
-    // Maybe people would want to use lasso tool and then switch to hand to move
-    // then go back to lasso more
-    // setSelectedAppsIds([]);
-  }
-
   return (
     <Box
       className="board-handle"
@@ -217,7 +209,8 @@ export function Background(props: BackgroundProps) {
       }}
       // Drag and drop event handlers
       {...dragProps}
-      onPointerDown={handleDeselect}
+      // Note to future devs, handledeselect behaviour move to BackgroundLayer.tsx
+      // onPointerDown={handleDeselect}
     >
       <HelpModal onClose={helpOnClose} isOpen={helpIsOpen}></HelpModal>
       {renderContent()}

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
@@ -33,7 +33,6 @@ export function Lasso(props: LassoProps) {
 
   // Lasso mode apps & Selected apps
   const setLassoMode = useUIStore((state) => state.setLassoMode);
-  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
   const selectedApps = useUIStore((state) => state.selectedAppsIds);
   const clearSelectedApps = useUIStore((state) => state.clearSelectedApps);
 

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
@@ -125,11 +125,6 @@ export function Lasso(props: LassoProps) {
     }
   };
 
-  // Deselect Application by clicking on board
-  function handleDeselect() {
-    setSelectedApp('');
-  }
-
   return (
     <>
       {/* lassoMode */}
@@ -148,7 +143,8 @@ export function Lasso(props: LassoProps) {
             // the cursor should remain a pointer
             // cursor: 'crosshair',
           }}
-          onPointerDown={handleDeselect}
+          // Note to future devs, handledeselect behaviour move to BackgroundLayer.tsx
+          // onPointerDown={handleDeselect}
           onMouseDown={mouseDown}
           onMouseUp={mouseUp}
           onMouseMove={mouseMove}

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
@@ -33,6 +33,7 @@ export function Lasso(props: LassoProps) {
 
   // Lasso mode apps & Selected apps
   const setLassoMode = useUIStore((state) => state.setLassoMode);
+  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
   const selectedApps = useUIStore((state) => state.selectedAppsIds);
   const clearSelectedApps = useUIStore((state) => state.clearSelectedApps);
 
@@ -124,6 +125,11 @@ export function Lasso(props: LassoProps) {
     }
   };
 
+  // Deselect Application by clicking on board
+  function handleDeselect() {
+    setSelectedApp('');
+  }
+
   return (
     <>
       {/* lassoMode */}
@@ -142,6 +148,7 @@ export function Lasso(props: LassoProps) {
             // the cursor should remain a pointer
             // cursor: 'crosshair',
           }}
+          onPointerDown={handleDeselect}
           onMouseDown={mouseDown}
           onMouseUp={mouseUp}
           onMouseMove={mouseMove}

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
@@ -24,6 +24,7 @@ type BoxProps = {
   last_mousex: number;
   last_mousey: number;
   selectedApps: string[];
+  remove: boolean;
 };
 
 export function Lasso(props: LassoProps) {
@@ -38,6 +39,7 @@ export function Lasso(props: LassoProps) {
 
   // Mouse Positions
   const [mousedown, setMouseDown] = useState(false);
+  const [removal, setRemoval] = useState(false);
   const { uiToBoard } = useCursorBoardPosition();
   const [last_mousex, set_last_mousex] = useState(0);
   const [last_mousey, set_last_mousey] = useState(0);
@@ -85,8 +87,12 @@ export function Lasso(props: LassoProps) {
   };
 
   // Mouse Behaviours
-  const mouseDown = (ev: any) => {
+  const mouseDown = (ev: React.MouseEvent<SVGElement>) => {
     if (ev.button == 0) {
+      if (ev.ctrlKey === false && ev.shiftKey === false) {
+        clearSelectedApps();
+      }
+      setRemoval(ev.shiftKey);
       lassoStart(ev.clientX, ev.clientY);
     }
   };
@@ -95,8 +101,9 @@ export function Lasso(props: LassoProps) {
     lassoEnd();
   };
 
-  const mouseMove = (ev: any) => {
+  const mouseMove = (ev: React.MouseEvent<SVGElement>) => {
     if (ev.button == 0 && mousedown) {
+      setRemoval(ev.shiftKey);
       lassoMove(ev.clientX, ev.clientY);
     } else if (ev.buttons === 4) {
       setIsDragging(true); // Keep Current Lasso Selection
@@ -153,7 +160,14 @@ export function Lasso(props: LassoProps) {
           {...dragProps}
         >
           {mousedown ? (
-            <DrawBox mousex={mousex} mousey={mousey} last_mousex={last_mousex} last_mousey={last_mousey} selectedApps={selectedApps} />
+            <DrawBox
+              mousex={mousex}
+              mousey={mousey}
+              last_mousex={last_mousex}
+              last_mousey={last_mousey}
+              selectedApps={selectedApps}
+              remove={removal}
+            />
           ) : null}
         </svg>
       </div>
@@ -260,9 +274,14 @@ const DrawBox = (props: BoxProps) => {
     if (selectedAppId.length) {
       setSelectedApp('');
     }
+
+    if (props.remove) {
+      setSelectedApps([...clickSelectedApps.filter((app) => !rectSelectedApps.includes(app))]);
+    } else {
+      setSelectedApps([...rectSelectedApps, ...clickSelectedApps]);
+    }
     // Only update UI store when local state changes
-    setSelectedApps([...rectSelectedApps, ...clickSelectedApps]);
-  }, [rectSelectedApps, clickSelectedApps]);
+  }, [props.remove, rectSelectedApps, clickSelectedApps]);
 
   return (
     <rect

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -99,9 +99,6 @@ export function Whiteboard(props: WhiteboardProps) {
   // On pointer down, start a new current line
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
-      setSelectedApp('');
-      setSelectedAppsIds([]);
-
       if (yLines && yDoc && canAnnotate && boardSynced) {
         // if primary pointing device and left button
         if (e.isPrimary && e.button === 0) {
@@ -344,6 +341,7 @@ export function Whiteboard(props: WhiteboardProps) {
         onPointerUp={handlePointerUp}
         onTouchMove={handleTouchMove}
         {...dragProps}
+        // Note to future devs, handledeselect behaviour move to BackgroundLayer.tsx
       >
         <g>
           {/* Lines */}

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -60,6 +60,8 @@ export function Whiteboard(props: WhiteboardProps) {
   const setClearAllMarkers = useUIStore((state) => state.setClearAllMarkers);
   const color = useUIStore((state) => state.markerColor);
   const boardSynced = useUIStore((state) => state.boardSynced);
+  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
+  const setSelectedAppsIds = useUIStore((state) => state.setSelectedAppsIds);
 
   // Annotations Store
   const updateAnnotation = useAnnotationStore((state) => state.update);
@@ -97,6 +99,9 @@ export function Whiteboard(props: WhiteboardProps) {
   // On pointer down, start a new current line
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
+      setSelectedApp('');
+      setSelectedAppsIds([]);
+
       if (yLines && yDoc && canAnnotate && boardSynced) {
         // if primary pointing device and left button
         if (e.isPrimary && e.button === 0) {

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -302,8 +302,6 @@ export function Whiteboard(props: WhiteboardProps) {
     }
   }, [undoLastMaker]);
 
-  const spacebarPressed = useKeyPress(' ');
-
   // Switch between pen and interactive mode
   // Going to make each interaction mode a hotkey/ keybind
   // useHotkeys(
@@ -332,8 +330,8 @@ export function Whiteboard(props: WhiteboardProps) {
     <div
       className="canvas-container"
       style={{
-        pointerEvents: !spacebarPressed && (primaryActionMode === 'pen' || primaryActionMode === 'eraser') ? 'auto' : 'none',
-        touchAction: !spacebarPressed && (primaryActionMode === 'pen' || primaryActionMode === 'eraser') ? 'none' : 'auto',
+        pointerEvents: primaryActionMode === 'pen' || primaryActionMode === 'eraser' ? 'auto' : 'none',
+        touchAction: primaryActionMode === 'pen' || primaryActionMode === 'eraser' ? 'none' : 'auto',
       }}
     >
       <svg

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -302,18 +302,6 @@ export function Whiteboard(props: WhiteboardProps) {
     }
   }, [undoLastMaker]);
 
-  // Switch between pen and interactive mode
-  // Going to make each interaction mode a hotkey/ keybind
-  // useHotkeys(
-  //   'shift+w',
-  //   () => {
-  //     if (canAnnotate) {
-  //       // setWhiteboardMode(primaryActionMode === 'none' ? 'pen' : 'none');
-  //     }
-  //   },
-  //   { dependencies: [primaryActionMode] }
-  // );
-
   // Delete a line when it is clicked
   const lineClicked = (id: string) => {
     if (yLines) {

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -11,16 +11,16 @@ import * as Simplify from 'simplify-js';
 
 // Yjs Imports
 import * as Y from 'yjs';
-import { WebsocketProvider } from 'y-websocket';
+// import { WebsocketProvider } from 'y-websocket';
 
 // SAGE Imports
 import {
   YjsRoomConnection,
-  YjsRooms,
+  // YjsRooms,
   useAbility,
   useAnnotationStore,
-  useHotkeys,
-  useKeyPress,
+  // useHotkeys,
+  // useKeyPress,
   useThrottleScale,
   useUIStore,
   useUser,
@@ -37,7 +37,7 @@ type WhiteboardProps = {
 
 export function Whiteboard(props: WhiteboardProps) {
   // Settings
-  const { setPrimaryActionMode, settings } = useUserSettings();
+  const { settings } = useUserSettings();
   const primaryActionMode = settings.primaryActionMode;
 
   const { user } = useUser();
@@ -339,7 +339,7 @@ export function Whiteboard(props: WhiteboardProps) {
         onPointerUp={handlePointerUp}
         onTouchMove={handleTouchMove}
         {...dragProps}
-        // Note to future devs, handledeselect behaviour move to BackgroundLayer.tsx
+      // Note to future devs, handledeselect behaviour move to BackgroundLayer.tsx
       >
         <g>
           {/* Lines */}

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -60,8 +60,6 @@ export function Whiteboard(props: WhiteboardProps) {
   const setClearAllMarkers = useUIStore((state) => state.setClearAllMarkers);
   const color = useUIStore((state) => state.markerColor);
   const boardSynced = useUIStore((state) => state.boardSynced);
-  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
-  const setSelectedAppsIds = useUIStore((state) => state.setSelectedAppsIds);
 
   // Annotations Store
   const updateAnnotation = useAnnotationStore((state) => state.update);

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/BoardContextMenu.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/BoardContextMenu.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Box, Button, useColorModeValue, VStack, Text, useColorMode, HStack, Center, Divider } from '@chakra-ui/react';
+import { Box, Button, useColorModeValue, VStack, Text, useColorMode, HStack, Center, Divider, Spacer } from '@chakra-ui/react';
 
 import { useAppStore, useUIStore, useUser, useRouteNav, useCursorBoardPosition, usePanelStore, useConfigStore } from '@sage3/frontend';
 import { AppName, AppState } from '@sage3/applications/schema';
@@ -148,7 +148,7 @@ export function BoardContextMenu(props: ContextProps) {
       w={'100%'}
     >
       <HStack spacing={2} alignItems="start" justifyContent={'left'}>
-        <VStack w={'130px'}>
+        <VStack w={'130px'} spacing={"6px"}>
           <Text className="header" color={textColor} fontSize={18} h={'auto'} userSelect={'none'} fontWeight="bold" justifyContent={'left'}>
             Actions
           </Text>
@@ -160,7 +160,7 @@ export function BoardContextMenu(props: ContextProps) {
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="2em"
             p={1}
             mt={0}
             fontSize={14}
@@ -174,7 +174,7 @@ export function BoardContextMenu(props: ContextProps) {
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="2em"
             p={1}
             mt={0}
             fontSize={14}
@@ -187,7 +187,7 @@ export function BoardContextMenu(props: ContextProps) {
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="2em"
             p={1}
             mt={0}
             fontSize={14}
@@ -200,7 +200,7 @@ export function BoardContextMenu(props: ContextProps) {
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="2em"
             p={1}
             mt={0}
             fontSize={14}
@@ -213,7 +213,7 @@ export function BoardContextMenu(props: ContextProps) {
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="2em"
             p={1}
             mt={0}
             fontSize={14}
@@ -229,15 +229,15 @@ export function BoardContextMenu(props: ContextProps) {
           <Divider orientation="vertical" h={'100%'} />
         </Center>
 
-        <VStack w={'125px'}>
-          <Text className="header" color={textColor} fontSize={18} fontWeight="bold" h={'auto'} userSelect={'none'}>
+        <VStack w={'130px'} spacing={"6px"}>
+          <Text className="header" color={textColor} fontSize={18} h={'auto'} userSelect={'none'} fontWeight="bold" justifyContent={'left'}>
             Apps
           </Text>
 
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="32px"
             p={1}
             mt={0}
             fontSize={14}
@@ -252,7 +252,7 @@ export function BoardContextMenu(props: ContextProps) {
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="2em"
             p={1}
             mt={0}
             fontSize={14}
@@ -267,7 +267,7 @@ export function BoardContextMenu(props: ContextProps) {
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="2em"
             p={1}
             mt={0}
             fontSize={14}
@@ -282,7 +282,7 @@ export function BoardContextMenu(props: ContextProps) {
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="2em"
             p={1}
             mt={0}
             fontSize={14}
@@ -296,7 +296,21 @@ export function BoardContextMenu(props: ContextProps) {
           <Button
             w="100%"
             borderRadius={2}
-            h="auto"
+            h="2em"
+            p={1}
+            mt={0}
+            fontSize={14}
+            color={textColor}
+            justifyContent="flex-start"
+            isDisabled={!appsList.includes('TLDraw')}
+            onClick={() => newApplication('TLDraw', user?.data.name)}
+          >
+            TLDraw
+          </Button>
+          <Button
+            w="100%"
+            borderRadius={2}
+            h="2em"
             p={1}
             mt={0}
             fontSize={14}

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/BoardContextMenu.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/BoardContextMenu.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Box, Button, useColorModeValue, VStack, Text, useColorMode, HStack, Center } from '@chakra-ui/react';
+import { Box, Button, useColorModeValue, VStack, Text, useColorMode, HStack, Center, Divider } from '@chakra-ui/react';
 
 import { useAppStore, useUIStore, useUser, useRouteNav, useCursorBoardPosition, usePanelStore, useConfigStore } from '@sage3/frontend';
 import { AppName, AppState } from '@sage3/applications/schema';
@@ -136,26 +136,27 @@ export function BoardContextMenu(props: ContextProps) {
       pinned: false,
     });
   };
+  console.log(Applications['Chat']);
 
   return (
     <Box
       whiteSpace={'nowrap'}
       boxShadow={`4px 4px 10px 0px ${shadowColor}`}
       p="2"
-      rounded="md"
+      rounded="xl"
       bg={panelBackground}
       cursor="auto"
       w={'100%'}
     >
-      <Center pb={2}>
-        <Interactionbar />
-      </Center>
-
       <HStack spacing={2} alignItems="start" justifyContent={'left'}>
-        <VStack w={'125px'}>
+        <VStack w={'130px'}>
           <Text className="header" color={textColor} fontSize={18} h={'auto'} userSelect={'none'} fontWeight="bold" justifyContent={'left'}>
             Actions
           </Text>
+
+          <Center>
+            <Interactionbar />
+          </Center>
 
           <Button
             w="100%"
@@ -224,6 +225,10 @@ export function BoardContextMenu(props: ContextProps) {
             Show all Apps
           </Button>
         </VStack>
+
+        <Center h={'235px'}>
+          <Divider orientation="vertical" h={'100%'} />
+        </Center>
 
         <VStack w={'125px'}>
           <Text className="header" color={textColor} fontSize={18} fontWeight="bold" h={'auto'} userSelect={'none'}>

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/BoardContextMenu.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/BoardContextMenu.tsx
@@ -136,7 +136,6 @@ export function BoardContextMenu(props: ContextProps) {
       pinned: false,
     });
   };
-  console.log(Applications['Chat']);
 
   return (
     <Box

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
@@ -37,6 +37,11 @@ export function Interactionbar() {
           <IconButton
             size="sm"
             colorScheme={primaryActionMode === 'grab' ? user?.data.color || 'teal' : 'gray'}
+            sx={{
+              _dark: {
+                bg: primaryActionMode === 'grab' ? `${user?.data.color}.200` : 'gray.700', // 'inherit' didnt seem to work
+              },
+            }}
             icon={<LiaHandPaperSolid />}
             fontSize="xl"
             aria-label={'input-type'}
@@ -49,6 +54,11 @@ export function Interactionbar() {
           <IconButton
             size="sm"
             colorScheme={primaryActionMode === 'lasso' ? user?.data.color || 'teal' : 'gray'}
+            sx={{
+              _dark: {
+                bg: primaryActionMode === 'lasso' ? `${user?.data.color}.200` : 'gray.700',
+              },
+            }}
             icon={<LiaMousePointerSolid />}
             fontSize="xl"
             aria-label={'input-type'}
@@ -62,6 +72,11 @@ export function Interactionbar() {
           <IconButton
             size="sm"
             colorScheme={primaryActionMode === 'pen' ? user?.data.color || 'teal' : 'gray'}
+            sx={{
+              _dark: {
+                bg: primaryActionMode === 'pen' ? `${user?.data.color}.200` : 'gray.700',
+              },
+            }}
             icon={<BiPencil />}
             fontSize="xl"
             aria-label={'input-type'}
@@ -76,6 +91,11 @@ export function Interactionbar() {
           <IconButton
             size="sm"
             colorScheme={primaryActionMode === 'eraser' ? user?.data.color || 'teal' : 'gray'}
+            sx={{
+              _dark: {
+                bg: primaryActionMode === 'eraser' ? `${user?.data.color}.200` : 'gray.700',
+              },
+            }}
             icon={<BsEraserFill />}
             fontSize="xl"
             aria-label={'input-type'}

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
@@ -47,6 +47,7 @@ export function Interactionbar() {
             aria-label={'input-type'}
             onClick={() => {
               setPrimaryActionMode('grab');
+              setSelectedAppsIds([]);
             }}
           ></IconButton>
         </Tooltip>

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
@@ -27,83 +27,81 @@ export function Interactionbar() {
   const setSelectedAppsIds = useUIStore((state) => state.setSelectedAppsIds);
 
   return (
-    <>
-      <ButtonGroup isAttached size="xs">
-        <Tooltip label={'Grab (Panning Tool) — [1]'}>
-          <IconButton
-            size="sm"
-            colorScheme={primaryActionMode === 'grab' ? user?.data.color || 'teal' : 'gray'}
-            sx={{
-              _dark: {
-                bg: primaryActionMode === 'grab' ? `${user?.data.color}.200` : 'gray.600', // 'inherit' didnt seem to work
-              },
-            }}
-            icon={<LiaHandPaperSolid />}
-            fontSize="xl"
-            aria-label={'input-type'}
-            onClick={() => {
-              setPrimaryActionMode('grab');
-              setSelectedAppsIds([]);
-            }}
-          ></IconButton>
-        </Tooltip>
-        <Tooltip label={'Selection — [2]'}>
-          <IconButton
-            size="sm"
-            colorScheme={primaryActionMode === 'lasso' ? user?.data.color || 'teal' : 'gray'}
-            sx={{
-              _dark: {
-                bg: primaryActionMode === 'lasso' ? `${user?.data.color}.200` : 'gray.600',
-              },
-            }}
-            icon={<LiaMousePointerSolid />}
-            fontSize="xl"
-            aria-label={'input-type'}
-            onClick={() => {
-              setPrimaryActionMode('lasso');
-            }}
-          ></IconButton>
-        </Tooltip>
+    <ButtonGroup isAttached size="xs">
+      <Tooltip label={'Grab (Panning Tool) — [1]'}>
+        <IconButton
+          size="sm"
+          colorScheme={primaryActionMode === 'grab' ? user?.data.color || 'teal' : 'gray'}
+          sx={{
+            _dark: {
+              bg: primaryActionMode === 'grab' ? `${user?.data.color}.200` : 'gray.600', // 'inherit' didnt seem to work
+            },
+          }}
+          icon={<LiaHandPaperSolid />}
+          fontSize="xl"
+          aria-label={'input-type'}
+          onClick={() => {
+            setPrimaryActionMode('grab');
+            setSelectedAppsIds([]);
+          }}
+        ></IconButton>
+      </Tooltip>
+      <Tooltip label={'Selection — [2]'}>
+        <IconButton
+          size="sm"
+          colorScheme={primaryActionMode === 'lasso' ? user?.data.color || 'teal' : 'gray'}
+          sx={{
+            _dark: {
+              bg: primaryActionMode === 'lasso' ? `${user?.data.color}.200` : 'gray.600',
+            },
+          }}
+          icon={<LiaMousePointerSolid />}
+          fontSize="xl"
+          aria-label={'input-type'}
+          onClick={() => {
+            setPrimaryActionMode('lasso');
+          }}
+        ></IconButton>
+      </Tooltip>
 
-        <Tooltip label={'Marker — [3]'}>
-          <IconButton
-            size="sm"
-            colorScheme={primaryActionMode === 'pen' ? user?.data.color || 'teal' : 'gray'}
-            sx={{
-              _dark: {
-                bg: primaryActionMode === 'pen' ? `${user?.data.color}.200` : 'gray.600',
-              },
-            }}
-            icon={<BiPencil />}
-            fontSize="xl"
-            aria-label={'input-type'}
-            onClick={() => {
-              setPrimaryActionMode('pen');
-              setSelectedApp('');
-              setSelectedAppsIds([]);
-            }}
-          ></IconButton>
-        </Tooltip>
-        <Tooltip label={'Eraser — [4]'}>
-          <IconButton
-            size="sm"
-            colorScheme={primaryActionMode === 'eraser' ? user?.data.color || 'teal' : 'gray'}
-            sx={{
-              _dark: {
-                bg: primaryActionMode === 'eraser' ? `${user?.data.color}.200` : 'gray.600',
-              },
-            }}
-            icon={<BsEraserFill />}
-            fontSize="xl"
-            aria-label={'input-type'}
-            onClick={() => {
-              setPrimaryActionMode('eraser');
-              setSelectedApp('');
-              setSelectedAppsIds([]);
-            }}
-          ></IconButton>
-        </Tooltip>
-      </ButtonGroup>
-    </>
+      <Tooltip label={'Marker — [3]'}>
+        <IconButton
+          size="sm"
+          colorScheme={primaryActionMode === 'pen' ? user?.data.color || 'teal' : 'gray'}
+          sx={{
+            _dark: {
+              bg: primaryActionMode === 'pen' ? `${user?.data.color}.200` : 'gray.600',
+            },
+          }}
+          icon={<BiPencil />}
+          fontSize="xl"
+          aria-label={'input-type'}
+          onClick={() => {
+            setPrimaryActionMode('pen');
+            setSelectedApp('');
+            setSelectedAppsIds([]);
+          }}
+        ></IconButton>
+      </Tooltip>
+      <Tooltip label={'Eraser — [4]'}>
+        <IconButton
+          size="sm"
+          colorScheme={primaryActionMode === 'eraser' ? user?.data.color || 'teal' : 'gray'}
+          sx={{
+            _dark: {
+              bg: primaryActionMode === 'eraser' ? `${user?.data.color}.200` : 'gray.600',
+            },
+          }}
+          icon={<BsEraserFill />}
+          fontSize="xl"
+          aria-label={'input-type'}
+          onClick={() => {
+            setPrimaryActionMode('eraser');
+            setSelectedApp('');
+            setSelectedAppsIds([]);
+          }}
+        ></IconButton>
+      </Tooltip>
+    </ButtonGroup>
   );
 }

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
@@ -12,7 +12,7 @@ import { BiPencil } from 'react-icons/bi';
 import { BsEraserFill } from 'react-icons/bs';
 import { LiaMousePointerSolid, LiaHandPaperSolid } from 'react-icons/lia';
 
-import { useUserSettings, useUser, useHotkeys } from '@sage3/frontend';
+import { useUserSettings, useUser, useHotkeys, useUIStore } from '@sage3/frontend';
 
 export function Interactionbar() {
   // Settings
@@ -25,6 +25,8 @@ export function Interactionbar() {
   // Panel Stores
   // const annotations = usePanelStore((state) => state.panels['annotations']);
   // const updatePanel = usePanelStore((state) => state.updatePanel);
+  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
+  const setSelectedAppsIds = useUIStore((state) => state.setSelectedAppsIds);
 
   return (
     <>
@@ -63,6 +65,8 @@ export function Interactionbar() {
             aria-label={'input-type'}
             onClick={() => {
               setPrimaryActionMode('pen');
+              setSelectedApp('');
+              setSelectedAppsIds([]);
             }}
           ></IconButton>
         </Tooltip>
@@ -75,6 +79,8 @@ export function Interactionbar() {
             aria-label={'input-type'}
             onClick={() => {
               setPrimaryActionMode('eraser');
+              setSelectedApp('');
+              setSelectedAppsIds([]);
             }}
           ></IconButton>
         </Tooltip>

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
@@ -6,13 +6,13 @@
  * the file LICENSE, distributed as part of this software.
  */
 
-import { IconButton, Tooltip, ButtonGroup, useColorModeValue } from '@chakra-ui/react';
+import { IconButton, Tooltip, ButtonGroup } from '@chakra-ui/react';
 
 import { BiPencil } from 'react-icons/bi';
 import { BsEraserFill } from 'react-icons/bs';
 import { LiaMousePointerSolid, LiaHandPaperSolid } from 'react-icons/lia';
 
-import { useUserSettings, useUser, useHotkeys, useUIStore } from '@sage3/frontend';
+import { useUserSettings, useUser, useUIStore } from '@sage3/frontend';
 
 export function Interactionbar() {
   // Settings
@@ -25,10 +25,6 @@ export function Interactionbar() {
   // UiStore
   const setSelectedApp = useUIStore((state) => state.setSelectedApp);
   const setSelectedAppsIds = useUIStore((state) => state.setSelectedAppsIds);
-
-  // Panel Stores
-  // const annotations = usePanelStore((state) => state.panels['annotations']);
-  // const updatePanel = usePanelStore((state) => state.updatePanel);
 
   return (
     <>

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
@@ -39,7 +39,7 @@ export function Interactionbar() {
             colorScheme={primaryActionMode === 'grab' ? user?.data.color || 'teal' : 'gray'}
             sx={{
               _dark: {
-                bg: primaryActionMode === 'grab' ? `${user?.data.color}.200` : 'gray.700', // 'inherit' didnt seem to work
+                bg: primaryActionMode === 'grab' ? `${user?.data.color}.200` : 'gray.600', // 'inherit' didnt seem to work
               },
             }}
             icon={<LiaHandPaperSolid />}
@@ -56,7 +56,7 @@ export function Interactionbar() {
             colorScheme={primaryActionMode === 'lasso' ? user?.data.color || 'teal' : 'gray'}
             sx={{
               _dark: {
-                bg: primaryActionMode === 'lasso' ? `${user?.data.color}.200` : 'gray.700',
+                bg: primaryActionMode === 'lasso' ? `${user?.data.color}.200` : 'gray.600',
               },
             }}
             icon={<LiaMousePointerSolid />}
@@ -74,7 +74,7 @@ export function Interactionbar() {
             colorScheme={primaryActionMode === 'pen' ? user?.data.color || 'teal' : 'gray'}
             sx={{
               _dark: {
-                bg: primaryActionMode === 'pen' ? `${user?.data.color}.200` : 'gray.700',
+                bg: primaryActionMode === 'pen' ? `${user?.data.color}.200` : 'gray.600',
               },
             }}
             icon={<BiPencil />}
@@ -93,7 +93,7 @@ export function Interactionbar() {
             colorScheme={primaryActionMode === 'eraser' ? user?.data.color || 'teal' : 'gray'}
             sx={{
               _dark: {
-                bg: primaryActionMode === 'eraser' ? `${user?.data.color}.200` : 'gray.700',
+                bg: primaryActionMode === 'eraser' ? `${user?.data.color}.200` : 'gray.600',
               },
             }}
             icon={<BsEraserFill />}

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
@@ -6,7 +6,7 @@
  * the file LICENSE, distributed as part of this software.
  */
 
-import { IconButton, Tooltip, ButtonGroup } from '@chakra-ui/react';
+import { IconButton, Tooltip, ButtonGroup, useColorModeValue } from '@chakra-ui/react';
 
 import { BiPencil } from 'react-icons/bi';
 import { BsEraserFill } from 'react-icons/bs';
@@ -22,11 +22,13 @@ export function Interactionbar() {
   // User
   const { user } = useUser();
 
+  // UiStore
+  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
+  const setSelectedAppsIds = useUIStore((state) => state.setSelectedAppsIds);
+
   // Panel Stores
   // const annotations = usePanelStore((state) => state.panels['annotations']);
   // const updatePanel = usePanelStore((state) => state.updatePanel);
-  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
-  const setSelectedAppsIds = useUIStore((state) => state.setSelectedAppsIds);
 
   return (
     <>

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/InteractionbarShortcuts.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/InteractionbarShortcuts.tsx
@@ -55,6 +55,7 @@ export function InteractionbarShortcuts() {
     (event: KeyboardEvent): void | boolean => {
       event.stopPropagation();
       setPrimaryActionMode('grab');
+      setSelectedAppsIds([]);
     },
     { dependencies: [] }
   );

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/InteractionbarShortcuts.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/InteractionbarShortcuts.tsx
@@ -6,11 +6,13 @@
  * the file LICENSE, distributed as part of this software.
  */
 
-import { useUserSettings, useHotkeys } from '@sage3/frontend';
+import { useUserSettings, useHotkeys, useUIStore } from '@sage3/frontend';
 
 export function InteractionbarShortcuts() {
   // Settings
   const { setPrimaryActionMode } = useUserSettings();
+  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
+  const setSelectedAppsIds = useUIStore((state) => state.setSelectedAppsIds);
 
   // useHotkeys(
   //   'h',
@@ -71,6 +73,8 @@ export function InteractionbarShortcuts() {
     (event: KeyboardEvent): void | boolean => {
       event.stopPropagation();
       setPrimaryActionMode('pen');
+      setSelectedApp('');
+      setSelectedAppsIds([]);
     },
     { dependencies: [] }
   );
@@ -80,6 +84,8 @@ export function InteractionbarShortcuts() {
     (event: KeyboardEvent): void | boolean => {
       event.stopPropagation();
       setPrimaryActionMode('eraser');
+      setSelectedApp('');
+      setSelectedAppsIds([]);
     },
     { dependencies: [] }
   );

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Annotations/AnnotationsPanel.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Panels/Annotations/AnnotationsPanel.tsx
@@ -248,9 +248,9 @@ export function AnnotationsPanel() {
                 </Tooltip>
               </Slider>
             </HStack>
-            <Text fontSize={'xs'} alignSelf={'center'} mt={'3px'}>
+            {/* <Text fontSize={'xs'} alignSelf={'center'} mt={'3px'}>
               While drawing, use the arrow keys or spacebar+mouse to navigate
-            </Text>
+            </Text> */}
           </VStack>
         </Box>
       </Panel>

--- a/webstack/libs/applications/src/lib/components/AppWindow/AppWindow.tsx
+++ b/webstack/libs/applications/src/lib/components/AppWindow/AppWindow.tsx
@@ -13,7 +13,7 @@ import { MdWindow } from 'react-icons/md';
 import { IconType } from 'react-icons/lib';
 
 // SAGE3 Frontend
-import { useAppStore, useUIStore, useKeyPress, useHexColor, useThrottleScale, useAbility, useInsightStore } from '@sage3/frontend';
+import { useAppStore, useUIStore, useHexColor, useThrottleScale, useAbility, useInsightStore } from '@sage3/frontend';
 
 // Window Components
 import { App } from '../../schema';

--- a/webstack/libs/applications/src/lib/components/AppWindow/AppWindow.tsx
+++ b/webstack/libs/applications/src/lib/components/AppWindow/AppWindow.tsx
@@ -119,9 +119,6 @@ export function AppWindow(props: WindowProps) {
   const toast = useToast();
   const toastID = 'error-toast';
 
-  // Detect if spacebar is held down to allow for board dragging through apps
-  const spacebarPressed = useKeyPress(' ');
-
   // Track the app store errors
   useEffect(() => {
     if (storeError) {
@@ -337,7 +334,7 @@ export function AppWindow(props: WindowProps) {
       lockAspectRatio={props.lockAspectRatio ? props.lockAspectRatio : false}
       style={{
         zIndex: props.lockToBackground ? 0 : myZ,
-        pointerEvents: spacebarPressed || lassoMode || (!canMove && !canResize) ? 'none' : 'auto',
+        pointerEvents: lassoMode || (!canMove && !canResize) ? 'none' : 'auto',
       }}
       resizeHandleStyles={{
         bottom: { transform: `scaleY(${handleScale})` },

--- a/webstack/libs/frontend/src/lib/ui/components/context-menu/context-menu.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/context-menu/context-menu.tsx
@@ -127,7 +127,7 @@ export const ContextMenu = (props: { children: JSX.Element; divIds: string[] }) 
       style={{
         top: contextMenuPos.y + 2,
         left: contextMenuPos.x + 2,
-        backgroundColor: bgColor,
+        // backgroundColor: bgColor,
       }}
     >
       {props.children}

--- a/webstack/libs/frontend/src/lib/ui/components/context-menu/style.scss
+++ b/webstack/libs/frontend/src/lib/ui/components/context-menu/style.scss
@@ -17,7 +17,7 @@
   list-style: none;
   opacity: 1;
   transition: opacity 0.5s linear;
-  z-index: 10000;
+  z-index: 1800;
 }
 
 

--- a/webstack/libs/frontend/src/lib/ui/theme/theme.ts
+++ b/webstack/libs/frontend/src/lib/ui/theme/theme.ts
@@ -71,6 +71,16 @@ const components = {
       colorScheme: 'primary',
     },
   },
+  Button: {
+    variants: {
+      solid: (props: any) => ({
+        bg: props.colorScheme === 'gray' ? 'gray.100' : `${props.colorScheme}.500`,
+        _dark: {
+          bg: props.colorScheme === 'gray' ? 'gray.700' : `${props.colorScheme}.200`,
+        },
+      }),
+    },
+  },
 };
 
 // Extend the theme

--- a/webstack/libs/frontend/src/lib/ui/theme/theme.ts
+++ b/webstack/libs/frontend/src/lib/ui/theme/theme.ts
@@ -71,16 +71,16 @@ const components = {
       colorScheme: 'primary',
     },
   },
-  Button: {
-    variants: {
-      solid: (props: any) => ({
-        bg: props.colorScheme === 'gray' ? 'gray.100' : `${props.colorScheme}.500`,
-        _dark: {
-          bg: props.colorScheme === 'gray' ? 'gray.700' : `${props.colorScheme}.200`,
-        },
-      }),
-    },
-  },
+  // Button: {
+  //   variants: {
+  //     solid: (props: any) => ({
+  //       bg: props.colorScheme === 'gray' ? 'gray.100' : `${props.colorScheme}.500`,
+  //       _dark: {
+  //         bg: props.colorScheme === 'gray' ? 'gray.700' : `${props.colorScheme}.200`,
+  //       },
+  //     }),
+  //   },
+  // },
 };
 
 // Extend the theme

--- a/webstack/libs/frontend/src/lib/ui/theme/theme.ts
+++ b/webstack/libs/frontend/src/lib/ui/theme/theme.ts
@@ -71,16 +71,6 @@ const components = {
       colorScheme: 'primary',
     },
   },
-  // Button: {
-  //   variants: {
-  //     solid: (props: any) => ({
-  //       bg: props.colorScheme === 'gray' ? 'gray.100' : `${props.colorScheme}.500`,
-  //       _dark: {
-  //         bg: props.colorScheme === 'gray' ? 'gray.700' : `${props.colorScheme}.200`,
-  //       },
-  //     }),
-  //   },
-  // },
 };
 
 // Extend the theme

--- a/webstack/libs/frontend/src/lib/ui/theme/theme.ts
+++ b/webstack/libs/frontend/src/lib/ui/theme/theme.ts
@@ -71,6 +71,17 @@ const components = {
       colorScheme: 'primary',
     },
   },
+  // Looking to change the color scheme?  Remember to change the Interactionbar.tsx's color scheme logic
+  // Button: {
+  //   variants: {
+  //     solid: (props: any) => ({
+  //       bg: props.colorScheme === 'gray' ? 'gray.100' : `${props.colorScheme}.500`,
+  //       _dark: {
+  //         bg: props.colorScheme === 'gray' ? 'gray.600' : `${props.colorScheme}.200`,
+  //       },
+  //     }),
+  //   },
+  // },
 };
 
 // Extend the theme


### PR DESCRIPTION
## Modifications
### Visual Changes
- Updated context menu look
![image](https://github.com/user-attachments/assets/075ec353-1d2c-4627-9758-6d0f9c3b8d97)
- Opaque dark mode interaction bar inactive colors
  - ideally this colorscheme logic would be in `theme.ts` however, unintended css changes may occur.  Therefore color logic is relegated to interaction bar component  (for now)
![image](https://github.com/user-attachments/assets/e011917d-8ac4-4ae9-aa47-e254b7c124bb)
- Tooltips in context menu now show above context menu.  (context menu z-index reduced to approximately tooltip's zindex - 1)


### Functional Changes
- Removed movement behaviors associated with space bar
- Removed irrelevant tips involving old movement scheme that was in annotations panel
- Apps deselect when touchpad panning, mouse drag, or touchscreen (onDown) is initially clicked on the board's background
- When switching to pen or eraser it will clear the selectedApp and selectedAppIds
- Lasso
  - Shift + Selection will now deselect prior selected apps
  - Ctrl + Selection will add newly selected apps to prior selection
  - If not modifiers are engaged, it will start  a new selection
  - Switching out of lasso mode will clear selected apps

## Testing
- Limited tested was done, only testing done on local computer to ensure that changes introduced worked.
  - i.e., no regression testing was done for this commit