### PR TITLE
[MapGl] Crash due to geotiff removal

### DIFF
--- a/webstack/libs/applications/src/lib/apps/MapGL/MapGL.tsx
+++ b/webstack/libs/applications/src/lib/apps/MapGL/MapGL.tsx
@@ -295,8 +295,14 @@ function AppComponent(props: App): JSX.Element {
 
   useEffect(() => {
     if (map) {
-      map.removeLayer('geotiff-layer');
-      map.removeSource('geotiff');
+      if (map.getLayer('geotiff-layer')) {
+        // Remove the geotiff layer if it exists
+        map.removeLayer('geotiff-layer');
+      }
+      // Remove the geotiff source if it exists
+      if (map.getSource('geotiff')) {
+        map.removeSource('geotiff');
+      }
 
       const canvas = document.createElement('canvas');
       canvas.setAttribute('id', 'canvas');


### PR DESCRIPTION
MapGL would crash and show a red screen in the app window on re-entering a board with a mapgl app open.

