### PR TITLE
Redesign Electron landing page for better scaling and usability

### DIFF
--- a/webstack/clients/electron/css/landing.css
+++ b/webstack/clients/electron/css/landing.css
@@ -5,50 +5,202 @@ body {
   color: white;
 }
 
-#hubs-list {
-  margin-top: 8px;
+/* Logo - hidden on short viewports to prioritize hub list */
+.logo-container {
   width: 500px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+@media (max-height: 500px) {
+  .logo-container,
+  .bottom-divider {
+    display: none;
+  }
+}
+
+/* Header row */
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 500px;
+  margin-bottom: 8px;
+}
+
+.header-title h2 {
+  margin: 0;
+}
+
+.header-buttons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Middle section */
+.middle-section {
+  flex: 1;
+  min-height: 0;
+  width: 500px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+#hubs-list {
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
   overflow-x: hidden;
   gap: 10px;
+  flex: 1;
+  min-height: 0;
 }
+/* Always reserve scrollbar space so header buttons and list align */
 #hubs-list::-webkit-scrollbar {
   width: 10px;
+  background: rgba(58, 58, 58, 0.3);
 }
 #hubs-list::-webkit-scrollbar-thumb {
   background: rgb(58, 58, 58);
   border-radius: 12px;
-  /* width:3px */
-}
-#hubs-list::-webkit-scrollbar {
-  background: transparent;
-  border-radius: '12px';
 }
 
 .hub {
   background: rgb(58, 58, 58);
   border-radius: 8px;
-  /* border: 1px solid rgb(209, 209, 209); */
   padding: 12px;
   height: 32px;
   align-items: center;
   display: flex;
   justify-content: space-between;
-  width: 100%;
-  cursor: pointer;
   width: 455px;
+  cursor: pointer;
   transition: all 0.15s ease-in-out;
 }
 
