### PR TITLE
[Electron] Gray Screen 'Cannot GET /'

### DIFF
--- a/webstack/clients/electron/electron.js
+++ b/webstack/clients/electron/electron.js
@@ -728,6 +728,16 @@ function createWindow() {
     }
   });
 
+  // Detect when the title of the webpage changes to see if the user has ended up on the Gray CANNOT GET page
+  mainWindow.on('page-title-updated', function (event, title) {
+    // If the title is Error, then the page is not found
+    if (title === 'Error') {
+      // The user has ended up on the Gray CANNOT GET page
+      // Redirect them back to the landing page
+      mainWindow.loadFile('./html/landing.html');
+    }
+  });
+
   // New webview going to be added
   mainWindow.webContents.on('will-attach-webview', function (event, webPreferences, params) {
     console.log('will-attach-webview');


### PR DESCRIPTION
Another check in the electron client to detect the gray screen.

If the page.title == 'Error' then redirect to the landing page.


<img width="465" alt="Screenshot 2024-11-25 at 1 59 40 PM" src="https://github.com/user-attachments/assets/1aa29edf-b12c-490d-b30b-400c9814d8dc">

