### PR TITLE
[Touch UI] Updates to touch interaction

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
@@ -57,6 +57,12 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
   const movementTimeoutRef = useRef<number | null>(null);
   const movementZoomSafetyTimeoutRef = useRef<number | null>(null);
 
+  // Touch pinch-zoom tuning: small distance changes between fingers should not
+  // cause large zoom jumps. Use a deadzone and clamp per-frame zoom delta.
+  const TOUCH_PINCH_DEADZONE = 10; // pixels of distance change before zoom engages
+  const TOUCH_PINCH_MAX_STEP = 40; // max effective distance delta per frame
+  const touchGestureModeRef = useRef<'none' | 'pan' | 'pinch'>('none');
+
   /////////////////////////////////
   // UI Store Board Syncronizers //
   /////////////////////////////////
@@ -403,15 +409,29 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
               { x: event.touches[0].clientX, y: event.touches[0].clientY },
               { x: event.touches[1].clientX, y: event.touches[1].clientY }
             );
-            const zoomDelta = prevDistance - distance;
+            const zoomDeltaRaw = prevDistance - distance;
             const avgX = (event.touches[0].clientX + event.touches[1].clientX) / 2;
             const avgY = (event.touches[0].clientY + event.touches[1].clientY) / 2;
 
             if (prevDistance > 0) {
-              if (zoomDelta < 0) {
-                localZoomInDelta(zoomDelta, { x: avgX, y: avgY });
-              } else if (zoomDelta > 0) {
-                localZoomOutDelta(zoomDelta, { x: avgX, y: avgY });
+              // Decide and lock gesture mode for this 2-finger gesture
+              if (touchGestureModeRef.current === 'none') {
+                touchGestureModeRef.current =
+                  Math.abs(zoomDeltaRaw) > TOUCH_PINCH_DEADZONE ? 'pinch' : 'pan';
+              }
+
+              // Only apply zoom when we are in pinch mode and distance change
+              // is beyond the deadzone. Pan is always applied below.
+              if (touchGestureModeRef.current === 'pinch' && Math.abs(zoomDeltaRaw) > TOUCH_PINCH_DEADZONE) {
+                // Clamp the effective zoom delta to avoid huge jumps per frame
+                const zoomDelta =
+                  Math.sign(zoomDeltaRaw) * Math.min(Math.abs(zoomDeltaRaw), TOUCH_PINCH_MAX_STEP);
+
+                if (zoomDelta < 0) {
+                  localZoomInDelta(zoomDelta, { x: avgX, y: avgY });
+                } else if (zoomDelta > 0) {
+                  localZoomOutDelta(zoomDelta, { x: avgX, y: avgY });
+                }
               }
             }
 
@@ -433,12 +453,21 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
       });
     };
 
+    // Reset gesture mode when fingers lift
+    const handleTouchEnd = (event: TouchEvent) => {
+      if (event.touches.length < 2) {
+        touchGestureModeRef.current = 'none';
+      }
+    };
+
     window.addEventListener('touchmove', handleTouchMove, { passive: false });
+    window.addEventListener('touchend', handleTouchEnd, { passive: false });
     window.addEventListener('mousemove', handleMouseMove, { passive: false });
     window.addEventListener('wheel', handleMove, { passive: false });
 
     return () => {
       window.removeEventListener('touchmove', handleTouchMove);
+      window.removeEventListener('touchend', handleTouchEnd);
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('wheel', handleMove);
     };

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
@@ -58,9 +58,10 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
   const movementZoomSafetyTimeoutRef = useRef<number | null>(null);
 
   // Touch pinch-zoom tuning: small distance changes between fingers should not
-  // cause large zoom jumps. Use a deadzone and clamp per-frame zoom delta.
-  const TOUCH_PINCH_DEADZONE = 10; // pixels of distance change before zoom engages
-  const TOUCH_PINCH_MAX_STEP = 40; // max effective distance delta per frame
+  // cause large zoom jumps. Use a deadzone and clamp the per-frame scale ratio.
+  const TOUCH_PINCH_DEADZONE = 10;    // pixels of distance change before zoom engages
+  const TOUCH_PINCH_MIN_RATIO = 0.95; // max zoom-out per frame (5%)
+  const TOUCH_PINCH_MAX_RATIO = 1.05; // max zoom-in per frame (5%)
 
   /////////////////////////////////
   // UI Store Board Syncronizers //