-#join-board {
-  height: 160px;
+.bottom-divider {
   width: 500px;
+  margin: 24px 0 0 0;
+  border: 0;
+  border-top: 1px solid #444;
+}
+
+/* Join board dialog (popup) */
+#join-board {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 110vh;
+  display: none;
+}
+
+/* Shared dialog styles */
+#join-board-dialog,
+#add-hub-dialog {
+  width: 600px;
+  height: 220px;
+  border-radius: 12px;
+  z-index: 101;
+  position: absolute;
+  top: calc(50% - 110px);
+  left: calc(50% - 300px);
+  background: #4e4e4e;
+  padding: 18px;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  width: 500px;
-  align-items: left;
+}
+
+#join-board-dialog h2,
+#add-hub-dialog h2 {
+  margin: 0 0 8px 0;
+}
+
+.dialog-description {
+  color: #aaa;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0 0 16px 0;
+}
+
+.dialog-description code {
+  background: rgb(58, 58, 58);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+/* Dialog form - flex to push buttons to bottom */
+#join-board-form,
+#new-hub-form {
+  width: 100%;
+  box-sizing: border-box;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+#join-board-form #input-join-board,
+#new-hub-form #input-url {
+  width: 100%;
+  max-width: 100%;
+  height: 32px;
+  padding: 8px;
+  box-sizing: border-box;
+  margin: 0 0 12px 0;
+  font-size: 16px;
+}
+
+/* Dialog button row - at bottom, Cancel left, primary action right */
+.dialog-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: auto;
+  padding-top: 12px;
+}
+
+.dialog-buttons .cancel-button {
+  background: transparent;
+  color: #aaa;
+  border: 1px solid #666;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.15s ease-in-out;
+}
+
+.dialog-buttons .cancel-button:hover {
+  color: white;
+  border-color: #888;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.dialog-buttons input[type='submit'] {
+  width: auto;
+  min-width: 100px;
+  margin: 0;
+  padding: 8px 24px;
+}
+
+#join-board-form #submit-join-board {
+  margin: 0;
+}
+
+#join-board-dimmer {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.25);
+  z-index: 100;
 }
 
 .container {
@@ -64,15 +216,8 @@ body {
   max-height: 80vh;
   width: 100%;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
-}
-
-.submit-button {
-  border: none;
-  border-radius: 0.325rem;
-  font-size: 18px;
-  cursor: pointer;
 }
 
 .add-hub-button {
@@ -87,18 +232,16 @@ body {
   height: 28px;
   cursor: pointer;
   transition: all ease-in-out 0.15s;
-  scale: 1;
   padding-left: 8px;
   padding-right: 8px;
 }
 
 .add-hub-button:hover {
   background: rgb(144, 207, 150);
-  scale: 1;
   transition: all ease-in-out 0.15s;
 }
 
-.refresh-hub-button {
+.join-board-button {
   background: rgb(75, 129, 95);
   color: white;
   font-size: 14px;
@@ -107,19 +250,41 @@ body {
   align-items: center;
   border: none;
   border-radius: 8px;
-  margin-left: 8px;
   height: 28px;
   cursor: pointer;
   transition: all ease-in-out 0.15s;
-  scale: 1;
   padding-left: 8px;
   padding-right: 8px;
 }
 
+.join-board-button:hover {
+  background: rgb(144, 207, 150);
+  transition: all ease-in-out 0.15s;
+}
+
+.refresh-hub-button {
+  background: rgb(75, 129, 95);
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  border-radius: 8px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  transition: all ease-in-out 0.15s;
+  padding: 0;
+}
+
 .refresh-hub-button:hover {
   background: rgb(144, 207, 150);
-  scale: 1;
   transition: all ease-in-out 0.15s;
+}
+
+.refresh-icon {
+  width: 16px;
+  height: 16px;
 }
 
 input[type='text'],
@@ -133,6 +298,14 @@ select {
   font-size: 18px;
   width: 600px;
   margin-top: 24px;
+}
+
+/* Dialog inputs override global width to stay contained */
+#join-board-dialog input[type='text'],
+#add-hub-dialog input[type='text'] {
+  width: 100%;
+  max-width: 100%;
+  margin-top: 0;
 }
 
 input[type='url'],
@@ -155,7 +328,6 @@ input[type='submit'] {
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  transform: scale(1);
   transition: all ease-in-out 0.15s;
   font-weight: bold;
 }
@@ -164,43 +336,15 @@ input::placeholder {
   color: darkgray;
 }
 
-#input-join-board {
-  width: calc(100% - 20px);
-  height: 32px;
-  padding: 8px;
-  border-radius: 4px;
-  border: none;
-  font-size: 18px;
-  margin-top: 12px;
-}
-
-#submit-join-board {
-  width: calc(100% - 20px);
-}
-
 #add-hub {
   position: absolute;
   left: 0px;
   top: 0px;
   width: 100vw;
   height: 110vh;
-  visibility: hidden;
-  transition: visibility 0s, opacity 0.5s linear;
+  display: none;
 }
 
-#add-hub-dialog {
-  width: 600px;
-  height: 170px;
-  border-radius: 12px;
-  z-index: 101;
-  position: absolute;
-  top: calc(50% - 100px);
-  left: calc(50% - 300px);
-  background: #4e4e4e;
-  display: 'flex';
-  flex-direction: 'column';
-  padding: 18px;
-}
 #add-hub-dimmer {
   position: absolute;
   width: 100%;

--- a/webstack/clients/electron/html/landing.html
+++ b/webstack/clients/electron/html/landing.html
@@ -69,7 +69,7 @@
           hubElement.style.pointerEvents = 'auto';
           if (info.onlineUsers) {
             onlineUsers.innerText = info.onlineUsers + ' Users';
-          } 
+          }
           // On hover style change
           hubElement.onmouseover = () => {
             hubElement.style.backgroundColor = 'rgb(78, 78, 78)';
@@ -84,16 +84,17 @@
           // Server is Offline
           onlineIcon.style.backgroundColor = red;
           hubElement.style.cursor = 'not-allowed';
+          hubElement.style.pointerEvents = 'none';
         }
       });
     }
 
-    // Change the user's page the the given url
+    // Change the user's page to the given url
     async function changePage(url) {
       window.location = url;
     }
 
-    // Function to show a dialog alert box at the bottom of the screen and removes it after 5 seconds
+    // Function to show a notification at the bottom of the screen; removes it after 3 seconds
     function showNotification(message, isError) {
       const notification = document.createElement('div');
       notification.className = 'notification';
@@ -120,14 +121,12 @@
 
     // Show the add hub dialog
     function showAddHubDialog() {
-      const addHub = document.getElementById('add-hub');
-      addHub.style.visibility = 'visible';
+      document.getElementById('add-hub').style.display = 'block';
     }
 
     // Hide the add hub dialog
     function hideAddHubDialog() {
-      const addHub = document.getElementById('add-hub');
-      addHub.style.visibility = 'hidden';
+      document.getElementById('add-hub').style.display = 'none';
     }
 
     // Fetch the sage3 server info from the given url
@@ -147,13 +146,10 @@
           console.log('Error:', response.status);
           return false;
         }
