### PR TITLE
fix: guard against null Redis documents causing server crashes

### DIFF
--- a/webstack/apps/homebase/src/api/collections/apps.ts
+++ b/webstack/apps/homebase/src/api/collections/apps.ts
@@ -29,6 +29,7 @@ class SAGE3AppsCollection extends SAGE3Collection<AppSchema> {
         const apps = [] as { position: Position; size: Size; type: AppName; id: string }[];
         docs = await this.collection.query('boardId', boardId);
         docs.forEach((app) => {
+          if (!app) return;
           const aInfo = { position: app.data.position, size: app.data.size, type: app.data.type, id: app._id };
           apps.push(aInfo);
         });

--- a/webstack/apps/homebase/src/api/collections/index.ts
+++ b/webstack/apps/homebase/src/api/collections/index.ts
@@ -104,8 +104,8 @@ export async function loadCollections(): Promise<void> {
     const apps = await AppsCollection.getAll();
     if (!links || !apps) return;
 
-    const appIds = new Set(apps.map((app) => app._id));
-    const invalidLinks = links.filter((link) => !appIds.has(link.data.sourceAppId) || !appIds.has(link.data.targetAppId));
+    const appIds = new Set(apps.filter(Boolean).map((app) => app._id));
+    const invalidLinks = links.filter((link) => link && (!appIds.has(link.data.sourceAppId) || !appIds.has(link.data.targetAppId)));
 
     if (invalidLinks.length > 0) {
       const invalidLinkIds = invalidLinks.map((link) => link._id);

--- a/webstack/apps/homebase/src/api/collections/plugins.ts
+++ b/webstack/apps/homebase/src/api/collections/plugins.ts
@@ -135,7 +135,7 @@ class SAGE3PluginsCollection extends SAGE3Collection<PluginSchema> {
       // Check to see if plugin with that name already exists in this room
       // Plugins are unique per room (roomId + name combination)
       const check = await this.collection.query('name', pluginName);
-      const existingPluginInRoom = check.find((p) => p.data.roomId === roomId);
+      const existingPluginInRoom = check.find((p) => p !== null && p.data.roomId === roomId);
       
       if (existingPluginInRoom) {
         // Check if the existing plugin is owned by the user

--- a/webstack/libs/backend/src/lib/generics/SAGECollection.ts
+++ b/webstack/libs/backend/src/lib/generics/SAGECollection.ts
@@ -116,7 +116,7 @@ export class SAGE3Collection<T extends SBJSON> {
   public async getBatch(ids: string[]): Promise<SBDocument<T>[] | undefined> {
     try {
       const docs = await Promise.all(ids.map((id) => this._collection.docRef(id).read()));
-      return docs.filter((doc) => doc !== undefined) as SBDocument<T>[];
+      return docs.filter((doc) => doc !== undefined && doc !== null) as SBDocument<T>[];
     } catch (error) {
       this.printError(error);
       return undefined;

--- a/webstack/libs/sagebase/src/lib/modules/database/SBCollection.ts
+++ b/webstack/libs/sagebase/src/lib/modules/database/SBCollection.ts
@@ -194,7 +194,7 @@ export class SBCollectionRef<Type extends SBJSON> {
     if (docs) {
       const returnList = [] as SBDocument<Type>[];
       docs.forEach((doc) => {
-        if (doc !== undefined) returnList.push(doc);
+        if (doc !== undefined && doc !== null) returnList.push(doc);
       });
       return returnList;
     } else {
@@ -321,7 +321,7 @@ export class SBCollectionRef<Type extends SBJSON> {
       const docs = await Promise.all([...docRefPromises]);
       const a = [] as SBDocument<Type>[];
       docs.forEach((el) => {
-        if (el !== undefined) a.push(el);
+        if (el !== undefined && el !== null) a.push(el);
       });
       return a;
     } catch (error) {

--- a/webstack/libs/sagebase/src/lib/modules/database/SBDocument.ts
+++ b/webstack/libs/sagebase/src/lib/modules/database/SBDocument.ts
@@ -97,7 +97,9 @@ export class SBDocumentRef<Type extends SBJSON> {
   public async read(): Promise<SBDocument<Type> | undefined> {
     try {
       const redisRes = await this.redis.json.get(`${this._path}`);
-      return redisRes as SBDocument<Type>;
+      // redis.json.get() returns null when the key doesn't exist (e.g. deleted between
+      // a keys() scan and this fetch). Normalize to undefined so callers see a consistent type.
+      return redisRes === null ? undefined : (redisRes as SBDocument<Type>);
     } catch (error) {
       this.ERRORLOG(error);
       return undefined;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  - `redis.json.get()` returns `null` when a key is found during a `keys()` scan but deleted before the subsequent fetch — a TOCTOU race that occurs on server restart or during cleanup.                                               
  - Collection methods were filtering `undefined` but not `null`, allowing null entries to reach callers that accessed `.data` without a null check, crashing the process.                                                              
  - Root fix is in `SBDocument.read()` — null is normalized to `undefined` at the Redis boundary so it never escapes into collection logic.                                                                                             
  - Belt-and-suspenders null guards added to all collection array methods and two specific call sites.                                                                                                                                  
                                                                                                                                                                                                                                        
  ## Root Cause                                                                                                                                                                                                                         
                                                                                                                                                                                                                                        
  The crash appeared as:                                                                                                                                                                                                              
  TypeError: Cannot read properties of null (reading 'data')
      at Array.filter                                                                                                                                                                                                                   
                     
  The stack trace pointed to a `.filter()` callback accessing `.data` on a null value. The most likely site is `checkAllLinks()` in `collections/index.ts`, which filters a `links` array and accesses `link.data` directly — the only  
  such pattern in the area. This function is triggered when a user deletes an app, which matches the timing of the observed crash. Only one of two homebase replicas crashed because the per-process throttle causes each instance to
  run the check at slightly different times, making the null race timing-dependent.                                                                                                                                                     
  
  ## Files Changed                                                                                                                                                                                                                      
                                                            
  | File | Change |                                                                                                                                                                                                                     
  |------|--------|
  | `libs/sagebase/.../SBDocument.ts` | `read()`: normalize `null → undefined` at the Redis layer |                                                                                                                                     
  | `libs/sagebase/.../SBCollection.ts` | `getAllDocs()`, `query()`: filter `null` alongside `undefined` |                                                                                                                              
  | `libs/backend/.../SAGECollection.ts` | `getBatch()`: same |                                                                                                                                                                         
  | `apps/homebase/.../collections/index.ts` | `checkAllLinks()`: null guards on `apps` and `links` arrays |                                                                                                                            
  | `apps/homebase/.../collections/apps.ts` | null guard before `.data` access in board preview query |                                                                                                                                 
  | `apps/homebase/.../collections/plugins.ts` | null guard before `.data` access in plugin name lookup |                                                                                                                               
                                                                                                                                                                                                                                        
  ## Test Plan                                                                                                                                                                                                                          
                                                                                                                                                                                                                                        
  - [x] Delete apps on a board with multiple homebase replicas running — neither instance should crash                                                                                                                                  
  - [x] Upload files, create/delete rooms and boards — normal operations unaffected
  - [x] Batch GET requests return all found documents; missing IDs are silently omitted   