### PR TITLE
[Twilio] Hotfix to remove video property to Twilio connect()

### DIFF
--- a/webstack/libs/frontend/src/lib/stores/twilio.ts
+++ b/webstack/libs/frontend/src/lib/stores/twilio.ts
@@ -65,11 +65,6 @@ export const useTwilioStore = create<TwilioState>()((set, get) => ({
       // Connect to the room with the token
       const room = await connect(token, {
         audio: false,
-        video: {
-          width: { ideal: 1920, max: 1920 },
-          height: { ideal: 1920, max: 1920 },
-          frameRate: 20,
-        },
         preferredVideoCodecs: [{ codec: 'VP8', simulcast: true }],
       } as ConnectOptions);
       set((state) => ({ ...state, room }));

--- a/webstack/sage3-dev.hjson
+++ b/webstack/sage3-dev.hjson
@@ -51,11 +51,11 @@
   "services": {
     "twilio": {
       // Your Account SID from www.twilio.com/console
-      "accountSid": "ACa5fdb1b5f5d49948191e9fe2f07ba199",
+      "accountSid": "",
       // API Key
-      "apiKey": "SK817e92031bc01b3c5ed505fce93537a8",
+      "apiKey": "",
       // API Secret
-      "apiSecret": "xGxkgbqvLY0WFDXVgeYmggMBIHuInsc1"
+      "apiSecret": ""
     },
     "openai": {
       // API Key

--- a/webstack/sage3-dev.hjson
+++ b/webstack/sage3-dev.hjson
@@ -51,11 +51,11 @@
   "services": {
     "twilio": {
       // Your Account SID from www.twilio.com/console
-      "accountSid": "",
+      "accountSid": "ACa5fdb1b5f5d49948191e9fe2f07ba199",
       // API Key
-      "apiKey": "",
+      "apiKey": "SK817e92031bc01b3c5ed505fce93537a8",
       // API Secret
-      "apiSecret": ""
+      "apiSecret": "xGxkgbqvLY0WFDXVgeYmggMBIHuInsc1"
     },
     "openai": {
       // API Key


### PR DESCRIPTION
Noticed during meeting starting a screenshare on Ryan's computer would have RJ's phone start FaceTime.

The Twilio Store connect function's video property was the culprit. Providing this property triggers the user to start webcam sharing. Removed property 