-        const data = await response.json();
       } catch (error) {
         console.error('Error:', error);
         return false;
       }
-
-      return data;
     }
 
     // Listen for messages from the main process to update bookmark list
@@ -196,7 +192,17 @@
       window.electron.send('store-interface', { request: 'get-list' });
     }
 
-    // Somone pastes in a URL and wants to join a board
+    // Show the join board dialog
+    function showJoinBoardDialog() {
+      document.getElementById('join-board').style.display = 'block';
+    }
+
+    // Hide the join board dialog
+    function hideJoinBoardDialog() {
+      document.getElementById('join-board').style.display = 'none';
+    }
+
+    // Someone pastes in a URL and wants to join a board
     async function joinBoard(url) {
       const isSage3 = url.startsWith('sage3://');
       const isHttps = url.startsWith('https://') && url.includes('/#/enter/');
@@ -231,8 +237,8 @@
       let roomId = null;
       try {
         const splitUrl = url.split('/');
-      boardId = splitUrl[splitUrl.length - 1];
-      roomId = splitUrl[splitUrl.length - 2];
+        boardId = splitUrl[splitUrl.length - 1];
+        roomId = splitUrl[splitUrl.length - 2];
       } catch (error) {
         console.error('Error:', error);
         showNotification('Invalid URL', true);
@@ -245,7 +251,7 @@
       }
       // Lets build that Board URL
       const boardURL = `https://${hostname}/#/enter/${roomId}/${boardId}`;
-      // Change the page
+      hideJoinBoardDialog();
       changePage(boardURL);
 
     }
@@ -257,62 +263,68 @@
 
   <div class="container">
     <div class="column">
-      <!-- <div style="height: 200px; width: 500px; display: flex; align-items: center; justify-content: center; pointer-events: none;">
-        <img src="../images/SAGE3_APNG_WhiteText.png" style="transform: translateX(-15px)" alt="logo" width="750px" />
-      </div> -->
-
-
-      <div style="width: 500px; display: flex; align-items: center; justify-content: center; pointer-events: none;">
-        <img src="../images/sage3_banner.webp"  alt="logo" width="100%" />
+      <div class="logo-container">
+        <img src="../images/sage3_banner.webp" alt="logo" width="100%" />
       </div>
 
-      <!-- <div style="height: 40px; width: 100%"></div> -->
-
-      <div style="display: flex;  justify-content: space-between; width:455px; margin-bottom: 8px;">
-        <div style="display: flex; align-items: center ; justify-content: left;">
-          <h2 style="margin:0px; transform: translateX(-20px)">Select a Hub</h2>
+      <div class="header-row">
+        <div class="header-title">
+          <h2>Select a Hub</h2>
         </div>
-        <div style="display: flex; align-items: center ; justify-content: right;">
+        <div class="header-buttons">
           <button class="add-hub-button" onclick="showAddHubDialog()">Add an Unlisted Hub</button>
-          <button class="refresh-hub-button" onclick="refreshHubList()">Refresh</button>
+          <button class="join-board-button" onclick="showJoinBoardDialog()">Join Board</button>
+          <button class="refresh-hub-button" onclick="refreshHubList()" title="Refresh hub list">
+            <svg class="refresh-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M23 4v6h-6M1 20v-6h6" />
+              <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+            </svg>
+          </button>
         </div>
-
       </div>
 
-      <!-- vertical list of hubs  -->
-      <div id="hubs-list"></div>
+      <!-- Hub list -->
+      <div class="middle-section">
+        <div id="hubs-list"></div>
+      </div>
 
+      <hr class="bottom-divider" />
 
-      <!-- Divider -->
-      <hr style="width: 400px; margin-top: 20px; margin-bottom: 20px; border: 0; border-top: 1px solid #333;">
-
-
+      <!-- Join board dialog -->
       <div id="join-board">
