### PR TITLE
 [Homepage] Homepage Performance Improvements  

### DIFF
--- a/webstack/apps/homebase/src/api/collections/apps.ts
+++ b/webstack/apps/homebase/src/api/collections/apps.ts
@@ -1,14 +1,13 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
  * the file LICENSE, distributed as part of this software.
  */
 
-import { AppName, AppSchema } from '@sage3/applications/schema';
+import { AppSchema } from '@sage3/applications/schema';
 import { SAGE3Collection, sageRouter } from '@sage3/backend';
-import { Position, Size } from '@sage3/shared/types';
 
 class SAGE3AppsCollection extends SAGE3Collection<AppSchema> {
   constructor() {
@@ -18,25 +17,6 @@ class SAGE3AppsCollection extends SAGE3Collection<AppSchema> {
       type: 'Stickie',
     });
     const router = sageRouter<AppSchema>(this);
-
-    // Get subset snapshot of the apps to build preview on frontend
-    router.post('/preview', async ({ body }, res) => {
-      const boardId = body.boardId;
-      if (!boardId) {
-        res.status(500).send({ success: false, message: 'No BoardID Provided.', data: undefined });
-      } else {
-        let docs = null;
-        const apps = [] as { position: Position; size: Size; type: AppName; id: string }[];
-        docs = await this.collection.query('boardId', boardId);
-        docs.forEach((app) => {
-          if (!app) return;
-          const aInfo = { position: app.data.position, size: app.data.size, type: app.data.type, id: app._id };
-          apps.push(aInfo);
-        });
-        if (docs) res.status(200).send({ success: true, message: 'Successfully retrieved documents.', data: apps });
-        else res.status(500).send({ success: false, message: 'Failed to retrieve documents.', data: undefined });
-      }
-    });
     this.httpRouter = router;
   }
 

--- a/webstack/apps/homebase/src/api/collections/boards.ts
+++ b/webstack/apps/homebase/src/api/collections/boards.ts
@@ -1,17 +1,26 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
  * the file LICENSE, distributed as part of this software.
  */
 
-import { BoardSchema } from '@sage3/shared/types';
+import { AppName } from '@sage3/applications/schema';
+import { BoardSchema, Position, Size } from '@sage3/shared/types';
 import { SAGE3Collection, sageRouter } from '@sage3/backend';
 
 import { AnnotationsCollection } from './annotations';
 import { AppsCollection } from './apps';
 import { InsightCollection } from './insight';
+
+// Minimal app info needed for board preview rendering
+type AppPreviewInfo = { position: Position; size: Size; type: AppName; id: string };
+
+// Server-side cache: boardId -> { apps, timestamp }
+// Absorbs burst traffic when multiple users load the homepage simultaneously
+const previewCache = new Map<string, { apps: AppPreviewInfo[]; timestamp: number }>();
+const PREVIEW_CACHE_TTL = 30 * 1000; // 30 seconds
 
 export type BoardDeleteInfo = {
   boardId: string;
@@ -29,22 +38,67 @@ class SAGE3BoardsCollection extends SAGE3Collection<BoardSchema> {
       roomId: '',
     });
     const router = sageRouter<BoardSchema>(this);
+
+    // Batch preview: returns app layout (position/size/type) for multiple boards in one request.
+    // Used by the homepage to render spatial previews without subscribing to app data.
+    router.post('/preview', async ({ body }, res) => {
+      const boardIds = body.boardIds as string[];
+      const force = body.force === true;
+      if (!boardIds || !Array.isArray(boardIds) || boardIds.length === 0) {
+        res.status(400).send({ success: false, message: 'No boardIds provided.' });
+        return;
+      }
+
+      const now = Date.now();
+      const result: Record<string, AppPreviewInfo[]> = {};
+      const uncached: string[] = [];
+
+      // Serve from cache where available (skipped when force=true)
+      for (const boardId of boardIds) {
+        const cached = previewCache.get(boardId);
+        if (!force && cached && now - cached.timestamp < PREVIEW_CACHE_TTL) {
+          result[boardId] = cached.apps;
+        } else {
+          uncached.push(boardId);
+        }
+      }
+
+      // Fetch uncached boards in parallel
+      if (uncached.length > 0) {
+        const fetched = await Promise.all(
+          uncached.map(async (boardId) => {
+            const docs = await AppsCollection.query('boardId', boardId);
+            const apps = (docs || []).map((app) => ({
+              position: app.data.position,
+              size: app.data.size,
+              type: app.data.type,
+              id: app._id,
+            }));
+            previewCache.set(boardId, { apps, timestamp: now });
+            return { boardId, apps };
+          })
+        );
+        fetched.forEach(({ boardId, apps }) => {
+          result[boardId] = apps;
+        });
+      }
+
+      res.status(200).send({ success: true, data: result });
+    });
+
     this.httpRouter = router;
   }
 
