### PR TITLE
[BoardPreview] Only a subset of the Apps array

### DIFF
--- a/webstack/apps/homebase/src/api/collections/apps.ts
+++ b/webstack/apps/homebase/src/api/collections/apps.ts
@@ -6,8 +6,9 @@
  * the file LICENSE, distributed as part of this software.
  */
 
-import { AppSchema } from '@sage3/applications/schema';
+import { AppName, AppSchema } from '@sage3/applications/schema';
 import { SAGE3Collection, sageRouter } from '@sage3/backend';
+import { Position, Size } from '@sage3/shared/types';
 
 class SAGE3AppsCollection extends SAGE3Collection<AppSchema> {
   constructor() {
@@ -17,6 +18,24 @@ class SAGE3AppsCollection extends SAGE3Collection<AppSchema> {
       type: 'Stickie',
     });
     const router = sageRouter<AppSchema>(this);
+
+    // GET: Get all the docs, multiple docs by id, or query
+    router.post('/preview', async ({ body }, res) => {
+      const boardId = body.boardId;
+      if (!boardId) {
+        res.status(500).send({ success: false, message: 'No BoardID Provided.' });
+      } else {
+        let docs = null;
+        const apps = [] as { position: Position; size: Size; type: AppName; id: string }[];
+        docs = await this.collection.query('boardId', boardId);
+        docs.forEach((app) => {
+          const aInfo = { position: app.data.position, size: app.data.size, type: app.data.type, id: app._id };
+          apps.push(aInfo);
+        });
+        if (docs) res.status(200).send({ success: true, message: 'Successfully retrieved documents.', data: apps });
+        else res.status(500).send({ success: false, message: 'Failed to retrieve documents.', data: undefined });
+      }
+    });
     this.httpRouter = router;
   }
 

--- a/webstack/apps/homebase/src/api/collections/apps.ts
+++ b/webstack/apps/homebase/src/api/collections/apps.ts
@@ -19,11 +19,11 @@ class SAGE3AppsCollection extends SAGE3Collection<AppSchema> {
     });
     const router = sageRouter<AppSchema>(this);
 
-    // GET: Get all the docs, multiple docs by id, or query
+    // Get subset snapshot of the apps to build preview on frontend
     router.post('/preview', async ({ body }, res) => {
       const boardId = body.boardId;
       if (!boardId) {
-        res.status(500).send({ success: false, message: 'No BoardID Provided.' });
+        res.status(500).send({ success: false, message: 'No BoardID Provided.', data: undefined });
       } else {
         let docs = null;
         const apps = [] as { position: Position; size: Size; type: AppName; id: string }[];

--- a/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
@@ -44,17 +44,21 @@ const getAppInfo = async (boardId: string): Promise<AppInfo[]> => {
 };
 
 const updateAppInfo = async (boardId: string): Promise<AppInfo[]> => {
-  const res = await APIHttp.QUERY<App>('/apps', { boardId });
-  if (res.success && res.data) {
-    const apps = res.data;
-    const appArray = [] as AppInfo[];
-    apps.forEach((app) => {
-      const aInfo = { position: app.data.position, size: app.data.size, type: app.data.type, id: app._id };
-      appArray.push(aInfo);
-    });
-    return appArray;
+  const response = await fetch('/api/apps/preview', {
+    body: JSON.stringify({ boardId: boardId }),
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  });
+  const docs = await response.json();
+  if (docs.success && docs.data) {
+    return docs.data;
+  } else {
+    return [];
   }
-  return [];
 };
 
 export function BoardPreview(props: { board: Board; width: number; height: number; isSelected?: boolean }): JSX.Element {

--- a/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
@@ -10,9 +10,9 @@ import { useState, useEffect, useRef } from 'react';
 import { Box, Text, Icon, useColorModeValue } from '@chakra-ui/react';
 import { MdLock } from 'react-icons/md';
 
-import { APIHttp, useHexColor } from '@sage3/frontend';
+import { apiUrls, useHexColor } from '@sage3/frontend';
 import { Board, Position, Size } from '@sage3/shared/types';
-import { App, AppName } from '@sage3/applications/schema';
+import { AppName } from '@sage3/applications/schema';
 
 // Type for app info
 type AppInfo = { position: Position; size: Size; type: AppName; id: string };
@@ -44,7 +44,7 @@ const getAppInfo = async (boardId: string): Promise<AppInfo[]> => {
 };
 
 const updateAppInfo = async (boardId: string): Promise<AppInfo[]> => {
-  const response = await fetch('/api/apps/preview', {
+  const response = await fetch(apiUrls.apps.preview, {
     body: JSON.stringify({ boardId: boardId }),
     method: 'POST',
     credentials: 'include',

--- a/webstack/libs/frontend/src/lib/config/urls.ts
+++ b/webstack/libs/frontend/src/lib/config/urls.ts
@@ -13,6 +13,9 @@ export const apiUrls = {
   config: {
     getConfig: '/api/configuration',
   },
+  apps: {
+    preview: '/api/apps/preview',
+  },
   assets: {
     getAssets: '/api/assets',
     getAssetById: (id: string) => `/api/assets/static/${id}`,


### PR DESCRIPTION
Board Preview on the homepage previously fetched the whole App object and built the preview locally. 

Moved logic to server to decompose app preview to just a subset of the data:

```
{ 
  position: Position; 
  size: Size; 
  type: AppName; 
  id: string 
}
```

Should hopefully help Home page performance.