### PR TITLE
[FIX] Intersection of App Toolbar and UI Navbar

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/AppToolbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/AppToolbar.tsx
@@ -92,6 +92,8 @@ import { AI_ENABLED_APPS, Applications } from '@sage3/applications/apps';
 import { Position, Size } from '@sage3/shared/types';
 import ky from 'ky';
 
+const UI_BAR_OFFSET = 50
+
 type AppToolbarProps = {
   boardId: string;
   roomId: string;
@@ -217,7 +219,7 @@ export function AppToolbar(props: AppToolbarProps) {
       }
 
       // Default Toolbar Poistion. Middle of screen at bottom
-      const defaultPosition = screenLimit({ x: ww / 2 - twhalf, y: wh - toolbarHeight - 50 });
+      const defaultPosition = screenLimit({ x: ww / 2 - twhalf, y: wh - toolbarHeight - UI_BAR_OFFSET });
 
       // App Bottom Position
       const appBottomPosition = screenLimit({ x: appXWin + aw / 2 - twhalf, y: appBYWin });
@@ -236,7 +238,7 @@ export function AppToolbar(props: AppToolbarProps) {
         setAppToolbarPosition(defaultPosition);
       }
       // App is close to bottom of the screen
-      else if (appBYWin + toolbarHeight > wh) {
+      else if (appBYWin + toolbarHeight + UI_BAR_OFFSET > wh) {
         setPosition(appTopPosition);
         setAppToolbarPosition(appTopPosition);
       } else {

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/AppToolbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/AppToolbar.tsx
@@ -217,7 +217,7 @@ export function AppToolbar(props: AppToolbarProps) {
       }
 
       // Default Toolbar Poistion. Middle of screen at bottom
-      const defaultPosition = screenLimit({ x: ww / 2 - twhalf, y: wh - toolbarHeight });
+      const defaultPosition = screenLimit({ x: ww / 2 - twhalf, y: wh - toolbarHeight - 50 });
 
       // App Bottom Position
       const appBottomPosition = screenLimit({ x: appXWin + aw / 2 - twhalf, y: appBYWin });


### PR DESCRIPTION
## Issue

![image](https://github.com/user-attachments/assets/efab9bd8-e1b8-474f-aeb5-6b8705e5e774)
![image](https://github.com/user-attachments/assets/eb6dad02-579d-4a8d-b93e-806dc4db852e)


App toolbar intersecting with UI navigation bar

## Solution

![image](https://github.com/user-attachments/assets/0c85f539-1cc7-4223-a852-361a0ac27797)

Increase height of app bar default position by 50px


## Testing

- [x] App taller than window
- [x] App is offscreen
- [X] App is within screen bounds but is near bottom