@@ -412,21 +413,23 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
             const avgX = (event.touches[0].clientX + event.touches[1].clientX) / 2;
             const avgY = (event.touches[0].clientY + event.touches[1].clientY) / 2;
 
-            if (prevDistance > 0) {
-              // Apply a deadzone so tiny finger-distance jitter does not zoom.
-              // Do not hard-lock the gesture into pan or pinch: allow both,
-              // but gate zoom behind the deadzone and clamp its sensitivity.
-              if (Math.abs(zoomDeltaRaw) > TOUCH_PINCH_DEADZONE) {
-                // Clamp the effective zoom delta to avoid huge jumps per frame
-                const zoomDelta =
-                  Math.sign(zoomDeltaRaw) * Math.min(Math.abs(zoomDeltaRaw), TOUCH_PINCH_MAX_STEP);
+            if (prevDistance > 0 && Math.abs(zoomDeltaRaw) > TOUCH_PINCH_DEADZONE) {
+              // Use ratio-based zoom for smooth, continuous pinch behaviour.
+              // This avoids the discrete "stepping" of the wheel-based zoom
+              // helpers which quantize through WheelStepZoom.
+              const rawRatio = distance / prevDistance;
+              // Clamp the per-frame ratio so zoom can't jump too fast
+              const ratio = Math.max(TOUCH_PINCH_MIN_RATIO, Math.min(rawRatio, TOUCH_PINCH_MAX_RATIO));
 
-                if (zoomDelta < 0) {
-                  localZoomInDelta(zoomDelta, { x: avgX, y: avgY });
-                } else if (zoomDelta > 0) {
-                  localZoomOutDelta(zoomDelta, { x: avgX, y: avgY });
-                }
-              }
+              setLocalBoardPosition((prevBoard) => {
+                const newScale = Math.max(MinZoom, Math.min(prevBoard.scale * ratio, MaxZoom));
+                return zoomOnLocationNewPosition(
+                  { x: prevBoard.x, y: prevBoard.y },
+                  { x: avgX, y: avgY },
+                  prevBoard.scale,
+                  newScale,
+                );
+              });
             }
 
             setLocalBoardPosition((prevBoard) => {

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/BackgroundLayer.tsx
@@ -61,7 +61,6 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
   // cause large zoom jumps. Use a deadzone and clamp per-frame zoom delta.
   const TOUCH_PINCH_DEADZONE = 10; // pixels of distance change before zoom engages
   const TOUCH_PINCH_MAX_STEP = 40; // max effective distance delta per frame
-  const touchGestureModeRef = useRef<'none' | 'pan' | 'pinch'>('none');
 
   /////////////////////////////////
   // UI Store Board Syncronizers //
@@ -414,15 +413,10 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
             const avgY = (event.touches[0].clientY + event.touches[1].clientY) / 2;
 
             if (prevDistance > 0) {
-              // Decide and lock gesture mode for this 2-finger gesture
-              if (touchGestureModeRef.current === 'none') {
-                touchGestureModeRef.current =
-                  Math.abs(zoomDeltaRaw) > TOUCH_PINCH_DEADZONE ? 'pinch' : 'pan';
-              }
-
-              // Only apply zoom when we are in pinch mode and distance change
-              // is beyond the deadzone. Pan is always applied below.
-              if (touchGestureModeRef.current === 'pinch' && Math.abs(zoomDeltaRaw) > TOUCH_PINCH_DEADZONE) {
+              // Apply a deadzone so tiny finger-distance jitter does not zoom.
+              // Do not hard-lock the gesture into pan or pinch: allow both,
+              // but gate zoom behind the deadzone and clamp its sensitivity.
+              if (Math.abs(zoomDeltaRaw) > TOUCH_PINCH_DEADZONE) {
                 // Clamp the effective zoom delta to avoid huge jumps per frame
                 const zoomDelta =
                   Math.sign(zoomDeltaRaw) * Math.min(Math.abs(zoomDeltaRaw), TOUCH_PINCH_MAX_STEP);
@@ -453,21 +447,12 @@ export function BackgroundLayer(props: BackgroundLayerProps) {
       });
     };
 
-    // Reset gesture mode when fingers lift
-    const handleTouchEnd = (event: TouchEvent) => {
-      if (event.touches.length < 2) {
-        touchGestureModeRef.current = 'none';
-      }
-    };
-
     window.addEventListener('touchmove', handleTouchMove, { passive: false });
-    window.addEventListener('touchend', handleTouchEnd, { passive: false });
     window.addEventListener('mousemove', handleMouseMove, { passive: false });
     window.addEventListener('wheel', handleMove, { passive: false });
 
     return () => {
       window.removeEventListener('touchmove', handleTouchMove);
-      window.removeEventListener('touchend', handleTouchEnd);
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('wheel', handleMove);
     };

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Lasso.tsx
@@ -41,8 +41,11 @@ export function Lasso(props: LassoProps) {
   const [mousedown, setMouseDown] = useState(false);
   const [modifierAction, setModifierAction] = useState<'none' | 'removal' | 'inverse'>('none');
 
-  // Temporary Fix to Avoid Rerenders
-  const { getBoardCursor } = useCursorBoardPosition();
+  // Use uiToBoard to convert client coordinates to board coordinates.
+  // getBoardCursor only tracks mousemove events and does not update for
+  // touch, so we compute the board position directly from the coordinates
+  // passed by both mouse and touch handlers.
+  const { uiToBoard } = useCursorBoardPosition();
 
   const [last_mousex, set_last_mousex] = useState(0);
   const [last_mousey, set_last_mousey] = useState(0);
@@ -55,9 +58,9 @@ export function Lasso(props: LassoProps) {
   // Drag and Drop On Board
   const { dragProps, renderContent } = useDragAndDropBoard({ roomId: props.roomId, boardId: props.boardId });
 
-  // Get initial position
+  // Get initial position — x, y are client coordinates (from mouse or touch)
   const lassoStart = (x: number, y: number) => {
-    const position = getBoardCursor();
+    const position = uiToBoard(x, y);
     set_last_mousex(position.x);
     set_last_mousey(position.y);
     set_mousex(position.x);
@@ -81,9 +84,9 @@ export function Lasso(props: LassoProps) {
     setIsDragging(false);
   };
 
-  // Get last position
+  // Update lasso position — x, y are client coordinates (from mouse or touch)
   const lassoMove = (x: number, y: number) => {
-    const position = getBoardCursor();
+    const position = uiToBoard(x, y);
     setIsDragging(true);
     set_mousex(position.x);
     set_mousey(position.y);
@@ -142,7 +145,7 @@ export function Lasso(props: LassoProps) {
   return (
     <>
       {/* lassoMode */}
-      <div className="canvas-container">
+      <div className="canvas-container" style={{ touchAction: 'none' }}>
         <svg
           id="lasso"
           className="canvas-layer"
@@ -152,10 +155,7 @@ export function Lasso(props: LassoProps) {
             height: boardHeight + 'px',
             left: 0,
             top: 0,
-            // pointerEvents: 'none',
-            // To keep in theme with other notable whiteboard applications,
-            // the cursor should remain a pointer
-            // cursor: 'crosshair',
+            touchAction: 'none',
           }}
           // Note to future devs, handledeselect behaviour move to BackgroundLayer.tsx
           // onPointerDown={handleDeselect}

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -113,6 +113,26 @@ export function Whiteboard(props: WhiteboardProps) {
   }
 
   /**
+   * Cancel and remove the in-progress stroke (if any).  Called when a second
+   * touch finger arrives so the initial single-finger touch doesn't leave a
+   * tiny dot behind during a pan/zoom gesture.
+   */
+  function cancelInProgressStroke() {
+    const current = rCurrentLine.current;
+    if (!current || !yLines) {
+      rCurrentLine.current = undefined;
+      return;
+    }
+    // Remove the incomplete shape from the Yjs array
+    const index = yLines.toArray().indexOf(current);
+    if (index >= 0) {
+      yLines.delete(index, 1);
+    }
+    rCurrentLine.current = undefined;
+    setCursorPosition(null);
+  }
+
+  /**
    * Convert pointer coordinates from client space to board space, accounting
    * for board position and current scale.  Returns an array [x, y].
    */
@@ -221,9 +241,13 @@ export function Whiteboard(props: WhiteboardProps) {
         activeTouchCount.current += 1;
       }
 
-      // Ignore drawing when more than one touch is active; multi-touch is used
-      // for pan/zoom and should not create or modify strokes.
-      if (e.pointerType === 'touch' && activeTouchCount.current > 1) return;
+      // When a second finger arrives, cancel any in-progress stroke from the
+      // first finger so it doesn't leave a tiny dot behind.  Multi-touch is
+      // used for pan/zoom and should not create or modify strokes.
+      if (e.pointerType === 'touch' && activeTouchCount.current > 1) {
+        cancelInProgressStroke();
+        return;
+      }
       // Determine type based on current tool
       const type = primaryActionMode === 'rectangle' ? 'rectangle' : primaryActionMode === 'pen' ? 'line' : primaryActionMode === 'circle' ? 'circle' : primaryActionMode === 'arrow' ? 'arrow' : primaryActionMode === 'doubleArrow' ? 'doubleArrow' : 'eraser';
       if (type === 'eraser') return;
@@ -277,9 +301,12 @@ export function Whiteboard(props: WhiteboardProps) {
       // For mouse / pen / touch we require an active pointer capture to avoid stray moves.
       if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
 
-      // If multiple touch points are active, delegate to background pan/zoom
-      // logic and do not update the current stroke.
-      if (e.pointerType === 'touch' && activeTouchCount.current > 1) return;
+      // If multiple touch points are active, cancel the in-progress stroke
+      // and delegate to background pan/zoom logic.
+      if (e.pointerType === 'touch' && activeTouchCount.current > 1) {
+        cancelInProgressStroke();
+        return;
+      }
       const [x, y] = getPoint(e.clientX, e.clientY);
       setCursorPosition(primaryActionMode !== 'eraser' ? { x, y } : null);
 

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -92,6 +92,7 @@ export function Whiteboard(props: WhiteboardProps) {
   const [yLines, setYlines] = useState<Y.Array<Y.Map<any>> | null>(null);
   const [lines, setLines] = useState<Y.Map<any>[]>([]);
   const rCurrentLine = useRef<Y.Map<any>>();
+  const activeTouchCount = useRef(0);
 
   // Preview cursor state
   const [cursorPosition, setCursorPosition] = useState<{ x: number; y: number } | null>(null);
@@ -214,6 +215,15 @@ export function Whiteboard(props: WhiteboardProps) {
    */
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
+      // Track active touch pointers to distinguish between single-finger draw
+      // and multi-touch gestures (handled by BackgroundLayer for pan/zoom).
+      if (e.pointerType === 'touch') {
+        activeTouchCount.current += 1;
+      }
+
+      // Ignore drawing when more than one touch is active; multi-touch is used
+      // for pan/zoom and should not create or modify strokes.
+      if (e.pointerType === 'touch' && activeTouchCount.current > 1) return;
       // Determine type based on current tool
       const type = primaryActionMode === 'rectangle' ? 'rectangle' : primaryActionMode === 'pen' ? 'line' : primaryActionMode === 'circle' ? 'circle' : primaryActionMode === 'arrow' ? 'arrow' : primaryActionMode === 'doubleArrow' ? 'doubleArrow' : 'eraser';
       if (type === 'eraser') return;
@@ -264,10 +274,12 @@ export function Whiteboard(props: WhiteboardProps) {
   const handlePointerMove = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
       if (!rCurrentLine.current) return;
-      // For mouse / pen we require an active pointer capture to avoid stray moves.
-      // For touch, some browsers don't maintain capture the same way, and we also
-      // synthesize touch moves via onTouchMove below, so we only guard on capture.
+      // For mouse / pen / touch we require an active pointer capture to avoid stray moves.
       if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
+
+      // If multiple touch points are active, delegate to background pan/zoom
+      // logic and do not update the current stroke.
+      if (e.pointerType === 'touch' && activeTouchCount.current > 1) return;
       const [x, y] = getPoint(e.clientX, e.clientY);
       setCursorPosition(primaryActionMode !== 'eraser' ? { x, y } : null);
 
@@ -305,6 +317,9 @@ export function Whiteboard(props: WhiteboardProps) {
    */
   const handlePointerUp = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
+      if (e.pointerType === 'touch' && activeTouchCount.current > 0) {
+        activeTouchCount.current -= 1;
+      }
       e.currentTarget.releasePointerCapture(e.pointerId);
       const current = rCurrentLine.current;
       if (!current) return;

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -264,7 +264,10 @@ export function Whiteboard(props: WhiteboardProps) {
   const handlePointerMove = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
       if (!rCurrentLine.current) return;
-      if (!e.currentTarget.hasPointerCapture(e.pointerId) || e.pointerType === 'touch') return;
+      // For mouse / pen we require an active pointer capture to avoid stray moves.
+      // For touch, some browsers don't maintain capture the same way, and we also
+      // synthesize touch moves via onTouchMove below, so we only guard on capture.
+      if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
       const [x, y] = getPoint(e.clientX, e.clientY);
       setCursorPosition(primaryActionMode !== 'eraser' ? { x, y } : null);
 
@@ -543,7 +546,8 @@ export function Whiteboard(props: WhiteboardProps) {
           left: 0,
           top: 0,
           zIndex: 1000,
-          cursor: primaryActionMode === 'pen' ? 'crosshair' : 'eraser',
+        // Use a consistent crosshair cursor for all annotation tools
+        cursor: 'crosshair',
         }}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}


### PR DESCRIPTION
# This PR and summary were generated by Cursor Opus 4.6

## Summary

Fixes touch interaction for annotations, lasso selection, and pinch-zoom across touch devices (Windows touch walls, iPads). No changes to mouse or trackpad behaviour.

### Touch annotations (`Whiteboard.tsx`)

- **Fixed touch drawing being completely broken** — `handlePointerMove` had an `|| e.pointerType === 'touch'` guard that early-returned on every touch move event, preventing any annotation from being drawn via touch.
- **Multi-touch no longer draws stray marks** — added an `activeTouchCount` ref that tracks how many touch pointers are active. When a second finger arrives, drawing is blocked and any in-progress stroke from the first finger is cancelled and removed from the Yjs array (`cancelInProgressStroke`), preventing leftover dots.
- **Cursor cleanup** — replaced the invalid CSS cursor value `'eraser'` with a consistent `'crosshair'` for all annotation tools.

### Touch pinch-zoom (`BackgroundLayer.tsx`)

- **Smooth ratio-based zoom** — replaced the old approach that fed raw pixel deltas through `localZoomInDelta`/`localZoomOutDelta` (which quantized via `WheelStepZoom`, causing visible stepping) with direct ratio-based scaling: `newScale = prevScale * (distance / prevDistance)`.
- **Deadzone** — zoom only engages when the change in finger distance exceeds `TOUCH_PINCH_DEADZONE` (10px), so small finger drift during two-finger pan doesn't accidentally trigger zoom.
- **Per-frame clamp** — the scale ratio is clamped to 0.95–1.05 per frame (`TOUCH_PINCH_MIN_RATIO` / `TOUCH_PINCH_MAX_RATIO`) to prevent large zoom jumps on high-resolution touch walls.
- Pan (board translation) is always applied for two-finger gestures regardless of whether zoom is triggered.

### Lasso on touch (`Lasso.tsx`)

- **Fixed lasso not working on touch devices** — `lassoStart` and `lassoMove` were calling `getBoardCursor()`, which only tracks `mousemove` events and never updates for touch input. Switched to `uiToBoard(x, y)` which correctly converts client coordinates from both mouse and touch handlers to board space.
- **Added `touchAction: 'none'`** to the lasso container `div` and `svg` to prevent the browser from intercepting touch events for its own scroll/zoom gestures.
- Removed stale commented-out CSS properties (`pointerEvents`, `cursor`).

## Files changed

- `BackgroundLayer.tsx` — pinch-zoom deadzone, ratio-based zoom, per-frame ratio clamp
- `Whiteboard.tsx` — touch drawing fix, multi-touch detection, in-progress stroke cancellation, cursor cleanup
- `Lasso.tsx` — `uiToBoard` for touch coordinate conversion, `touchAction: 'none'`