### PR TITLE
[Presence] Node Server Replicas Presence issues

### DIFF
--- a/webstack/apps/homebase/src/api/collections/index.ts
+++ b/webstack/apps/homebase/src/api/collections/index.ts
@@ -44,7 +44,7 @@ export async function loadCollections(): Promise<void> {
   await UsersCollection.initialize();
   await AssetsCollection.initialize();
   await MessageCollection.initialize(true, 60); // clear, and TTL 1min
-  await PresenceCollection.initialize(true);
+  await PresenceCollection.initialize();
   await PluginsCollection.initialize();
   await InsightCollection.initialize();
   await RoomMembersCollection.initialize();

--- a/webstack/apps/homebase/src/api/routers/custom/config.ts
+++ b/webstack/apps/homebase/src/api/routers/custom/config.ts
@@ -67,7 +67,7 @@ export function InfoRouter(): express.Router {
   // Get server configuration data structure
   router.get('/', async (req, res) => {
     // Ask presence collection for total users
-    const presenceDocs = await PresenceCollection.getAll();
+    const presenceDocs = await PresenceCollection.query('status', 'online');
     const onlineUsers = presenceDocs ? presenceDocs.length : 0;
 
     // Configuration public values

--- a/webstack/apps/homebase/src/main.ts
+++ b/webstack/apps/homebase/src/main.ts
@@ -24,7 +24,7 @@ import * as dns from 'node:dns';
 
 // Websocket
 import { WebSocket } from 'ws';
-import { SAGEnlp, SAGEPresence, SubscriptionCache } from '@sage3/backend';
+import { SAGEnlp, SAGEPresence, redisPresence, SubscriptionCache } from '@sage3/backend';
 import { setupWsforLogs } from './api/routers/custom';
 
 // Create the web server with Express
@@ -137,6 +137,9 @@ async function startServer() {
     setupWsforLogs(socket);
   });
 
+  // Load Redis Presnce
+  redisPresence.init(config.redis.url, 'SAGE3', PresenceCollection);
+
   // Websocket API for sagebase
   apiWebSocketServer.on('connection', (socket: WebSocket, req: IncomingMessage) => {
     // The authSchema of the current user
@@ -147,8 +150,7 @@ async function startServer() {
     const subCache = new SubscriptionCache(socket);
 
     // A helper class to track the presence of users.
-    const presence = new SAGEPresence(user.id, socket, PresenceCollection);
-    presence.init();
+    new SAGEPresence(user.id, socket);
 
     socket.on('message', (msg) => {
       try {

--- a/webstack/apps/homebase/src/main.ts
+++ b/webstack/apps/homebase/src/main.ts
@@ -24,7 +24,7 @@ import * as dns from 'node:dns';
 
 // Websocket
 import { WebSocket } from 'ws';
-import { SAGEnlp, SAGEPresence, redisPresence, SubscriptionCache } from '@sage3/backend';
+import { SAGEnlp, SAGE_PRESENCE, SocketPresence, SubscriptionCache } from '@sage3/backend';
 import { setupWsforLogs } from './api/routers/custom';
 
 // Create the web server with Express
@@ -138,7 +138,7 @@ async function startServer() {
   });
 
   // Load Redis Presnce
-  redisPresence.init(config.redis.url, 'SAGE3', PresenceCollection);
+  SAGE_PRESENCE.init(config.redis.url, 'SAGE3', PresenceCollection);
 
   // Websocket API for sagebase
   apiWebSocketServer.on('connection', (socket: WebSocket, req: IncomingMessage) => {
@@ -150,7 +150,7 @@ async function startServer() {
     const subCache = new SubscriptionCache(socket);
 
     // A helper class to track the presence of users.
-    new SAGEPresence(user.id, socket);
+    new SocketPresence(user.id, socket);
 
     socket.on('message', (msg) => {
       try {

--- a/webstack/apps/webapp/src/app/pages/home/Home.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/Home.tsx
@@ -607,12 +607,15 @@ export function HomePage() {
   useEffect(() => {
     // Update the document title
     document.title = 'SAGE3 - Home';
+
     subcribeToAssets();
     subscribeToPresence();
     subscribeToUsers();
     subscribeToRooms();
     subscribeToBoards();
     subPlugins();
+
+    if (user) updatePresence(user?._id, { boardId: '', roomId: '' });
 
     // return to room from a board
     if (roomId && roomsFetched && user) {
@@ -1013,11 +1016,7 @@ export function HomePage() {
                   </Box>
                 </Box>
               </MenuButton>
-              <MenuList
-                width="20%"
-                minWidth="220px"
-                maxWidth="400px"
-              >
+              <MenuList width="20%" minWidth="220px" maxWidth="400px">
                 {hubs.map((hub) => {
                   return (
                     <MenuItem
@@ -1392,7 +1391,8 @@ export function HomePage() {
                         {boardListView == 'grid' && (
                           <Flex
                             gap="4"
-                            pl="2" py="1"
+                            pl="2"
+                            py="1"
                             display="flex"
                             flexWrap="wrap"
                             justifyContent="left"
@@ -1882,7 +1882,7 @@ export function HomePage() {
 
                             <Text fontSize="xs" color={subTextColor}>
                               {room.data.ownerId === userId ||
-                                members.find((roomMember) => roomMember.data.roomId === room._id)?.data.members.includes(userId) ? (
+                              members.find((roomMember) => roomMember.data.roomId === room._id)?.data.members.includes(userId) ? (
                                 room.data.ownerId === userId ? (
                                   <Tag size="sm" width="100px" display="flex" justifyContent="center" colorScheme="green">
                                     Owner

--- a/webstack/libs/backend/src/lib/utils/presence.ts
+++ b/webstack/libs/backend/src/lib/utils/presence.ts
@@ -74,8 +74,6 @@ class RedisPresence {
   public async removeSocket(socketId: string, uid: string) {
     // Remove the socket from the redis path
     this._redisClient.del(`${this._path}:${socketId}:${uid}`);
-    // Check if the user is still connected
-    this.checkAndUpdate(uid);
   }
 
   // Check if the user is online. If not, set them offline

--- a/webstack/libs/backend/src/lib/utils/presence.ts
+++ b/webstack/libs/backend/src/lib/utils/presence.ts
@@ -81,7 +81,7 @@ class SAGEPresence {
   private async checkAndUpdate(uid: string) {
     const online = await this.checkUser(uid);
     if (!online) {
-      await this._collection.update(uid, uid, { status: 'offline' });
+      await this._collection.update(uid, uid, { status: 'offline', boardId: '', roomId: '' });
     }
   }
 

--- a/webstack/libs/backend/src/lib/utils/presence.ts
+++ b/webstack/libs/backend/src/lib/utils/presence.ts
@@ -13,7 +13,7 @@ import { createClient, RedisClientType } from 'redis';
 import { genId } from '@sage3/shared';
 
 // REDIS class to sync presence across multiple node-server replicas
-class RedisPresence {
+class SAGEPresence {
   private _redisClient!: RedisClientType;
   private _path!: string;
   private _collection!: SAGE3Collection<PresenceSchema>;
@@ -93,12 +93,12 @@ class RedisPresence {
   }
 }
 
-export const redisPresence = new RedisPresence();
+export const SAGE_PRESENCE = new SAGEPresence();
 
 /**
  * Class to help with the management of presence of users connected to the server.
  */
-export class SAGEPresence {
+export class SocketPresence {
   private _userId: string;
   private _socketId: string;
   private _socket: WebSocket;
@@ -111,22 +111,22 @@ export class SAGEPresence {
 
     this._socketId = genId();
 
-    redisPresence.addSocket(this._socketId, this._userId);
+    SAGE_PRESENCE.addSocket(this._socketId, this._userId);
 
     // Refresh Key every 15 seconds
     const FIFTEEN_SECS = 15 * 1000;
     setInterval(() => {
-      redisPresence.refreshSocket(this._socketId, this._userId);
+      SAGE_PRESENCE.refreshSocket(this._socketId, this._userId);
     }, FIFTEEN_SECS);
 
     this._socket.on('close', () => {
       console.log(`Presence> ${this._userId} disconnected.`);
-      redisPresence.removeSocket(this._socketId, this._userId);
+      SAGE_PRESENCE.removeSocket(this._socketId, this._userId);
     });
 
     this._socket.on('error', () => {
       console.log(`Presence> ${this._userId} disconnected.`);
-      redisPresence.removeSocket(this._socketId, this._userId);
+      SAGE_PRESENCE.removeSocket(this._socketId, this._userId);
     });
   }
 }

--- a/webstack/libs/backend/src/lib/utils/presence.ts
+++ b/webstack/libs/backend/src/lib/utils/presence.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2025. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -9,91 +9,124 @@
 import { SAGE3Collection } from '../generics';
 import { WebSocket } from 'ws';
 import { PresenceSchema } from '@sage3/shared/types';
+import { createClient, RedisClientType } from 'redis';
+import { genId } from '@sage3/shared';
 
-// Dictionary to keep track of users if they sign in multiple times
-const userPresenceDict = {} as { [key: string]: SAGEPresence[] };
+// REDIS class to sync presence across multiple node-server replicas
+class RedisPresence {
+  private _redisClient!: RedisClientType;
+  private _path!: string;
+  private _collection!: SAGE3Collection<PresenceSchema>;
+
+  async init(redisUrl: string, prefix: string, presenceCollection: SAGE3Collection<PresenceSchema>) {
+    this._redisClient = createClient({ url: redisUrl });
+    this._path = `${prefix}:SOCKET:PRESENCE`;
+    this._collection = presenceCollection;
+    await this._redisClient.connect();
+
+    // Set interval to check all users
+    setInterval(() => this.AllUserCheck(), 30);
+  }
+
+  // Go over all presence collection and find everyone that is online.
+  // Check they are online by going over the redis socket connections and ensure that user is online
+  private async AllUserCheck() {
+    const usersOnline = await this._collection.query('status', 'online');
+    if (!usersOnline) return;
+    // Get all userIds
+    const uids = usersOnline.map((el) => el.data.userId);
+    uids.forEach((uid) => this.checkAndUpdate(uid));
+  }
+
+  // Add a socket connection by a user to the database
+  public async addSocket(socketId: string, uid: string) {
+    // Add a socket to the redis path `THIS.PATH:SOCKETID:UID with a TTL of 30 secs
+    this._redisClient.set(`${this._path}:${socketId}:${uid}`, 1, { EX: 30 });
+    // Update the presence collection with the new socket
+    // Check if the user is already in the presence collection
+    const check = await this._collection.get(uid);
+    if (!check) {
+      // If not, add the user to the presence collection
+      const presence = {
+        userId: uid,
+        status: 'online',
+        roomId: '',
+        boardId: '',
+        cursor: { x: 0, y: 0, z: 0 },
+        viewport: {
+          position: { x: 0, y: 0, z: 0 },
+          size: { width: 0, height: 0, depth: 0 },
+        },
+      } as PresenceSchema;
+      await this._collection.add(presence, uid, uid);
+    } else {
+      // If the user is already in the presence collection, update the status to online
+      await this._collection.update(uid, uid, { status: 'online' });
+    }
+  }
+
+  // Refresh the socket TTL
+  public async refreshSocket(socketId: string, uid: string) {
+    // Refresh the TTL of the socket
+    this._redisClient.expire(`${this._path}:${socketId}:${uid}`, 30);
+  }
+
+  public async removeSocket(socketId: string, uid: string) {
+    // Remove the socket from the redis path
+    this._redisClient.del(`${this._path}:${socketId}:${uid}`);
+    // Check if the user is still connected
+    this.checkAndUpdate(uid);
+  }
+
+  // Check if the user is online. If not, set them offline
+  private async checkAndUpdate(uid: string) {
+    const online = await this.checkUser(uid);
+    if (!online) {
+      await this._collection.update(uid, uid, { status: 'offline' });
+    }
+  }
+
+  // Is this user connected on any of the server replicas?
+  private async checkUser(uid: string) {
+    // Check if the user is still connected. the path is SAGE3:SOCKET:PRESENCE:SOCKETID:UID
+    const sockets = await this._redisClient.keys(`${this._path}:*:${uid}`);
+    return sockets.length > 0;
+  }
+}
+
+export const redisPresence = new RedisPresence();
 
 /**
  * Class to help with the management of presence of users connected to the server.
  */
 export class SAGEPresence {
   private _userId: string;
+  private _socketId: string;
   private _socket: WebSocket;
-  private _collection: SAGE3Collection<PresenceSchema>;
 
   // Constructor.
   // Sets listeners on socket for disconnects and erros so server can update presenceCollection.
-  constructor(userId: string, socket: WebSocket, presenceCollection: SAGE3Collection<PresenceSchema>) {
+  constructor(userId: string, socket: WebSocket) {
     this._userId = userId;
     this._socket = socket;
-    this._collection = presenceCollection;
+
+    this._socketId = genId();
+
+    redisPresence.addSocket(this._socketId, this._userId);
+
+    // Refresh Key every 15 seconds
+    setInterval(() => {
+      redisPresence.refreshSocket(this._socketId, this._userId);
+    }, 15 * 1000);
 
     this._socket.on('close', () => {
       console.log(`Presence> ${this._userId} disconnected.`);
-      this.onDisconnect();
+      redisPresence.removeSocket(this._socketId, this._userId);
     });
 
     this._socket.on('error', () => {
       console.log(`Presence> ${this._userId} disconnected.`);
-      this.onDisconnect();
+      redisPresence.removeSocket(this._socketId, this._userId);
     });
-  }
-
-  // Due eo the CheckPresnece being an async call,
-  // We need async init call since a constructor can not be async.
-  public async init() {
-    const check = await this.checkPresence();
-    if (!check) {
-      this.addPresence();
-    }
-    this.addToDict();
-  }
-
-  // On Close handler
-  private async onDisconnect() {
-    this.removeFromDict();
-    // If the user's array in the dict is empty, remove the user from the presence collection
-    if (userPresenceDict[this._userId].length === 0) {
-      this.removePresence();
-    }
-  }
-
-  // Add to the dict
-  public async addToDict() {
-    userPresenceDict[this._userId] = userPresenceDict[this._userId] ? [...userPresenceDict[this._userId], this] : [this];
-  }
-
-  // Remove from the dict
-  private async removeFromDict() {
-    userPresenceDict[this._userId] = userPresenceDict[this._userId].filter((presence) => presence !== this);
-  }
-
-  // Check if the user's presence already exists
-  private async checkPresence(): Promise<boolean> {
-    const check = await this._collection.get(this._userId);
-    return check !== null;
-  }
-
-  // Helper function to add the user's presence to the collection
-  private async addPresence(): Promise<boolean> {
-    const presence = {
-      userId: this._userId,
-      status: 'online',
-      roomId: '',
-      boardId: '',
-      cursor: { x: 0, y: 0, z: 0 },
-      viewport: {
-        position: { x: 0, y: 0, z: 0 },
-        size: { width: 0, height: 0, depth: 0 },
-      },
-    } as PresenceSchema;
-    const res = await this._collection.add(presence, this._userId, this._userId);
-    return res !== undefined;
-  }
-
-  // Remove the doc from the presence collection when the user goes offline
-  private async removePresence(): Promise<boolean> {
-    const res = await this._collection.delete(this._userId);
-    return res !== undefined;
   }
 }

--- a/webstack/libs/backend/src/lib/utils/presence.ts
+++ b/webstack/libs/backend/src/lib/utils/presence.ts
@@ -25,7 +25,8 @@ class RedisPresence {
     await this._redisClient.connect();
 
     // Set interval to check all users
-    setInterval(() => this.AllUserCheck(), 30);
+    const THIRTY_SECS = 30 * 1000;
+    setInterval(() => this.AllUserCheck(), THIRTY_SECS);
   }
 
   // Go over all presence collection and find everyone that is online.
@@ -113,9 +114,10 @@ export class SAGEPresence {
     redisPresence.addSocket(this._socketId, this._userId);
 
     // Refresh Key every 15 seconds
+    const FIFTEEN_SECS = 15 * 1000;
     setInterval(() => {
       redisPresence.refreshSocket(this._socketId, this._userId);
-    }, 15 * 1000);
+    }, FIFTEEN_SECS);
 
     this._socket.on('close', () => {
       console.log(`Presence> ${this._userId} disconnected.`);

--- a/webstack/libs/frontend/src/lib/stores/presence.ts
+++ b/webstack/libs/frontend/src/lib/stores/presence.ts
@@ -77,7 +77,6 @@ const PresenceStore = create<PresenceState>()((set, get) => {
       }
     },
     subscribe: async () => {
-      console.log('hello');
       if (!SAGE3Ability.canCurrentUser('read', 'presence')) return;
       set({ presences: [], partialPrescences: [] });
       const reponse = await APIHttp.GET<Presence>('/presence');


### PR DESCRIPTION
Presence had some state in the node server. With the new node_server replicas, this can cause some issues. This moves the state to the REDIS database to ensure the state is synced across clients.

Users can connect multiple times so for each socket connected there is a stored value in the REDIS database `${SOCKET_ID}:${USER_ID}` with a TTL over 30 secs that is refreshed every 15secs. 

Every 30 secs the backend checks the presence collection for users `ONLINE` and verifies by ensuring the path has at least one matching pair for the USER_ID.

#1155 