### PR TITLE
Black Screen Fix Attempt #1

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/Board.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/Board.tsx
@@ -173,24 +173,27 @@ export function BoardPage() {
     document.title = 'SAGE3 - Board';
 
     async function handleJoinBoard(rId: string, bId: string) {
-      // assets
-      await subAssets(rId);
-      // This is if someone is joining a board by a link
-      subRooms();
-      // Sub to boards belonging to this room
-      subBoards(rId);
-      // Subscribe to the app on the board that was selected
-      subApps(bId);
-      // Sub to users and presence
-      subscribeToPresence();
-      subscribeToUsers();
-      // Sub to insights
-      subToInsight(bId);
-      // plugins
-      subPlugins();
+      await Promise.all([
+        // assets
+        subAssets(rId),
+        // This is if someone is joining a board by a link
+        subRooms(),
+        // Sub to boards belonging to this room
+        subBoards(rId),
+        // Subscribe to the app on the board that was selected
+        subApps(bId),
+        // Sub to users and presence
+        subscribeToPresence(),
+        subscribeToUsers(),
+        // Sub to insights
+        subToInsight(bId),
+        // plugins
+        subPlugins(),
+        // links
+        subLinks(bId),
+      ]);
+
       setInitialLoad(true);
-      // links
-      subLinks(bId);
     }
 
     handleJoinBoard(roomId, boardId);


### PR DESCRIPTION
### Issue/ Observations
- A black screen appears due to reading an undefined user data.
- Occurs when a user launches the Sage3 app which loads into a board that already has a user inside
- When loading Sage3 app, it seems to bypass the home screen and jump directly to the board?
- If user follows the regular interaction flow of homepage -> board; homepage calls subscriptions to users, presence, etc. in the background.  No black screen appears
- In testing, similar behavior will appear when disabling subscriptions from home and board page.

### Proposed Fix
**Assumption:** Race condition issue
**Attempted Fix:** If user jumps directly into board, it calls most of the subscriptions functions, however does not await before rendering the BackgroundLayer (which contains reads on undefined data).