### PR TITLE
[Board] Setting the Default Board Position to the UiStore's State

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
@@ -40,7 +40,7 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
   const setScale = useUIStore((state) => state.setScale);
 
   // Local States with Delayed Syncing to useUIStore
-  const [localBoardPosition, setLocalBoardPosition] = useState({ x: 0, y: 0, scale: 0 });
+  const [localBoardPosition, setLocalBoardPosition] = useState({ x: boardPosition.x, y: boardPosition.y, scale: scale });
   const [localSynced, setLocalSynced] = useState(true); // optimize performance against the useUIStore
   const [, setLastTouch] = useState([
     { x: 0, y: 0 },
@@ -462,7 +462,6 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
 
         {/* Whiteboard */}
         <WhiteboardMemo roomId={props.roomId} boardId={props.boardId} />
-
 
         {/* Lasso */}
         {canLasso && primaryActionMode === 'lasso' && <LassoMemo roomId={props.roomId} boardId={props.boardId} />}


### PR DESCRIPTION
# Issue
Hopefully this will address the following issue: https://github.com/SAGE-3/next/issues/1100


# Changes
Since the view port always seems to be either centered on apps or in the top left corner; one plausible cause is that the default:

```typescript
const [localBoardPosition, setLocalBoardPosition] = useState({ x: 0, y: 0, scale: 0 });
```

which should update via this useEffect:


```typescript
// Forward boardPosition to localBoardPosition
  useEffect(() => {
    setLocalBoardPosition({ x: boardPosition.x, y: boardPosition.y, scale: scale });
  }, [boardPosition.x, boardPosition.y, scale]);
```


is inhibited by some race condition or weird interaction maybe preventing that periodically.   Setting the default to the UIStore states may resolve the issue.

# Testing
Merge and pray that the issue never appears again.

PS: Could not reproduce the bug on Hawaii Dev by throttling connection in dev console.