-        <h3 style="margin: 0px;" >Join a Board</h3>
-        <form id="join-board-form" name="myForm" action="" onsubmit="joinBoard(this.url.value); return false;">
-          <input id="input-join-board" type="text" name="url" value="" placeholder="Enter the URL of the board you wish to join" required />
-          </br>
-          <input id="submit-join-board" type="submit" value="Join" />
-        </form>
+        <div id="join-board-dialog">
+          <h2>Join a Board</h2>
+          <p class="dialog-description">
+            Paste a SAGE3 board URL to join directly.
+          </p>
+          <form id="join-board-form" onsubmit="joinBoard(this.url.value); return false;">
+            <input id="input-join-board" type="text" name="url"
+              placeholder="Enter the URL of the board you wish to join" required />
+            <div class="dialog-buttons">
+              <button type="button" class="cancel-button" onclick="hideJoinBoardDialog()">Cancel</button>
+              <input id="submit-join-board" type="submit" value="Join" />
+            </div>
+          </form>
+        </div>
+        <div id="join-board-dimmer" onclick="hideJoinBoardDialog()"></div>
       </div>
 
       <!-- Add hub dialog -->
       <div id="add-hub">
         <div id="add-hub-dialog">
-          <h2 style="margin-top: 0px; margin-bottom:0px;">Add an Unlisted Hub</h2>
-          <p style="margin-top: 2px; margin-bottom:0px;">URL must contain 'https'. (i.e. https://sage.app)</p>
+          <h2>Add an Unlisted Hub</h2>
+          <p class="dialog-description">URL must contain 'https'. (e.g. https://sage.app)</p>
           <form id="new-hub-form" name="myForm" action="" onsubmit="addNewHub(this); return false;">
             <input id="input-url" type="text" name="serverurl" value=""
               placeholder="Enter the full URL of the hub you want to add" required />
-            </br>
-            <input type="submit" value="Submit" />
+            <div class="dialog-buttons">
+              <button type="button" class="cancel-button" onclick="hideAddHubDialog()">Cancel</button>
+              <input type="submit" value="Add" />
+            </div>
           </form>
         </div>
         <div id="add-hub-dimmer" onclick="hideAddHubDialog()"></div>
-        <div>
-        </div>
       </div>
-      <br />
     </div>
   </div>
 </body>

--- a/webstack/clients/electron/package.json
+++ b/webstack/clients/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SAGE3",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Electron-based SAGE3 client",
   "main": "electron.js",
   "repository": {
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@electron/notarize": "^2.3.2",
     "@electron/packager": "^18.4.4",
-    "electron": "^40.0.0"
+    "electron": "^40.7.0"
   },
   "optionalDependencies": {
     "electron-installer-debian": "latest",

--- a/webstack/clients/electron/yarn.lock
+++ b/webstack/clients/electron/yarn.lock
@@ -672,10 +672,10 @@ electron-winstaller@latest:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron@^40.0.0:
-  version "40.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-40.0.0.tgz#01b1589ce2619dc7e792b1ca78d3ff1ae2ce05e7"
-  integrity sha512-UyBy5yJ0/wm4gNugCtNPjvddjAknMTuXR2aCHioXicH7aKRKGDBPp4xqTEi/doVcB3R+MN3wfU9o8d/9pwgK2A==
+electron@^40.7.0:
+  version "40.7.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-40.7.0.tgz#ed57e7a1d400bb8a93ce70c39f2ca023d28792e7"
+  integrity sha512-oQe76S/3V1rcb0+i45hAxnCH8udkRZSaHUNwglzNAEKbB94LSJ1qwbFo8+uRc2UsYZgCqSIMRcyX40GyOkD+Xw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^24.9.0"


### PR DESCRIPTION
### Description:
The Electron landing page was clipping content on high-DPI displays and small windows due to fixed pixel sizes, overflow: hidden on the body, and centered flex layout pushing content off-screen.

#### Changes:
- Fixed layout to properly scroll the hub list within available space using flex sizing
- Moved "Join a Board" into a popup dialog matching the "Add an Unlisted Hub" dialog style
- Added a "Join Board" button to the header alongside "Add an Unlisted Hub" and a refresh icon button
- Logo automatically hides on short viewports (500px or less) to prioritize the hub list
- Unified dialog sizing, description text styling, and button placement (Cancel + primary action)
- Scrollbar always reserves space so the header and list stay aligned
- Cleaned up dead code in fetchServerInfo, fixed typos, corrected indentation, and added pointer-events: none on offline hubs