### PR TITLE
[Home] Redirect

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/UILayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/UILayer.tsx
@@ -295,6 +295,7 @@ export function UILayer(props: UILayerProps) {
     } else {
       toHome();
     }
+    localStorage.removeItem('boardId');
   }
 
   // Redirect to your previous board
@@ -398,7 +399,7 @@ export function UILayer(props: UILayerProps) {
           <Divider orientation="vertical" mx="1" />
           <MainButton
             buttonStyle="solid"
-            backToRoom={() => toHome(props.roomId)}
+            backToRoom={handleHomeClick}
             boardInfo={{
               boardId: props.boardId,
               roomId: props.roomId,


### PR DESCRIPTION
If a user is on a board and closes the client, local storage stores the boardId.
When the user relaunched the client they are automatically redirected back to the same BoardId.
If the use then clicks the Home button, the user is directed to the home page but then auto joins the same board again.

I remove the boardId from local storage when a user clicks the home button now.

