### PR TITLE
[Feature] Another Method to Deselect App When Zoomed In Too Close

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/UILayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/UILayer.tsx
@@ -71,6 +71,7 @@ import {
   UsersMenu,
   AssetsMenu,
   MainButton,
+  EscapeApp,
 } from './components';
 
 type UILayerProps = {
@@ -345,6 +346,7 @@ export function UILayer(props: UILayerProps) {
           />
           <Divider orientation="vertical" mx="1" />
           <Interactionbar isContextMenuOpen={isContextMenuOpen} />
+          <EscapeApp/>
           <Divider orientation="vertical" mx="1" />
           <ToolbarButton bgColor={usersColor as SAGEColors} icon={<MdPeople />} tooltip={'Users'} title={'Users'}>
             <UsersMenu boardId={props.boardId} />

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/AppToolbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/AppToolbar.tsx
@@ -65,7 +65,7 @@ import {
   MdOutlinePushPin,
 } from 'react-icons/md';
 import { HiOutlineTrash } from 'react-icons/hi';
-import { IoMdExit } from 'react-icons/io';
+import { MdDeselect } from 'react-icons/md';
 import { IoSparklesSharp } from 'react-icons/io5';
 
 import { formatDistance } from 'date-fns';
@@ -92,7 +92,7 @@ import { AI_ENABLED_APPS, Applications } from '@sage3/applications/apps';
 import { Position, Size } from '@sage3/shared/types';
 import ky from 'ky';
 
-const UI_BAR_OFFSET = 50
+const UI_BAR_OFFSET = 50;
 
 type AppToolbarProps = {
   boardId: string;
@@ -735,19 +735,20 @@ export function AppToolbar(props: AppToolbarProps) {
         </Modal>
 
         {/* Delete tag confirmation */}
-        {isDeleteTagOpen && <ConfirmModal
-          isOpen={isDeleteTagOpen}
-          onClose={onDeleteTagClose}
-          onConfirm={handleDeleteTag}
-          title="Delete this Tag"
-          message="Are you sure you want to delete this tag from this app?"
-          cancelText="Cancel"
-          confirmText="Delete"
-          cancelColor="green"
-          confirmColor="red"
-          size="lg"
-        />
-        }
+        {isDeleteTagOpen && (
+          <ConfirmModal
+            isOpen={isDeleteTagOpen}
+            onClose={onDeleteTagClose}
+            onConfirm={handleDeleteTag}
+            title="Delete this Tag"
+            message="Are you sure you want to delete this tag from this app?"
+            cancelText="Cancel"
+            confirmText="Delete"
+            cancelColor="green"
+            confirmColor="red"
+            size="lg"
+          />
+        )}
       </HStack>
     );
   }
@@ -862,7 +863,7 @@ export function AppToolbar(props: AppToolbarProps) {
                 </MenuItem>
                 <MenuDivider />
 
-                <MenuItem icon={<IoMdExit size="18px" />} onClick={() => setSelectedApp('')} py="1px" m="0">
+                <MenuItem icon={<MdDeselect size="18px" />} onClick={() => setSelectedApp('')} py="1px" m="0">
                   Deselect Application
                 </MenuItem>
               </MenuList>
@@ -874,7 +875,7 @@ export function AppToolbar(props: AppToolbarProps) {
               </Button>
             </Tooltip>
 
-            {isDeleteOpen &&
+            {isDeleteOpen && (
               <ConfirmModal
                 isOpen={isDeleteOpen}
                 onClose={onDeleteClose}
@@ -887,7 +888,7 @@ export function AppToolbar(props: AppToolbarProps) {
                 size="lg"
                 xOffSet={Math.max(0, (position.x - 150) / window.innerWidth)}
               />
-            }
+            )}
           </>
         </ErrorBoundary>
       );

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/EscapeApp.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/EscapeApp.tsx
@@ -9,14 +9,11 @@
 import { useEffect, useState } from 'react';
 import { Tooltip, IconButton, Divider } from '@chakra-ui/react';
 
-import {
-  useUIStore,
-  useThrottleApps,
-} from '@sage3/frontend';
-import { IoMdExit } from 'react-icons/io';
+import { useUIStore, useThrottleApps } from '@sage3/frontend';
+import { MdDeselect } from 'react-icons/md';
 
 type EscapeAppProps = {};
-const APP_SPACE_BUFFER = 150;            
+const APP_SPACE_BUFFER = 150;
 
 export function EscapeApp(props: EscapeAppProps) {
   const apps = useThrottleApps(1000);
@@ -27,11 +24,11 @@ export function EscapeApp(props: EscapeAppProps) {
   const selectedAppId = useUIStore((state) => state.selectedAppId);
   const setSelectedApp = useUIStore((state) => state.setSelectedApp);
 
-  useEffect(()=>{
+  useEffect(() => {
     if (!selectedAppId) {
       setViewportInApp(false);
-      return
-    };
+      return;
+    }
 
     let vpInApp = false;
     for (let i = 0; i < apps.length; i++) {
@@ -44,11 +41,12 @@ export function EscapeApp(props: EscapeAppProps) {
       const vy = viewport.position.y;
       const vw = viewport.size.width;
       const vh = viewport.size.height;
-      const isInside = vx >= x - APP_SPACE_BUFFER &&
-                      vx + vw <= x + w + APP_SPACE_BUFFER &&
-                      vy >= y - APP_SPACE_BUFFER &&
-                      vy + vh <= y + h + APP_SPACE_BUFFER;
-      
+      const isInside =
+        vx >= x - APP_SPACE_BUFFER &&
+        vx + vw <= x + w + APP_SPACE_BUFFER &&
+        vy >= y - APP_SPACE_BUFFER &&
+        vy + vh <= y + h + APP_SPACE_BUFFER;
+
       if (isInside) {
         vpInApp = true;
         break;
@@ -58,25 +56,25 @@ export function EscapeApp(props: EscapeAppProps) {
   }, [apps, viewport, selectedAppId]);
 
   return (
-  <>
-    {viewportInApp && 
     <>
-      <Divider orientation="vertical" mx="1" />
-      <Tooltip label={'Deselect App'} placement={'top'} hasArrow={true} openDelay={400}>
-        <IconButton
-          borderRadius={'0.5rem 0.5rem 0.5rem 0.5rem'}
-          size="sm"
-          colorScheme={'red'}
-          icon={<IoMdExit/>}
-          fontSize="xl"
-          aria-label={'input-type'}
-          onClick={() => {
-            setSelectedApp('');
-          }}
-        ></IconButton>
-        </Tooltip>
+      {viewportInApp && (
+        <>
+          <Divider orientation="vertical" mx="1" />
+          <Tooltip label={'Deselect App'} placement={'top'} hasArrow={true} openDelay={400}>
+            <IconButton
+              borderRadius={'0.5rem 0.5rem 0.5rem 0.5rem'}
+              size="sm"
+              colorScheme={'red'}
+              icon={<MdDeselect />}
+              fontSize="xl"
+              aria-label={'input-type'}
+              onClick={() => {
+                setSelectedApp('');
+              }}
+            ></IconButton>
+          </Tooltip>
+        </>
+      )}
     </>
-    }
-  </>
   );
 }

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/EscapeApp.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/EscapeApp.tsx
@@ -16,6 +16,7 @@ import {
 import { IoMdExit } from 'react-icons/io';
 
 type EscapeAppProps = {};
+const APP_SPACE_BUFFER = 150;            
 
 export function EscapeApp(props: EscapeAppProps) {
   const apps = useThrottleApps(1000);
@@ -43,11 +44,10 @@ export function EscapeApp(props: EscapeAppProps) {
       const vy = viewport.position.y;
       const vw = viewport.size.width;
       const vh = viewport.size.height;
-      const buffer = 150;            
-      const isInside = vx >= x - buffer &&
-                      vx + vw <= x + w + buffer &&
-                      vy >= y - buffer &&
-                      vy + vh <= y + h + buffer;
+      const isInside = vx >= x - APP_SPACE_BUFFER &&
+                      vx + vw <= x + w + APP_SPACE_BUFFER &&
+                      vy >= y - APP_SPACE_BUFFER &&
+                      vy + vh <= y + h + APP_SPACE_BUFFER;
       
       if (isInside) {
         vpInApp = true;

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/EscapeApp.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/EscapeApp.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2025. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+import { useEffect, useState } from 'react';
+import { Tooltip, IconButton, Divider } from '@chakra-ui/react';
+
+import {
+  useUIStore,
+  useThrottleApps,
+} from '@sage3/frontend';
+import { IoMdExit } from 'react-icons/io';
+
+type EscapeAppProps = {};
+
+export function EscapeApp(props: EscapeAppProps) {
+  const apps = useThrottleApps(1000);
+  const viewport = useUIStore((state) => state.viewport);
+  const [viewportInApp, setViewportInApp] = useState(false);
+
+  // UiStore
+  const selectedAppId = useUIStore((state) => state.selectedAppId);
+  const setSelectedApp = useUIStore((state) => state.setSelectedApp);
+
+  useEffect(()=>{
+    if (!selectedAppId) {
+      setViewportInApp(false);
+      return
+    };
+
+    let vpInApp = false;
+    for (let i = 0; i < apps.length; i++) {
+      const app = apps[i];
+      const h = app.data.size.height;
+      const w = app.data.size.width;
+      const x = app.data.position.x;
+      const y = app.data.position.y;
+      const vx = viewport.position.x;
+      const vy = viewport.position.y;
+      const vw = viewport.size.width;
+      const vh = viewport.size.height;
+      const buffer = 150;            
+      const isInside = vx >= x - buffer &&
+                      vx + vw <= x + w + buffer &&
+                      vy >= y - buffer &&
+                      vy + vh <= y + h + buffer;
+      
+      if (isInside) {
+        vpInApp = true;
+        break;
+      }
+    }
+    setViewportInApp(vpInApp);
+  }, [apps, viewport, selectedAppId]);
+
+  return (
+  <>
+    {selectedAppId && viewportInApp && 
+    <>
+      <Divider orientation="vertical" mx="1" />
+      <Tooltip label={'Deselect App'} placement={'top'} hasArrow={true} openDelay={400}>
+        <IconButton
+          borderRadius={'0.5rem 0.5rem 0.5rem 0.5rem'}
+          size="sm"
+          colorScheme={'red'}
+          icon={<IoMdExit/>}
+          fontSize="xl"
+          aria-label={'input-type'}
+          onClick={() => {
+            setSelectedApp('');
+          }}
+        ></IconButton>
+        </Tooltip>
+    </>
+    }
+  </>
+  );
+}

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/EscapeApp.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/EscapeApp.tsx
@@ -59,7 +59,7 @@ export function EscapeApp(props: EscapeAppProps) {
 
   return (
   <>
-    {selectedAppId && viewportInApp && 
+    {viewportInApp && 
     <>
       <Divider orientation="vertical" mx="1" />
       <Tooltip label={'Deselect App'} placement={'top'} hasArrow={true} openDelay={400}>

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/index.ts
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/index.ts
@@ -17,3 +17,4 @@ export * from './Interactionbar';
 export * from './InteractionbarShortcuts';
 export * from './Menus';
 export * from './MainButton';
+export * from './EscapeApp';


### PR DESCRIPTION
## Issue

It has been noted, during internal lab meetings, that the preexisting methods of deselecting an app that has captured all user inputs is not user friendly.

Existing methods:
- App toolbar -> Hamburger -> Deselect Application
- Selecting another interaction mode

## Proposed Solution

The `EscapeApp.tsx` code checks each app on the board to see if it is within the user's viewport and if it selected.  If the user's viewport is smaller than the app and is inside the app and the app is selected, then we show the escape app button in the UI bar at the bottom of the screen.

The `EscapeApp.tsx` code only does it checks if the app is selected and will break on first valid hit to mitigate performance degradation by introducing this feature.


https://github.com/user-attachments/assets/582babb7-db29-4e62-a939-9c46ac4b0b21

General demonstration.

https://github.com/user-attachments/assets/8bddf328-9366-421f-96c5-5e5f48ce50ae

Small threshold/buffer allotted.


## Testing

- No Regression Testing Done
- User A moving User A's viewport to be inside an app and User A selecting the app
- User B moving User A's selected app to cover User A's viewport
- Tested with a couple of overlapping apps
