### PR TITLE
[TOOLS] New App Creation Fix

### DIFF
--- a/webstack/tools/generators/newapp/index.ts
+++ b/webstack/tools/generators/newapp/index.ts
@@ -93,6 +93,7 @@ async function updateApps(root: string) {
 
   output += `\n`;
   output += `export * from './components';\n`;
+  output += `export * from './ai-apps';\n`;
 
   // Export all the applications and save
   await fs.writeFile(indexPath, output);


### PR DESCRIPTION
## Issue
![image](https://github.com/user-attachments/assets/f0add8ba-0134-45b2-8dc9-3c20a9fc3fd4)

## Fix
Added missing export ```output += `export * from './ai-apps';\n`;``` to ```tools/generators/newapp/index.ts``` to fix compilation error.

## Testing
1) Tested by starting development services (yarn start, etc.)
2) Created in a new app with ```cd next/webstack && yarn newapp``` 
3) Restarted the development services.
4) No errors shown

