### PR TITLE
[PERFORMANCE] Fixed Drag Optimization Breaking

### DIFF
--- a/webstack/libs/frontend/src/lib/providers/useCursorBoardPosition.tsx
+++ b/webstack/libs/frontend/src/lib/providers/useCursorBoardPosition.tsx
@@ -68,6 +68,7 @@ export function CursorBoardPositionProvider(props: React.PropsWithChildren<Recor
   }, [boardSynced]);
 
   // Simple hacky way to (try) fix de-synced mouse and appwindow while dragging
+  // Also provides performance benefits when dragging the board
   useEffect(() => {
     const updateCursor = (e: MouseEvent) => {
       setLastEvent(e);
@@ -75,9 +76,6 @@ export function CursorBoardPositionProvider(props: React.PropsWithChildren<Recor
     };
 
     const stopListening = (e: MouseEvent) => {
-      // !useUIStore.getState().appDragging
-      //  || e.button === 1
-      // Why was e.button === 1 disabled...?
       if (e.button === 0 || e.button === 1) {
         setIsMouseDown(true);
         window.removeEventListener('mousemove', updateCursor);

--- a/webstack/libs/frontend/src/lib/providers/useCursorBoardPosition.tsx
+++ b/webstack/libs/frontend/src/lib/providers/useCursorBoardPosition.tsx
@@ -42,6 +42,12 @@ export function CursorBoardPositionProvider(props: React.PropsWithChildren<Recor
   const boardSynced = useUIStore((state) => state.boardSynced);
   const [, setLastEvent] = useState<MouseEvent | undefined>(undefined);
 
+  // This is needed to prevent throttleMoveRef from resettting the listeners
+  // practical issue it solves: when dragging w/ left mouse,
+  // then stopped (while still holding down left mouse) the use effect resets the listeners
+  // this stops the temporary optimizations.
+  const [, setIsMouseDown] = useState<boolean>(false);
+
   // Throttle Functions for the cursor mousemove
   const throttleMove = throttle(100, (e: any) => {
     setCursor({ x: e.clientX, y: e.clientY });
@@ -71,17 +77,25 @@ export function CursorBoardPositionProvider(props: React.PropsWithChildren<Recor
     const stopListening = (e: MouseEvent) => {
       // !useUIStore.getState().appDragging
       //  || e.button === 1
-      if (e.button === 0) {
+      // Why was e.button === 1 disabled...?
+      if (e.button === 0 || e.button === 1) {
+        setIsMouseDown(true);
         window.removeEventListener('mousemove', updateCursor);
       }
     };
 
     const startListening = (e: MouseEvent) => {
+      setIsMouseDown(false);
       window.addEventListener('mousemove', updateCursor, { passive: true });
       // setLastEvent(e);
     };
 
-    window.addEventListener('mousemove', updateCursor, { passive: true });
+    setIsMouseDown((prev) => {
+      if (!prev) {
+        window.addEventListener('mousemove', updateCursor, { passive: true });
+      }
+      return prev;
+    });
     window.addEventListener('mousedown', stopListening);
     window.addEventListener('mouseup', startListening);
 
@@ -91,23 +105,6 @@ export function CursorBoardPositionProvider(props: React.PropsWithChildren<Recor
       window.removeEventListener('mousemove', updateCursor);
     };
   }, [throttleMoveRef]);
-
-  // Keep this here to revert if the above causes issues
-  // // UseEffect to update the cursor position
-  // useEffect(() => {
-  //   const updateCursor = (e: MouseEvent) => {
-  //     // Simple hacky way to fix de-synced mouse and appwindow while dragging
-  //     // if (!useUIStore.getState().appDragging) {
-  //     setLastEvent(e);
-  //     if (e.buttons !== 1) {
-  //       throttleMoveRef(e);
-  //     }
-  //   };
-  //   window.addEventListener('mousemove', updateCursor);
-  //   return () => {
-  //     window.removeEventListener('mousemove', updateCursor);
-  //   };
-  // }, [throttleMoveRef]);
 
   const uiToBoard = useCallback(
     (x: number, y: number) => {


### PR DESCRIPTION
## Issue:
https://github.com/user-attachments/assets/fac274a3-7d95-4270-9f52-d87f4b52121d

Video demonstrates a fault in the optimization when a user uses left click and drag, then the user stops moving while still holding left click.  Thereafter, the user resumes dragging.  We clearly see that the SageCell rerender is triggered and the frame rate drops.

## Fix/Changes
- Added a variable to store the relevant mouse down state.  So when ```throttleMoveRef``` triggers the ```useEffect``` it wont re-enable to ```eventListener```.
- For unknown reason(s), middle mouse drag was ignored.  I enabled middle mouse drag to receive this optimization as well.  Hopefully that won't cause any issues...
- Cleaned up commented out code as well.

## Testing
- No regression testing done, just ensured that the relevant benefits of the fix were observed in action using react-scan.

https://github.com/user-attachments/assets/58b6b6f6-0fc7-434c-a4ee-792a807e321d