-  // Delete all the boards of a specific user
+  // Delete all boards owned by a specific user
   public async deleteUsersBoards(userId: string): Promise<BoardDeleteInfo[]> {
-    // Delete the boards of the user
     const userBoards = await this.query('ownerId', userId);
     const boardsIds = userBoards ? userBoards.map((board) => board._id) : [];
-    // Promise all delete using deleteBoard
     const boardsDeleted = await Promise.all(boardsIds.map((boardId) => this.deleteBoard(boardId)));
     return boardsDeleted;
   }
 
-  // Delete all the boards in a specific room
+  // Delete all boards in a specific room
   public async deleteBoardsInRoom(roomId: string): Promise<BoardDeleteInfo[]> {
-    // Delete the boards in the room
     const roomBoards = await this.query('roomId', roomId);
     const boardsIds = roomBoards ? roomBoards.map((board) => board._id) : [];
     const boardsDeleteInfo = [];
@@ -55,9 +109,8 @@ class SAGE3BoardsCollection extends SAGE3Collection<BoardSchema> {
     return boardsDeleteInfo;
   }
 
-  // Transfer all the boards of a user to another user
+  // Transfer ownership of all boards from one user to another
   public async transferUsersBoards(oldUserId: string, newOwnerId: string): Promise<boolean> {
-    // Get all the boards of the user
     const userBoards = await this.query('ownerId', oldUserId);
     const boardsIds = userBoards ? userBoards.map((board) => board._id) : [];
     const res = await Promise.all(boardsIds.map((boardId) => this.update(boardId, newOwnerId, { ownerId: newOwnerId })));
@@ -77,16 +130,18 @@ class SAGE3BoardsCollection extends SAGE3Collection<BoardSchema> {
       annotationsDeleted: false,
       insightsDeleted: 0,
     } as BoardDeleteInfo;
-    // Delete the board
+    // Evict cached preview so stale app layout is not served after deletion
+    previewCache.delete(boardId);
+
     const boardDeleted = await this.delete(boardId);
     results.boardDeleted = boardDeleted ? true : false;
-    // Delete the apps of the board
+
     const appsDeleted = await AppsCollection.deleteAppsOnBoard(boardId);
     results.appsDeleted = appsDeleted;
-    // Delete the annotations of the board
+
     const annotationsDeleted = await AnnotationsCollection.deleteAnnotationsOnBoard(boardId);
     results.annotationsDeleted = annotationsDeleted;
-    // Delete the insights of the board
+
     const insightsDeleted = await InsightCollection.deleteInsightsOnBoard(boardId);
     results.insightsDeleted = insightsDeleted;
     return results;

--- a/webstack/apps/webapp/src/app/pages/home/Home.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/Home.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2025. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -10,7 +10,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-// Chakra Iports
+// Chakra Imports
 import {
   Box,
   useColorModeValue,
@@ -40,12 +40,12 @@ import {
 } from '@chakra-ui/react';
 
 // Icons
-import { MdAdd, MdHome, MdSearch, MdGridView, MdList, MdPeople, MdFolder, MdDashboard, MdSettings, MdExitToApp, MdMenu } from 'react-icons/md';
+import { MdAdd, MdHome, MdSearch, MdGridView, MdList, MdPeople, MdFolder, MdDashboard, MdSettings, MdExitToApp, MdMenu, MdRefresh } from 'react-icons/md';
 import { HiPuzzle } from 'react-icons/hi';
 import { LuChevronsUpDown } from 'react-icons/lu';
 
 // SAGE Imports
-import { Board, Room } from '@sage3/shared/types';
+import { Board, PresencePartial, Room } from '@sage3/shared/types';
 import { SAGE3Ability, generateReadableID, fuzzySearch } from '@sage3/shared';
 import {
   JoinBoardCheck,
@@ -71,7 +71,10 @@ import {
   isUUIDv4,
   MainButton,
   PartyButton,
+  apiUrls,
 } from '@sage3/frontend';
+
+import { AppInfo } from './components/BoardPreview';
 
 // Home Page Components
 import { BoardRow, BoardCard, RoomSearchModal, PasswordJoinRoomModal, AssetList, PluginsList, MembersList } from './components';
@@ -132,15 +135,25 @@ export function HomePage() {
   // User Selected Room, Board, and User
   const [selectedRoom, setSelectedRoom] = useState<Room | undefined>(undefined);
   const [selectedBoard, setSelectedBoard] = useState<Board | undefined>(undefined);
+
+  // boardSearch: debounced value used for filtering; boardSearchInput: live input display value
   const [boardSearch, setBoardSearch] = useState<string>('');
+  const [boardSearchInput, setBoardSearchInput] = useState<string>('');
+  const boardSearchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [passwordProtectedRoom, setPasswordProtectedRoom] = useState<Room | undefined>(undefined);
 
-  // Searchbar
+  // Board preview data: boardId -> AppInfo[]. Fetched in batch on room switch; never auto-cleared.
+  const [boardPreviews, setBoardPreviews] = useState<Map<string, AppInfo[]>>(new Map());
+  const [previewsLoading, setPreviewsLoading] = useState(false);
+
+  // searchSage: debounced value used for filtering; searchSageInput: live input display value
   const [searchSage, setSearchSage] = useState<string>('');
+  const [searchSageInput, setSearchSageInput] = useState<string>('');
+  const searchSageDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isSearchSageFocused, setSearchSageFocused] = useState<boolean>(false);
 
-  // Selected Board Ref
+  // Selected board ref — used to scroll the card into view
   const scrollToBoardRef = useRef<null | HTMLDivElement>(null);
 
   // Toast to inform user that they are not a member of a room
@@ -214,20 +227,18 @@ export function HomePage() {
   const starredBoardsRef = useRef<HTMLParagraphElement>(null);
   const recentBoardsRef = useRef<HTMLParagraphElement>(null);
 
-
   // Filter Functions
   const roomMemberFilter = (room: Room): boolean => {
     if (!user) return false;
     const roomMembership = members.find((m) => m.data.roomId === room._id);
     const isMember = roomMembership && roomMembership.data.members ? roomMembership.data.members.includes(userId) : false;
     const isOwner = room.data.ownerId === userId;
-    // const isMainRoom = room.data.name === 'Main Room' && room.data.ownerId === '';
     return isMember || isOwner;
   };
 
   const boardActiveFilter = (board: Board): boolean => {
     const roomMembership = members.find((m) => m.data.roomId === board.data.roomId);
-    const userCount = partialPrescences.filter((p) => p.data.boardId === board._id).length;
+    const userCount = (presenceByBoard.get(board._id) ?? []).length;
 
     // As a guest or spectator, check
     if (user?.data.userRole === 'guest' || user?.data.userRole === 'spectator') {
@@ -270,7 +281,72 @@ export function HomePage() {
     return fuzzySearch(board.data.name + ' ' + board.data.description, boardSearch);
   };
 
+  // Filtered + sorted board list for the selected room — avoids recomputing on every render
+  const filteredRoomBoards = useMemo(
+    () =>
+      boards
+        .filter((b) => b.data.roomId === selectedRoom?._id)
+        .filter(boardSearchFilter)
+        .sort((a, b) => a.data.name.localeCompare(b.data.name)),
+    [boards, selectedRoom?._id, boardSearch]
+  );
 
+  // Presence grouped by boardId — avoids O(boards × presences) filter on every render
+  const presenceByBoard = useMemo(() => {
+    const map = new Map<string, PresencePartial[]>();
+    partialPrescences.forEach((p) => {
+      const existing = map.get(p.data.boardId);
+      if (existing) existing.push(p);
+      else map.set(p.data.boardId, [p]);
+    });
+    return map;
+  }, [partialPrescences]);
+
+  // Fetch batch previews for the given boardIds, merging results into state.
+  // Pass force=true to bypass the server-side cache (used by the refresh button).
+  const fetchPreviews = async (boardIds: string[], force = false) => {
+    if (boardIds.length === 0) return;
+    setPreviewsLoading(true);
+    try {
+      const response = await fetch(apiUrls.boards.preview, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ boardIds, force }),
+      });
+      const res = await response.json();
+      if (res.success && res.data) {
+        setBoardPreviews((prev) => {
+          const next = new Map(prev);
+          Object.entries(res.data as Record<string, AppInfo[]>).forEach(([id, apps]) => next.set(id, apps));
+          return next;
+        });
+      }
+    } catch {
+      // Preview is non-critical — fail silently
+    } finally {
+      setPreviewsLoading(false);
+    }
+  };
+
+  // Re-fetch previews for the current context (room view or home view), bypassing cached entries
+  const refreshPreviews = async () => {
+    const idsToRefresh = selectedRoom
+      ? boards.filter((b) => b.data.roomId === selectedRoom._id).map((b) => b._id)
+      : [...new Set([
+          ...boards.filter(recentBoardsFilter),
+          ...boards.filter(boardStarredFilter),
+          ...boards.filter(boardActiveFilter),
+        ].map((b) => b._id))];
+
+    // Clear existing entries so fetchPreviews treats them as missing
+    setBoardPreviews((prev) => {
+      const next = new Map(prev);
+      idsToRefresh.forEach((id) => next.delete(id));
+      return next;
+    });
+    await fetchPreviews(idsToRefresh, true);
+  };
 
   const sageSearchFilter = (item: Board | Room) => {
     return fuzzySearch(item.data.name + '' + item.data.description, searchSage);
@@ -377,7 +453,28 @@ export function HomePage() {
       updatePresence(userId, { roomId });
     }
     setBoardSearch('');
+    setBoardSearchInput('');
   }, [selectedRoom]);
+
+  // Fetch board previews when the selected room changes (or on home view)
+  useEffect(() => {
+    if (selectedRoom) {
+      // Only fetch boardIds not already in state
+      const ids = boards
+        .filter((b) => b.data.roomId === selectedRoom._id)
+        .map((b) => b._id)
+        .filter((id) => !boardPreviews.has(id));
+      fetchPreviews(ids);
+    } else {
+      // Home view: fetch for recent, starred, and active boards
+      const ids = [...new Set([
+        ...boards.filter(recentBoardsFilter),
+        ...boards.filter(boardStarredFilter),
+        ...boards.filter(boardActiveFilter),
+      ].map((b) => b._id))].filter((id) => !boardPreviews.has(id));
+      fetchPreviews(ids);
+    }
+  }, [selectedRoom?._id, boards.length]);
 
   // Scroll selected board into view
   useEffect(() => {
@@ -422,9 +519,7 @@ export function HomePage() {
     }
   }
 
-
-
-  // Handle when the user wnats to leave a room membership
+  // Handle when the user wants to leave a room membership
   const handleLeaveRoomMembership = () => {
     const isOwner = selectedRoom?.data.ownerId === userId;
     if (selectedRoom && !isOwner) {
@@ -891,8 +986,6 @@ export function HomePage() {
         </Box>
       </Box>
 
-
-
       {/* Selected Room */}
       {selectedRoom && rooms.length > 0 && (
         <Box
@@ -1023,9 +1116,12 @@ export function HomePage() {
                             <Input
                               placeholder="Search Boards"
                               _placeholder={{ opacity: 0.7, color: searchPlaceholderColor }}
-                              value={boardSearch}
+                              value={boardSearchInput}
                               onChange={(e) => {
-                                setBoardSearch(e.target.value);
+                                const value = e.target.value;
+                                setBoardSearchInput(value);
+                                if (boardSearchDebounceRef.current) clearTimeout(boardSearchDebounceRef.current);
+                                boardSearchDebounceRef.current = setTimeout(() => setBoardSearch(value), 150);
                               }}
                               roundedTop="2xl"
                               _focusVisible={{ bg: searchBarColor, outline: 'none', transition: 'none' }}
@@ -1043,11 +1139,20 @@ export function HomePage() {
                               }}
                               icon={boardListView === 'grid' ? <MdList fontSize="24px" /> : <MdGridView fontSize="24px" />}
                               _hover={{ transform: 'scale(1.1)', bg: 'none' }}
-
+                            />
+                          </Tooltip>
+                          <Tooltip label="Refresh Board Previews" placement="top" hasArrow>
+                            <IconButton
+                              size="sm"
+                              bg="none"
+                              aria-label="Refresh board previews"
+                              isLoading={previewsLoading}
+                              onClick={refreshPreviews}
+                              icon={<MdRefresh fontSize="24px" />}
+                              _hover={{ transform: 'scale(1.1)', bg: 'none' }}
                             />
                           </Tooltip>
                         </Flex>
-                        {/* <Divider /> */}
                         {boardListView == 'grid' && (
                           <Flex
                             gap="4"
@@ -1076,19 +1181,15 @@ export function HomePage() {
                               },
                             }}
                           >
-                            {boards
-                              .filter((board) => board.data.roomId === selectedRoom?._id)
-                              .filter((board) => boardSearchFilter(board))
-                              .sort((a, b) => a.data.name.localeCompare(b.data.name))
-                              .map((board) => (
+                            {filteredRoomBoards.map((board) => (
                                 <Box key={board._id} ref={board._id === selectedBoard?._id ? scrollToBoardRef : undefined}>
                                   <BoardCard
                                     board={board}
                                     room={selectedRoom}
                                     onClick={() => handleBoardClick(board)}
-                                    // onClick={(board) => {handleBoardClick(board); enterBoardModalOnOpen()}}
                                     selected={selectedBoard ? selectedBoard._id === board._id : false}
-                                    usersPresent={partialPrescences.filter((p) => p.data.boardId === board._id)}
+                                    usersPresent={presenceByBoard.get(board._id) ?? []}
+                                    appInfo={boardPreviews.get(board._id) ?? []}
                                   />
                                 </Box>
                               ))}
@@ -1115,11 +1216,7 @@ export function HomePage() {
                               },
                             }}
                           >
-                            {boards
-                              .filter((board) => board.data.roomId === selectedRoom?._id)
-                              .filter((board) => boardSearchFilter(board))
-                              .sort((a, b) => a.data.name.localeCompare(b.data.name))
-                              .map((board) => (
+                            {filteredRoomBoards.map((board) => (
                                 <Box key={board._id} ref={board._id === selectedBoard?._id ? scrollToBoardRef : undefined}>
                                   <BoardRow
                                     key={board._id}
@@ -1127,7 +1224,7 @@ export function HomePage() {
                                     room={selectedRoom}
                                     onClick={() => handleBoardClick(board)}
                                     selected={selectedBoard ? selectedBoard._id === board._id : false}
-                                    usersPresent={partialPrescences.filter((p) => p.data.boardId === board._id).length}
+                                    usersPresent={(presenceByBoard.get(board._id) ?? []).length}
                                   />
                                 </Box>
                               ))}
@@ -1199,8 +1296,6 @@ export function HomePage() {
             w="full"
             maxW="2400px"
           >
-
-
             <Text fontSize="xx-large" fontWeight="bold" alignSelf="center">
               Good {getTimeBasedGreeting()}, {user?.data.name.split(' ')[0]}
             </Text>
@@ -1220,23 +1315,27 @@ export function HomePage() {
                 <Input
                   placeholder="Search your rooms, boards, or join board via URL"
                   _placeholder={{ opacity: 0.7, color: searchPlaceholderColor }}
-                  value={searchSage}
+                  value={searchSageInput}
                   onChange={(e) => {
-                    setSearchSage(e.target.value);
+                    const value = e.target.value;
+                    setSearchSageInput(value);
+                    if (searchSageDebounceRef.current) clearTimeout(searchSageDebounceRef.current);
+                    searchSageDebounceRef.current = setTimeout(() => setSearchSage(value), 150);
                   }}
                   onKeyDown={(e) => {
                     if (e.key === 'Escape') {
+                      setSearchSageInput('');
                       setSearchSage('');
                     }
                   }}
                   roundedTop="2xl"
                   _focusVisible={{ bg: searchBarColor, outline: 'none', transition: 'none' }}
                   bg={isSearchSageFocused ? searchBarColor : 'inherit'}
-                  roundedBottom={`${searchSage.length > 0 && isSearchSageFocused ? 'none' : '2xl'}`}
+                  roundedBottom={`${searchSageInput.length > 0 && isSearchSageFocused ? 'none' : '2xl'}`}
                 />
               </InputGroup>
               <Box
-                hidden={!(searchSage.length > 0) || !isSearchSageFocused}
+                hidden={!(searchSageInput.length > 0) || !isSearchSageFocused}
                 ref={searchSageRef}
                 bg={searchBgColor}
                 position="absolute"
@@ -1361,7 +1460,8 @@ export function HomePage() {
                                 room={room}
                                 onClick={() => handleBoardClick(board)}
                                 selected={selectedBoard ? selectedBoard._id === board._id : false}
-                                usersPresent={partialPrescences.filter((p) => p.data.boardId === board._id)}
+                                usersPresent={presenceByBoard.get(board._id) ?? []}
+                                appInfo={boardPreviews.get(board._id) ?? []}
                               />
                             </Box>
                           );
@@ -1422,7 +1522,8 @@ export function HomePage() {
                                 room={room}
                                 onClick={() => handleBoardClick(board)}
                                 selected={selectedBoard ? selectedBoard._id === board._id : false}
-                                usersPresent={partialPrescences.filter((p) => p.data.boardId === board._id)}
+                                usersPresent={presenceByBoard.get(board._id) ?? []}
+                                appInfo={boardPreviews.get(board._id) ?? []}
                               />
                             </Box>
                           );
@@ -1475,8 +1576,8 @@ export function HomePage() {
                         .sort((a, b) => a.data.name.localeCompare(b.data.name))
                         .sort((a, b) => {
                           // Sorted by alpha then user count
-                          const userCountA = partialPrescences.filter((p) => p.data.boardId === a._id).length;
-                          const userCountB = partialPrescences.filter((p) => p.data.boardId === b._id).length;
+                          const userCountA = (presenceByBoard.get(a._id) ?? []).length;
+                          const userCountB = (presenceByBoard.get(b._id) ?? []).length;
                           return userCountB - userCountA;
                         })
                         .map((board) => {
@@ -1489,7 +1590,8 @@ export function HomePage() {
                                 room={room}
                                 onClick={() => handleBoardClick(board)}
                                 selected={selectedBoard ? selectedBoard._id === board._id : false}
-                                usersPresent={partialPrescences.filter((p) => p.data.boardId === board._id)}
+                                usersPresent={presenceByBoard.get(board._id) ?? []}
+                                appInfo={boardPreviews.get(board._id) ?? []}
                               />
                             </Box>
                           );

--- a/webstack/apps/webapp/src/app/pages/home/components/BoardCard.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/components/BoardCard.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2024. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -27,7 +27,7 @@ import { MdStar, MdStarOutline } from 'react-icons/md';
 import { Board, PresencePartial, Room } from '@sage3/shared/types';
 import { EnterBoardModal, useHexColor, useUser, copyBoardUrlToClipboard, EditBoardModal, BoardInformationModal } from '@sage3/frontend';
 
-import { BoardPreview } from './BoardPreview';
+import { BoardPreview, AppInfo } from './BoardPreview';
 import { UserPresenceIcons } from './UserPresenceIcons';
 
 // Board Card Props
@@ -37,6 +37,7 @@ interface BoardCardProps {
   selected: boolean;
   onClick: (board: Board) => void;
   usersPresent: PresencePartial[];
+  appInfo: AppInfo[];
 }
 
 export function BoardCard(props: BoardCardProps) {
@@ -169,7 +170,7 @@ export function BoardCard(props: BoardCardProps) {
                 />
               </Box>
             </Box>
-            <BoardPreview board={props.board} width={230} height={120} isSelected={props.selected} />
+            <BoardPreview board={props.board} width={230} height={120} isSelected={props.selected} appInfo={props.appInfo} />
             <Tooltip hasArrow={true} label={isFavorite ? 'Unfavorite this board' : 'Favorite this board'} openDelay={400}>
               <IconButton
                 top="0"

--- a/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/components/BoardPreview.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2024. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -10,59 +10,16 @@ import { useState, useEffect, useRef } from 'react';
 import { Box, Text, Icon, useColorModeValue } from '@chakra-ui/react';
 import { MdLock } from 'react-icons/md';
 
-import { apiUrls, useHexColor } from '@sage3/frontend';
+import { useHexColor } from '@sage3/frontend';
 import { Board, Position, Size } from '@sage3/shared/types';
 import { AppName } from '@sage3/applications/schema';
 
-// Type for app info
-type AppInfo = { position: Position; size: Size; type: AppName; id: string };
+// Minimal app layout info needed to render the spatial preview
+export type AppInfo = { position: Position; size: Size; type: AppName; id: string };
 
-// A Global store to cache apps for each board
-// Has local time stamp to check if cache is expired. 60 seconds
-const cacheTime = 60 * 1000;
+const PADDING = 2;
 
-const appCache = new Map<string, { apps: AppInfo[]; timestamp: number }>();
-
-const getAppInfo = async (boardId: string): Promise<AppInfo[]> => {
-  // Get the apps from the cache
-  const apps = appCache.get(boardId);
-  // Check if cache is expired
-  if (apps) {
-    // Check if cache is expired
-    if (Date.now() - apps.timestamp < cacheTime) {
-      return apps.apps;
-    } else {
-      const newApps = await updateAppInfo(boardId);
-      appCache.set(boardId, { apps: newApps, timestamp: Date.now() });
-      return newApps;
-    }
-  } else {
-    const apps = await updateAppInfo(boardId);
-    appCache.set(boardId, { apps, timestamp: Date.now() });
-    return apps;
-  }
-};
-
-const updateAppInfo = async (boardId: string): Promise<AppInfo[]> => {
-  const response = await fetch(apiUrls.apps.preview, {
-    body: JSON.stringify({ boardId: boardId }),
-    method: 'POST',
-    credentials: 'include',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-  });
-  const docs = await response.json();
-  if (docs.success && docs.data) {
-    return docs.data;
-  } else {
-    return [];
-  }
-};
-
-export function BoardPreview(props: { board: Board; width: number; height: number; isSelected?: boolean }): JSX.Element {
-  const [appInfo, setAppInfo] = useState<{ position: Position; size: Size; type: AppName; id: string }[]>([]);
+export function BoardPreview(props: { board: Board; width: number; height: number; isSelected?: boolean; appInfo: AppInfo[] }): JSX.Element {
   const [boardWidth, setBoardWidth] = useState(0);
   const [boardHeight, setBoardHeight] = useState(0);
   const [appsX, setAppsX] = useState(0);
@@ -79,11 +36,11 @@ export function BoardPreview(props: { board: Board; width: number; height: numbe
     `linear-gradient(172deg, #2e2e2e, #313131, #292929)`
   );
 
-  const PADDING = 2; // Padding in pixels
+  // Recompute layout whenever the appInfo prop changes
+  useEffect(() => {
+    const apps = props.appInfo;
+    if (!apps || apps.length === 0) return;
 
-  async function updateMap() {
-    const apps = await getAppInfo(props.board._id);
-    if (!apps) return;
     const appsLeft = apps.map((app) => app.position.x);
     const appsRight = apps.map((app) => app.position.x + app.size.width);
     const appsTop = apps.map((app) => app.position.y);
@@ -91,29 +48,21 @@ export function BoardPreview(props: { board: Board; width: number; height: numbe
 
     const width = Math.max(...appsRight) - Math.min(...appsLeft);
     const height = Math.max(...appsBottom) - Math.min(...appsTop);
+    const scale = Math.min((props.width - 2 * PADDING) / width, (props.height - 2 * PADDING) / height) * 0.85;
 
-    const mapScale = Math.min((props.width - 2 * PADDING) / width, (props.height - 2 * PADDING) / height) * 0.85;
-    const x = Math.min(...appsLeft);
-    const y = Math.min(...appsTop);
+    setBoardWidth(width * scale);
+    setBoardHeight(height * scale);
+    setAppsX(Math.min(...appsLeft));
+    setAppsY(Math.min(...appsTop));
+    setMapScale(scale);
+  }, [props.appInfo, props.width, props.height]);
 
-    setBoardHeight(height * mapScale);
-    setBoardWidth(width * mapScale);
-    setAppsX(x);
-    setAppsY(y);
-    setMapScale(mapScale);
-    setAppInfo(apps);
-  }
-
+  // Redraw canvas when layout or colors change
   useEffect(() => {
-    updateMap();
-  }, [props.board._id]);
-
-  useEffect(() => {
-    if (canvasRef.current && appInfo.length > 0) {
+    if (canvasRef.current && props.appInfo.length > 0) {
       const canvas = canvasRef.current;
       const ctx = canvas.getContext('2d');
       if (ctx) {
-        // prevent blurry canvas with dpr
         const dpr = window.devicePixelRatio || 1;
         const canvasWidth = boardWidth + 2 * PADDING;
         const canvasHeight = boardHeight + 2 * PADDING;
@@ -128,18 +77,17 @@ export function BoardPreview(props: { board: Board; width: number; height: numbe
         ctx.strokeStyle = appBorderColor;
         ctx.lineWidth = 1;
 
-        appInfo.forEach((app) => {
+        props.appInfo.forEach((app) => {
           const x = (app.position.x - appsX) * mapScale + PADDING;
           const y = (app.position.y - appsY) * mapScale + PADDING;
           const width = app.size.width * mapScale;
           const height = app.size.height * mapScale;
-
           ctx.fillRect(x, y, width, height);
           ctx.strokeRect(x, y, width, height);
         });
       }
     }
-  }, [appInfo, boardColor, appBorderColor, mapScale, appsX, appsY, boardWidth, boardHeight]);
+  }, [props.appInfo, boardColor, appBorderColor, mapScale, appsX, appsY, boardWidth, boardHeight]);
 
   return (
     <Box
@@ -173,7 +121,7 @@ export function BoardPreview(props: { board: Board; width: number; height: numbe
             Private
           </Text>
         </>
-      ) : appInfo.length > 0 ? (
+      ) : props.appInfo.length > 0 ? (
         <canvas ref={canvasRef} style={{ width: `${boardWidth + 2 * PADDING}px`, height: `${boardHeight + 2 * PADDING}px` }} />
       ) : (
         <Text fontSize="xl" mb="2" color={boardColor} fontWeight="bold" css={{ textWrap: 'balance' }}>

--- a/webstack/libs/frontend/src/lib/config/urls.ts
+++ b/webstack/libs/frontend/src/lib/config/urls.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2023. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -12,9 +12,6 @@
 export const apiUrls = {
   config: {
     getConfig: '/api/configuration',
-  },
-  apps: {
-    preview: '/api/apps/preview',
   },
   assets: {
     getAssets: '/api/assets',
@@ -42,6 +39,7 @@ export const apiUrls = {
   boards: {
     getBoards: () => `/api/boards`,
     getBoard: (id: string) => `/api/boards/${id}`,
+    preview: '/api/boards/preview',
   },
   misc: {
     getTime: '/api/time',


### PR DESCRIPTION
  ## Problem                                                                                                                                                                                                          

On servers with many rooms and boards, the homepage was slow when switching between rooms. Every BoardCard mounted simultaneously and each fired its own POST /api/apps/preview request — resulting in N concurrent Redis queries hitting the server at once. 

The frontend cache helped slightly but didn't address the thundering herd at the source. 

Additionally, board previews on the home view (Recent/Starred/Active boards) appeared empty on first load because the fetch effect ran before the WebSocket board subscription had delivered data.                                                             
                                                                                                                                                                                                                   
  ## Changes
                                                                                                                                                                                                                   
  ### Backend (apps.ts, boards.ts)                                                                                                                                                                                     
  - Removed POST /api/apps/preview from the apps collection                                                                                                                                                        
  - Added POST /api/boards/preview — a batch endpoint that accepts an array of boardIds and returns app layout (position, size, type) for all of them in a single request, fetching uncached boards in parallel    
  - Added a 30-second server-side in-memory cache (Map<boardId, {apps, timestamp}>) to absorb burst traffic when multiple users load the homepage at the same time                                                 
  - The force=true flag bypasses the cache (used by the Refresh button)                                                                                                                                            
  - Cache entries are evicted immediately when a board is deleted, so stale layout is never served                                                                                                                 
                                                                                                                                                                                                                   
  ### Frontend (BoardPreview.tsx, BoardCard.tsx, Home.tsx, urls.ts)                                                                                                                                                    
  - BoardPreview no longer fetches or caches anything — it now accepts appInfo: AppInfo[] as a prop and renders a canvas minimap from it                                                                           
  - All preview fetching is centralized in Home.tsx via fetchPreviews(boardIds, force?), which merges results into a single boardPreviews: Map<string, AppInfo[]> state that persists across room switches         
  - A Refresh button in the board toolbar clears current previews and re-fetches with force=true                                                                                                                   
  - Added boards.length to the preview fetch useEffect deps — fixes home-view previews being empty on first load (boards arrive via subscription after mount)                                                      
  - Debounced both search inputs (150ms) so filtering doesn't run on every keystroke                                                                                                                               
  - Memoized the presence-by-board map — eliminates an O(boards × presences) filter on every render                                                                                                                
  - Memoized the filtered + sorted room board list     