### PR TITLE
[Homepage + Performance] Boardpreview cache of apps

### DIFF
--- a/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
@@ -14,6 +14,49 @@ import { APIHttp, useHexColor } from '@sage3/frontend';
 import { Board, Position, Size } from '@sage3/shared/types';
 import { App, AppName } from '@sage3/applications/schema';
 
+// Type for app info
+type AppInfo = { position: Position; size: Size; type: AppName; id: string };
+
+// A Global store to cache apps for each board
+// Has local time stamp to check if cache is expired. 60 seconds
+const cacheTime = 60 * 1000;
+
+const appCache = new Map<string, { apps: AppInfo[]; timestamp: number }>();
+
+const getAppInfo = async (boardId: string): Promise<AppInfo[]> => {
+  // Get the apps from the cache
+  const apps = appCache.get(boardId);
+  // Check if cache is expired
+  if (apps) {
+    // Check if cache is expired
+    if (Date.now() - apps.timestamp < cacheTime) {
+      return apps.apps;
+    } else {
+      const newApps = await updateAppInfo(boardId);
+      appCache.set(boardId, { apps: newApps, timestamp: Date.now() });
+      return newApps;
+    }
+  } else {
+    const apps = await updateAppInfo(boardId);
+    appCache.set(boardId, { apps, timestamp: Date.now() });
+    return apps;
+  }
+};
+
+const updateAppInfo = async (boardId: string): Promise<AppInfo[]> => {
+  console.log('Fetching apps for board:', boardId);
+  const res = await APIHttp.QUERY<App>('/apps', { boardId });
+  if (res.success && res.data) {
+    const apps = res.data;
+    const appArray = [] as AppInfo[];
+    apps.forEach((app) => {
+      const aInfo = { position: app.data.position, size: app.data.size, type: app.data.type, id: app._id };
+      appArray.push(aInfo);
+    });
+    return appArray;
+  }
+  return [];
+};
 
 export function BoardPreview(props: { board: Board; width: number; height: number; isSelected?: boolean }): JSX.Element {
   const [appInfo, setAppInfo] = useState<{ position: Position; size: Size; type: AppName; id: string }[]>([]);
@@ -35,38 +78,31 @@ export function BoardPreview(props: { board: Board; width: number; height: numbe
 
   const PADDING = 2; // Padding in pixels
 
-  async function updateAppInfo() {
-    const res = await APIHttp.QUERY<App>('/apps', { boardId: props.board._id });
-    if (res.success && res.data) {
-      const apps = res.data;
-      const appArray = [] as { position: Position; size: Size; type: AppName; id: string }[];
-      apps.forEach((app) => {
-        const aInfo = { position: app.data.position, size: app.data.size, type: app.data.type, id: app._id };
-        appArray.push(aInfo);
-      });
-      const appsLeft = apps.map((app) => app.data.position.x);
-      const appsRight = apps.map((app) => app.data.position.x + app.data.size.width);
-      const appsTop = apps.map((app) => app.data.position.y);
-      const appsBottom = apps.map((app) => app.data.position.y + app.data.size.height);
+  async function updateMap() {
+    const apps = await getAppInfo(props.board._id);
+    if (!apps) return;
+    const appsLeft = apps.map((app) => app.position.x);
+    const appsRight = apps.map((app) => app.position.x + app.size.width);
+    const appsTop = apps.map((app) => app.position.y);
+    const appsBottom = apps.map((app) => app.position.y + app.size.height);
 
-      const width = Math.max(...appsRight) - Math.min(...appsLeft);
-      const height = Math.max(...appsBottom) - Math.min(...appsTop);
+    const width = Math.max(...appsRight) - Math.min(...appsLeft);
+    const height = Math.max(...appsBottom) - Math.min(...appsTop);
 
-      const mapScale = Math.min((props.width - 2 * PADDING) / width, (props.height - 2 * PADDING) / height) * 0.85;
-      const x = Math.min(...appsLeft);
-      const y = Math.min(...appsTop);
+    const mapScale = Math.min((props.width - 2 * PADDING) / width, (props.height - 2 * PADDING) / height) * 0.85;
+    const x = Math.min(...appsLeft);
+    const y = Math.min(...appsTop);
 
-      setBoardHeight(height * mapScale);
-      setBoardWidth(width * mapScale);
-      setAppsX(x);
-      setAppsY(y);
-      setMapScale(mapScale);
-      setAppInfo(appArray);
-    }
+    setBoardHeight(height * mapScale);
+    setBoardWidth(width * mapScale);
+    setAppsX(x);
+    setAppsY(y);
+    setMapScale(mapScale);
+    setAppInfo(apps);
   }
 
   useEffect(() => {
-    updateAppInfo();
+    updateMap();
   }, [props.board._id]);
 
   useEffect(() => {

--- a/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
@@ -44,7 +44,6 @@ const getAppInfo = async (boardId: string): Promise<AppInfo[]> => {
 };
 
 const updateAppInfo = async (boardId: string): Promise<AppInfo[]> => {
-  console.log('Fetching apps for board:', boardId);
   const res = await APIHttp.QUERY<App>('/apps', { boardId });
   if (res.success && res.data) {
     const apps = res.data;


### PR DESCRIPTION
To increase performance on homepage the board previews now cache the apps instead of fetching every component re-render. Cache has an expiration of 60 seconds. 

