### PR TITLE
  [Homepage] Resizable Sidebar, Input Length Limits & UI Polish   

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/UILayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/UILayer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2025. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -107,9 +107,8 @@ export function UILayer(props: UILayerProps) {
 
   // User
   const { user } = useUser();
-  const usersColor = user ? user.data.color : 'teal';
-  // const usersColorMode = useColorModeValue(`${usersColor}.500`, `${usersColor}.300`);
-  // const backgroundColor = useColorModeValue('#f2f2f299', '#32323299');
+  // Hardcoded to teal for visual consistency across all toolbar buttons
+  const usersColor = 'teal';
 
   // Scale
   const scale = useThrottleScale(250);

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Interactionbar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2024. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -144,10 +144,11 @@ export function Interactionbar(props: {
           <IconButton
             borderRadius={'0.5rem 0 0 0.5rem'}
             size="sm"
-            colorScheme={primaryActionMode === 'lasso' ? user?.data.color || 'teal' : 'gray'}
+            colorScheme={primaryActionMode === 'lasso' ? 'teal' : 'gray'}
+
             sx={{
               _dark: {
-                bg: primaryActionMode === 'lasso' ? `${user?.data.color}.200` : 'gray.600',
+                bg: primaryActionMode === 'lasso' ? 'teal.200' : 'gray.600',
               },
             }}
             icon={<LiaMousePointerSolid />}
@@ -165,10 +166,11 @@ export function Interactionbar(props: {
           <IconButton
             borderRadius={0}
             size="sm"
-            colorScheme={primaryActionMode === 'grab' ? user?.data.color || 'teal' : 'gray'}
+            colorScheme={primaryActionMode === 'grab' ? 'teal' : 'gray'}
+
             sx={{
               _dark: {
-                bg: primaryActionMode === 'grab' ? `${user?.data.color}.200` : 'gray.600', // 'inherit' didnt seem to work
+                bg: primaryActionMode === 'grab' ? 'teal.200' : 'gray.600', // 'inherit' didnt seem to work
               },
             }}
             icon={<LiaHandPaperSolid />}
@@ -190,10 +192,11 @@ export function Interactionbar(props: {
               <IconButton
                  borderRadius={'0 0.5rem 0.5rem 0'}
                 size="sm"
-                colorScheme={(primaryActionMode === 'pen' || primaryActionMode === 'eraser' || primaryActionMode === 'rectangle' || primaryActionMode === 'circle' || primaryActionMode === 'arrow' || primaryActionMode === 'doubleArrow') ? user?.data.color || 'teal' : 'gray'}
+                colorScheme={(primaryActionMode === 'pen' || primaryActionMode === 'eraser' || primaryActionMode === 'rectangle' || primaryActionMode === 'circle' || primaryActionMode === 'arrow' || primaryActionMode === 'doubleArrow') ? 'teal' : 'gray'}
+
                 sx={{
                   _dark: {
-                    bg: (primaryActionMode === 'pen' || primaryActionMode === 'eraser' || primaryActionMode === 'rectangle' || primaryActionMode === 'circle' || primaryActionMode === 'arrow' || primaryActionMode === 'doubleArrow') ? `${user?.data.color}.200` : 'gray.600',
+                    bg: (primaryActionMode === 'pen' || primaryActionMode === 'eraser' || primaryActionMode === 'rectangle' || primaryActionMode === 'circle' || primaryActionMode === 'arrow' || primaryActionMode === 'doubleArrow') ? 'teal.200' : 'gray.600',
                   },
                 }}
                 icon={<BiPencil />}
@@ -224,7 +227,8 @@ export function Interactionbar(props: {
                   <ButtonGroup size="sm" isAttached>
                     <Tooltip placement="top" hasArrow label="Marker">
                       <Button
-                        colorScheme={primaryActionMode === 'pen' ? user?.data.color || 'teal' : 'gray'}
+                        colorScheme={primaryActionMode === 'pen' ? 'teal' : 'gray'}
+
                         variant={primaryActionMode === 'pen' ? 'solid' : 'outline'}
                         onClick={() => handleModeChange('pen')}
                         px="3"
@@ -234,7 +238,8 @@ export function Interactionbar(props: {
                     </Tooltip>
                     <Tooltip placement="top" hasArrow label="Rectangle">
                       <Button
-                        colorScheme={primaryActionMode === 'rectangle' ? user?.data.color || 'teal' : 'gray'}
+                        colorScheme={primaryActionMode === 'rectangle' ? 'teal' : 'gray'}
+
                         variant={primaryActionMode === 'rectangle' ? 'solid' : 'outline'}
                         onClick={() => handleModeChange('rectangle')}       // NEED TO CHANGE THIS TO ALLOW SHAPE TO BE A VALID MODE
                         px="3"
@@ -244,7 +249,8 @@ export function Interactionbar(props: {
                     </Tooltip>
                     <Tooltip placement="top" hasArrow label="Circle">
                       <Button
-                        colorScheme={primaryActionMode === 'circle' ? user?.data.color || 'teal' : 'gray'}
+                        colorScheme={primaryActionMode === 'circle' ? 'teal' : 'gray'}
+
                         variant={primaryActionMode === 'circle' ? 'solid' : 'outline'}
                         onClick={() => handleModeChange('circle')}
                         px="3"
@@ -254,7 +260,8 @@ export function Interactionbar(props: {
                     </Tooltip>
                     <Tooltip placement="top" hasArrow label="Arrow">
                       <Button
-                        colorScheme={primaryActionMode === 'arrow' ? user?.data.color || 'teal' : 'gray'}
+                        colorScheme={primaryActionMode === 'arrow' ? 'teal' : 'gray'}
+
                         variant={primaryActionMode === 'arrow' ? 'solid' : 'outline'}
                         onClick={() => handleModeChange('arrow')}
                         px="3"
@@ -264,7 +271,8 @@ export function Interactionbar(props: {
                     </Tooltip>
                     <Tooltip placement="top" hasArrow label="Double Arrow">
                       <Button
-                        colorScheme={primaryActionMode === 'doubleArrow' ? user?.data.color || 'teal' : 'gray'}
+                        colorScheme={primaryActionMode === 'doubleArrow' ? 'teal' : 'gray'}
+
                         variant={primaryActionMode === 'doubleArrow' ? 'solid' : 'outline'}
                         onClick={() => handleModeChange('doubleArrow')}
                         px="3"
@@ -274,7 +282,8 @@ export function Interactionbar(props: {
                     </Tooltip>
                     <Tooltip placement="top" hasArrow label="Eraser">
                       <Button
-                        colorScheme={primaryActionMode === 'eraser' ? user?.data.color || 'teal' : 'gray'}
+                        colorScheme={primaryActionMode === 'eraser' ? 'teal' : 'gray'}
+
                         variant={primaryActionMode === 'eraser' ? 'solid' : 'outline'}
                         onClick={() => handleModeChange('eraser')}
                         px="3"

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Menus/BoardContextMenu.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Menus/BoardContextMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -14,7 +14,7 @@ import { IoSparklesSharp } from 'react-icons/io5';
 import { MdApps, MdArrowBack, MdFolder, MdMap, MdPeople, MdScreenShare } from 'react-icons/md';
 
 import { SAGEColors } from '@sage3/shared';
-import { useUser, useUIStore } from '@sage3/frontend';
+import { useUIStore } from '@sage3/frontend';
 
 import { ContextButton } from './ContextButton';
 import { ScreenshareMenu } from './Menus/ScreenshareMenu';
@@ -32,9 +32,6 @@ type BoardContextProps = {
 };
 
 export function BoardContextMenu(props: BoardContextProps) {
-  // User information
-  const { user } = useUser();
-  const userColor = user ? user.data.color : 'teal';
 
   const contextMenuPosition = useUIStore((state) => state.contextMenuPosition);
   const setContextMenuPosition = useUIStore((state) => state.setContextMenuPosition);
@@ -82,25 +79,25 @@ export function BoardContextMenu(props: BoardContextProps) {
       <Box position="absolute" bottom="-60px" left="-125px" width="250px" height="118px">
         <Flex flexDir={'column'} justifyContent={'center'} alignItems={'center'} gap="3">
           <Flex gap="1" justifyContent={'center'}>
-            <ContextButton bgColor={userColor as SAGEColors} icon={<MdPeople />} tooltip={'Users'} title={'Users'}>
+            <ContextButton bgColor={'teal' as SAGEColors} icon={<MdPeople />} tooltip={'Users'} title={'Users'}>
               <UsersMenu boardId={props.boardId} />
             </ContextButton>
-            <ContextButton bgColor={userColor as SAGEColors} icon={<MdScreenShare />} tooltip={'Screenshares'} title={'Screenshares'}>
+            <ContextButton bgColor={'teal' as SAGEColors} icon={<MdScreenShare />} tooltip={'Screenshares'} title={'Screenshares'}>
               <ScreenshareMenu boardId={props.boardId} roomId={props.roomId} />{' '}
             </ContextButton>
-            <ContextButton bgColor={userColor as SAGEColors} icon={<MdApps />} tooltip={'Applications'} title={'Applications'}>
+            <ContextButton bgColor={'teal' as SAGEColors} icon={<MdApps />} tooltip={'Applications'} title={'Applications'}>
               <ApplicationsMenu roomId={props.roomId} boardId={props.boardId} />
             </ContextButton>
-            <ContextButton bgColor={userColor as SAGEColors} icon={<HiPuzzle />} tooltip={'Plugins'} title={'Plugins'}>
+            <ContextButton bgColor={'teal' as SAGEColors} icon={<HiPuzzle />} tooltip={'Plugins'} title={'Plugins'}>
               <PluginsMenu roomId={props.roomId} boardId={props.boardId} />
             </ContextButton>
-            <ContextButton bgColor={userColor as SAGEColors} icon={<MdFolder />} tooltip={'Assets'} title={'Assets'}>
+            <ContextButton bgColor={'teal' as SAGEColors} icon={<MdFolder />} tooltip={'Assets'} title={'Assets'}>
               <AssetsMenu roomId={props.roomId} boardId={props.boardId} downloadRoomAssets={props.downloadRoomAssets} />{' '}
             </ContextButton>
-            <ContextButton bgColor={userColor as SAGEColors} icon={<HiChip />} tooltip={'Kernels'} title={'Kernels'}>
+            <ContextButton bgColor={'teal' as SAGEColors} icon={<HiChip />} tooltip={'Kernels'} title={'Kernels'}>
               <KernelsMenu roomId={props.roomId} boardId={props.boardId} />
             </ContextButton>
-            <ContextButton bgColor={userColor as SAGEColors} icon={<MdMap />} tooltip={'Map'} title={'Map'}>
+            <ContextButton bgColor={'teal' as SAGEColors} icon={<MdMap />} tooltip={'Map'} title={'Map'}>
               <NavigationMenu />
             </ContextButton>
           </Flex>

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Menus/Menus/NavigationMenu.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Menus/Menus/NavigationMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -155,7 +155,7 @@ export function NavigationMenu() {
           )}
         </Box>
       </Box>
-      <Button size="xs" colorScheme={user?.data.color} width="100% " variant="outline" onClick={fitAllApps}>
+      <Button size="xs" colorScheme="teal" width="100% " variant="outline" onClick={fitAllApps}>
         Show All Applications
       </Button>
     </Box>

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Menus/ToolbarButton.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Menus/ToolbarButton.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2024. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in

--- a/webstack/apps/webapp/src/app/pages/home/Home.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/Home.tsx
@@ -156,6 +156,17 @@ export function HomePage() {
   // Selected board ref — used to scroll the card into view
   const scrollToBoardRef = useRef<null | HTMLDivElement>(null);
 
+  // Sidebar width — user-resizable via drag handle, persisted in localStorage
+  const SIDEBAR_MIN = 180;
+  // 600px gives enough room to display a full 50-character room name at the default font size.
+  // (50 chars × ~8.5px avg width) + ~158px of nested padding/labels ≈ 583px needed.
+  const SIDEBAR_MAX = 600;
+  const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
+    const stored = localStorage.getItem('sage3-sidebar-width');
+    return stored ? Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, parseInt(stored, 10))) : 240;
+  });
+  const sidebarDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
   // Toast to inform user that they are not a member of a room
   const toast = useToast();
 
@@ -178,6 +189,10 @@ export function HomePage() {
   const homeSectionColor = useHexColor(homeSectionValue);
   const searchBarColorValue = useColorModeValue('gray.100', '#2c2c2c');
   const searchBarColor = useHexColor(searchBarColorValue);
+  const dividerLineValue = useColorModeValue('gray.300', 'gray.600');
+  const dividerLineColor = useHexColor(dividerLineValue);
+  const dividerLineHoverValue = useColorModeValue('gray.500', 'gray.400');
+  const dividerLineHoverColor = useHexColor(dividerLineHoverValue);
   const searchPlaceholderColorValue = useColorModeValue('gray.400', 'gray.100');
   const searchPlaceholderColor = useHexColor(searchPlaceholderColorValue);
   const searchBgColorValue = useColorModeValue('gray.50', 'gray.800');
@@ -793,10 +808,11 @@ export function HomePage() {
       {/* Sidebar Drawer */}
       <Box
         borderRadius={cardRadius}
-        width="20%"
-        minWidth="220px"
-        maxWidth="400px"
-        transition="width 0.5s"
+        width={`${sidebarWidth}px`}
+        minWidth={`${SIDEBAR_MIN}px`}
+        maxWidth={`${SIDEBAR_MAX}px`}
+        flexShrink={0}
+        mr="1.5"
         height="100%"
         display="flex"
         flexDirection="column"
@@ -827,7 +843,7 @@ export function HomePage() {
                   </Box>
                 </Box>
               </MenuButton>
-              <MenuList width="20%" minWidth="220px" maxWidth="400px">
+              <MenuList width={`${sidebarWidth}px`}>
                 {hubs.map((hub) => {
                   return (
                     <MenuItem
@@ -941,8 +957,8 @@ export function HomePage() {
                           key={'tooltip_room' + room._id}
                           openDelay={400}
                           hasArrow
-                          placement="top"
-                          label={room.data.description ? room.data.description : ""}
+                          placement="right"
+                          label={room.data.description ? `${room.data.name} — ${room.data.description}` : room.data.name}
                           closeOnScroll
                         >
                           <Box
@@ -986,6 +1002,39 @@ export function HomePage() {
         </Box>
       </Box>
 
+      {/* Drag handle — grab to resize the sidebar */}
+      <Box
+        width="16px"
+        height="100%"
+        flexShrink={0}
+        cursor="col-resize"
+        role="group"
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        onPointerDown={(e) => {
+          e.preventDefault();
+          (e.target as HTMLElement).setPointerCapture(e.pointerId);
+          sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
+        }}
+        onPointerMove={(e) => {
+          if (!sidebarDragRef.current) return;
+          const delta = e.clientX - sidebarDragRef.current.startX;
+          const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
+          setSidebarWidth(next);
+        }}
+        onPointerUp={(e) => {
+          if (!sidebarDragRef.current) return;
+          (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+          const delta = e.clientX - sidebarDragRef.current.startX;
+          const final = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
+          localStorage.setItem('sage3-sidebar-width', String(final));
+          sidebarDragRef.current = null;
+        }}
+      >
+        <Box flex="1" width="2px" bg={dividerLineColor} _groupHover={{ bg: dividerLineHoverColor }} transition="background 0.15s" />
+      </Box>
+
       {/* Selected Room */}
       {selectedRoom && rooms.length > 0 && (
         <Box
@@ -996,7 +1045,7 @@ export function HomePage() {
           maxHeight="100svh"
           height="100%"
           borderRadius={cardRadius}
-          marginLeft="3"
+          marginLeft="1.5"
           p={[1, 4, 4, 6]} // top right bottom left
         >
           <Box width="100%" position="relative">
@@ -1266,7 +1315,7 @@ export function HomePage() {
           maxHeight="100svh"
           height="100%"
           borderRadius={cardRadius}
-          marginLeft="3"
+          marginLeft="1.5"
           width="100%"
           overflow="hidden"
           py="2"

--- a/webstack/apps/webapp/src/app/pages/home/Home.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/Home.tsx
@@ -25,22 +25,22 @@ import {
   TabPanels,
   Tabs,
   Tooltip,
+  Button,
   Menu,
   MenuButton,
   MenuItem,
   MenuList,
+  IconButton,
   Input,
   InputGroup,
   InputLeftElement,
-  Flex,
-  IconButton,
   HStack,
   Divider,
   useOutsideClick,
 } from '@chakra-ui/react';
 
 // Icons
-import { MdAdd, MdHome, MdSearch, MdGridView, MdList, MdPeople, MdFolder, MdDashboard, MdSettings, MdExitToApp, MdMenu, MdRefresh } from 'react-icons/md';
+import { MdAdd, MdHome, MdSearch, MdPeople, MdFolder, MdDashboard, MdSettings, MdExitToApp, MdMenu } from 'react-icons/md';
 import { HiPuzzle } from 'react-icons/hi';
 import { LuChevronsUpDown } from 'react-icons/lu';
 
@@ -63,11 +63,9 @@ import {
   EnterBoardByURLModal,
   EditRoomModal,
   EditBoardModal,
-  EnterBoardModal,
   ConfirmModal,
   Clock,
   isElectron,
-  useUserSettings,
   isUUIDv4,
   MainButton,
   PartyButton,
@@ -77,7 +75,7 @@ import {
 import { AppInfo } from './components/BoardPreview';
 
 // Home Page Components
-import { BoardRow, BoardCard, RoomSearchModal, PasswordJoinRoomModal, AssetList, PluginsList, MembersList } from './components';
+import { BoardCard, RoomSearchModal, PasswordJoinRoomModal, AssetList, PluginsList, MembersList, BoardListPanel } from './components';
 import SearchRow from './components/search/SearchRow';
 
 /**
@@ -129,17 +127,9 @@ export function HomePage() {
   const subscribeToPresence = usePresenceStore((state) => state.subscribe);
 
   // Settings
-  const { setBoardListView, settings } = useUserSettings();
-  const boardListView = settings.selectedBoardListView ? settings.selectedBoardListView : 'grid';
-
   // User Selected Room, Board, and User
   const [selectedRoom, setSelectedRoom] = useState<Room | undefined>(undefined);
   const [selectedBoard, setSelectedBoard] = useState<Board | undefined>(undefined);
-
-  // boardSearch: debounced value used for filtering; boardSearchInput: live input display value
-  const [boardSearch, setBoardSearch] = useState<string>('');
-  const [boardSearchInput, setBoardSearchInput] = useState<string>('');
-  const boardSearchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [passwordProtectedRoom, setPasswordProtectedRoom] = useState<Room | undefined>(undefined);
 
@@ -154,7 +144,7 @@ export function HomePage() {
   const [isSearchSageFocused, setSearchSageFocused] = useState<boolean>(false);
 
   // Selected board ref — used to scroll the card into view
-  const scrollToBoardRef = useRef<null | HTMLDivElement>(null);
+  const scrollToBoardRef = useRef<HTMLDivElement>(null);
 
   // Sidebar width — user-resizable via drag handle, persisted in localStorage
   const SIDEBAR_MIN = 180;
@@ -171,10 +161,6 @@ export function HomePage() {
   const toast = useToast();
 
   // Colors
-  const tealValue = useColorModeValue('teal.400', 'teal.500');
-  const teal = useHexColor(tealValue);
-  const hoverTealValue = useColorModeValue('teal.500', 'teal.600');
-  const hoverTeal = useHexColor(hoverTealValue);
   const scrollBarValue = useColorModeValue('gray.300', '#666666');
   const scrollBarColor = useHexColor(scrollBarValue);
   const sidebarBackgroundValue = useColorModeValue('gray.50', '#303030');
@@ -189,10 +175,10 @@ export function HomePage() {
   const homeSectionColor = useHexColor(homeSectionValue);
   const searchBarColorValue = useColorModeValue('gray.100', '#2c2c2c');
   const searchBarColor = useHexColor(searchBarColorValue);
-  const dividerLineValue = useColorModeValue('gray.300', 'gray.600');
-  const dividerLineColor = useHexColor(dividerLineValue);
-  const dividerLineHoverValue = useColorModeValue('gray.500', 'gray.400');
-  const dividerLineHoverColor = useHexColor(dividerLineHoverValue);
+  const dividerTabValue = useColorModeValue('gray.300', 'gray.600');
+  const dividerTabColor = useHexColor(dividerTabValue);
+  const dividerTabHoverValue = useColorModeValue('gray.500', 'gray.400');
+  const dividerTabHoverColor = useHexColor(dividerTabHoverValue);
   const searchPlaceholderColorValue = useColorModeValue('gray.400', 'gray.100');
   const searchPlaceholderColor = useHexColor(searchPlaceholderColorValue);
   const searchBgColorValue = useColorModeValue('gray.50', 'gray.800');
@@ -208,14 +194,9 @@ export function HomePage() {
   const { isOpen: enterBoardByURLModalIsOpen, onOpen: enterBoardByURLModalOnOpen, onClose: enterBoardByURLModalOnClose } = useDisclosure();
   const { isOpen: editRoomModalIsOpen, onOpen: editRoomModalOnOpen, onClose: editRoomModalOnClose } = useDisclosure();
   const { isOpen: editBoardModalIsOpen, onOpen: editBoardModalOnOpen, onClose: editBoardModalOnClose } = useDisclosure();
-  const { isOpen: enterBoardModalIsOpen, onOpen: enterBoardModalOnOpen, onClose: enterBoardModalOnClose } = useDisclosure();
   const { isOpen: roomSearchModal, onOpen: roomSearchModalOnOpen, onClose: roomSearchModalOnClose } = useDisclosure();
   const { isOpen: leaveRoomModalIsOpen, onOpen: leaveRoomModalOnOpen, onClose: leaveRoomModalOnClose } = useDisclosure();
-  const {
-    isOpen: clearRecentBoardsModalIsOpen,
-    onOpen: clearRecentBoardsModalOnOpen,
-    onClose: clearRecentBoardsModalOnClose,
-  } = useDisclosure();
+  const { isOpen: clearRecentBoardsModalIsOpen, onClose: clearRecentBoardsModalOnClose } = useDisclosure();
   const {
     isOpen: passwordJoinRoomModalIsOpen,
     onOpen: passwordJoinRoomModalOnOpen,
@@ -236,7 +217,6 @@ export function HomePage() {
   const createRoomRef = useRef<HTMLButtonElement>(null);
   const searchSageRef = useRef<null | HTMLDivElement>(null);
   const searchInputRef = useRef<null | HTMLDivElement>(null);
-  const enterBoardByURLRef = useRef<HTMLDivElement>(null);
   const roomsRef = useRef<HTMLDivElement>(null);
   const activeBoardsRef = useRef<HTMLParagraphElement>(null);
   const starredBoardsRef = useRef<HTMLParagraphElement>(null);
@@ -291,20 +271,6 @@ export function HomePage() {
     const isMember = roomMembership && roomMembership.data.members ? roomMembership.data.members.includes(userId) : false;
     return isRecent && isMember;
   };
-
-  const boardSearchFilter = (board: Board) => {
-    return fuzzySearch(board.data.name + ' ' + board.data.description, boardSearch);
-  };
-
-  // Filtered + sorted board list for the selected room — avoids recomputing on every render
-  const filteredRoomBoards = useMemo(
-    () =>
-      boards
-        .filter((b) => b.data.roomId === selectedRoom?._id)
-        .filter(boardSearchFilter)
-        .sort((a, b) => a.data.name.localeCompare(b.data.name)),
-    [boards, selectedRoom?._id, boardSearch]
-  );
 
   // Presence grouped by boardId — avoids O(boards × presences) filter on every render
   const presenceByBoard = useMemo(() => {
@@ -467,11 +433,12 @@ export function HomePage() {
       const roomId = selectedRoom ? selectedRoom._id : '';
       updatePresence(userId, { roomId });
     }
-    setBoardSearch('');
-    setBoardSearchInput('');
   }, [selectedRoom]);
 
-  // Fetch board previews when the selected room changes (or on home view)
+  // Fetch board previews when the selected room changes (or on home view).
+  // recentBoards.length and savedBoards.length are included in deps to handle the race condition
+  // where user data (recentBoards/savedBoards) arrives after boards are already loaded — without
+  // them the effect would run with empty filter results and never re-trigger.
   useEffect(() => {
     if (selectedRoom) {
       // Only fetch boardIds not already in state
@@ -489,7 +456,7 @@ export function HomePage() {
       ].map((b) => b._id))].filter((id) => !boardPreviews.has(id));
       fetchPreviews(ids);
     }
-  }, [selectedRoom?._id, boards.length]);
+  }, [selectedRoom?._id, boards.length, recentBoards.length, savedBoards.length]);
 
   // Scroll selected board into view
   useEffect(() => {
@@ -541,30 +508,6 @@ export function HomePage() {
       leaveRoomMembership(selectedRoom._id);
       handleLeaveRoom();
       leaveRoomModalOnClose();
-    }
-  };
-
-  // Handle Join room membership
-  const handleJoinRoomMembership = (room: Room) => {
-    if (canJoin) {
-      if (room.data.isPrivate) {
-        setPasswordProtectedRoom(room);
-      } else {
-        joinRoomMembership(room._id);
-        toast({
-          title: `You have successfully joined ${room.data.name}`,
-          status: 'success',
-          duration: 4 * 1000,
-          isClosable: true,
-        });
-      }
-    } else {
-      toast({
-        title: 'You do not have permission to join rooms',
-        status: 'error',
-        duration: 2 * 1000,
-        isClosable: true,
-      });
     }
   };
 
@@ -763,9 +706,6 @@ export function HomePage() {
         ></EditBoardModal>
       )}
 
-      {/* Enter board modal */}
-      {selectedBoard && <EnterBoardModal board={selectedBoard} isOpen={enterBoardModalIsOpen} onClose={enterBoardModalOnClose} />}
-
       {/* Room Search Modal */}
       <RoomSearchModal isOpen={roomSearchModal} onClose={roomSearchModalOnClose} users={users} />
 
@@ -822,23 +762,19 @@ export function HomePage() {
           <Box ref={hubNameRef}>
             <Menu placement="bottom-start">
               <MenuButton
-                marginTop="auto"
-                display="flex"
-                as={Box}
-                backgroundColor={teal}
-                height="32px"
-                alignItems={'center'}
-                justifyContent={'left'}
-                borderRadius="10"
+                as={Button}
+                colorScheme="teal"
+                variant="solid"
+                size="sm"
                 width="100%"
-                transition={'all 0.5s'}
-                _hover={{ cursor: 'pointer', backgroundColor: hoverTeal }}
+                borderRadius="10"
+                px={4}
               >
-                <Box display="flex" justifyContent={'space-between'} alignItems={'center'}>
-                  <Text ml="2" fontSize="lg" fontWeight="bold" whiteSpace={'nowrap'} textOverflow={'ellipsis'} overflow="hidden">
+                <Box display="flex" justifyContent="space-between" alignItems="center" width="100%">
+                  <Text fontWeight="bold" whiteSpace="nowrap" textOverflow="ellipsis" overflow="hidden">
                     {config.serverName}
                   </Text>
-                  <Box pr="3" fontSize="lg">
+                  <Box fontSize="lg" flexShrink={0} ml={2}>
                     <LuChevronsUpDown />
                   </Box>
                 </Box>
@@ -860,11 +796,19 @@ export function HomePage() {
             </Menu>
           </Box>
         ) : (
-          <Box bg={teal} borderRadius="10" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis" ref={hubNameRef} height="40px">
-            <Text fontSize="24px" fontWeight="bold" whiteSpace={'nowrap'} textOverflow={'ellipsis'} overflow="hidden" pl="2">
+          <Button
+            colorScheme="teal"
+            variant="solid"
+            size="sm"
+            width="100%"
+            borderRadius="10"
+            px={4}
+            pointerEvents="none"
+          >
+            <Text fontWeight="bold" whiteSpace="nowrap" textOverflow="ellipsis" overflow="hidden" width="100%" textAlign="left">
               {config.serverName}
             </Text>
-          </Box>
+          </Button>
         )}
 
         {/* Rooms  section */}
@@ -1003,36 +947,35 @@ export function HomePage() {
       </Box>
 
       {/* Drag handle — grab to resize the sidebar */}
-      <Box
-        width="16px"
-        height="100%"
-        flexShrink={0}
-        cursor="col-resize"
-        role="group"
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        onPointerDown={(e) => {
-          e.preventDefault();
-          (e.target as HTMLElement).setPointerCapture(e.pointerId);
-          sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
-        }}
-        onPointerMove={(e) => {
-          if (!sidebarDragRef.current) return;
-          const delta = e.clientX - sidebarDragRef.current.startX;
-          const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
-          setSidebarWidth(next);
-        }}
-        onPointerUp={(e) => {
-          if (!sidebarDragRef.current) return;
-          (e.target as HTMLElement).releasePointerCapture(e.pointerId);
-          const delta = e.clientX - sidebarDragRef.current.startX;
-          const final = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
-          localStorage.setItem('sage3-sidebar-width', String(final));
-          sidebarDragRef.current = null;
-        }}
-      >
-        <Box flex="1" width="2px" bg={dividerLineColor} _groupHover={{ bg: dividerLineHoverColor }} transition="background 0.15s" />
+      <Box width="10px" height="100%" flexShrink={0} display="flex" alignItems="center" justifyContent="center">
+        <Box
+          width="6px"
+          height="150px"
+          borderRadius="full"
+          bg={dividerTabColor}
+          cursor="col-resize"
+          _hover={{ bg: dividerTabHoverColor }}
+          transition="background 0.15s"
+          onPointerDown={(e) => {
+            e.preventDefault();
+            (e.target as HTMLElement).setPointerCapture(e.pointerId);
+            sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
+          }}
+          onPointerMove={(e) => {
+            if (!sidebarDragRef.current) return;
+            const delta = e.clientX - sidebarDragRef.current.startX;
+            const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
+            setSidebarWidth(next);
+          }}
+          onPointerUp={(e) => {
+            if (!sidebarDragRef.current) return;
+            (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+            const delta = e.clientX - sidebarDragRef.current.startX;
+            const final = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
+            localStorage.setItem('sage3-sidebar-width', String(final));
+            sidebarDragRef.current = null;
+          }}
+        />
       </Box>
 
       {/* Selected Room */}
@@ -1140,147 +1083,21 @@ export function HomePage() {
 
                 <TabPanels height="100%">
                   <TabPanel px="0">
-                    <Box display="flex" gap="4">
-                      <Flex gap="2" flexDirection="column">
-                        <Flex align="center" gap="2" justify="flex-start" ml="2">
-                          <Tooltip label="Create New Board" aria-label="Create Board" placement="top" hasArrow>
-                            <IconButton
-                              size="sm"
-                              bg="none"
-                              aria-label="favorite-board"
-                              fontSize="xl"
-                              onFocus={(e) => e.preventDefault()}
-                              onClick={createBoardModalOnOpen}
-                              isDisabled={!canCreateBoards}
-                              _hover={{ transform: 'scale(1.1)', bg: 'none' }}
-                              icon={<MdAdd fontSize="24px" />}
-                            ></IconButton>
-                          </Tooltip>
-
-
-                          <InputGroup size="md" width="425px" my="1">
-                            <InputLeftElement pointerEvents="none">
-                              <MdSearch />
-                            </InputLeftElement>
-                            <Input
-                              placeholder="Search Boards"
-                              _placeholder={{ opacity: 0.7, color: searchPlaceholderColor }}
-                              value={boardSearchInput}
-                              onChange={(e) => {
-                                const value = e.target.value;
-                                setBoardSearchInput(value);
-                                if (boardSearchDebounceRef.current) clearTimeout(boardSearchDebounceRef.current);
-                                boardSearchDebounceRef.current = setTimeout(() => setBoardSearch(value), 150);
-                              }}
-                              roundedTop="2xl"
-                              _focusVisible={{ bg: searchBarColor, outline: 'none', transition: 'none' }}
-                              bg="inherit"
-                              roundedBottom="2xl"
-                            />
-                          </InputGroup>
-                          <Tooltip label={boardListView === 'grid' ? 'Switch to List View' : 'Switch to Grid View'} placement="top" hasArrow>
-                            <IconButton
-                              size="sm"
-                              bg="none"
-                              aria-label={boardListView === 'grid' ? 'Switch to List View' : 'Switch to Grid View'}
-                              onClick={() => {
-                                setBoardListView(boardListView === 'grid' ? 'list' : 'grid');
-                              }}
-                              icon={boardListView === 'grid' ? <MdList fontSize="24px" /> : <MdGridView fontSize="24px" />}
-                              _hover={{ transform: 'scale(1.1)', bg: 'none' }}
-                            />
-                          </Tooltip>
-                          <Tooltip label="Refresh Board Previews" placement="top" hasArrow>
-                            <IconButton
-                              size="sm"
-                              bg="none"
-                              aria-label="Refresh board previews"
-                              isLoading={previewsLoading}
-                              onClick={refreshPreviews}
-                              icon={<MdRefresh fontSize="24px" />}
-                              _hover={{ transform: 'scale(1.1)', bg: 'none' }}
-                            />
-                          </Tooltip>
-                        </Flex>
-                        {boardListView == 'grid' && (
-                          <Flex
-                            gap="4"
-                            pl="2"
-                            py="1"
-                            display="flex"
-                            flexWrap="wrap"
-                            justifyContent="left"
-                            style={{
-                              maxHeight: 'calc(100svh - 270px)',
-                              width: '100%',
-                              maxWidth: '2200px',
-                            }}
-                            margin="0 auto"
-                            overflowY="scroll"
-                            overflowX="hidden"
-                            minWidth="420px"
-                            css={{
-                              '&::-webkit-scrollbar': {
-                                background: 'transparent',
-                                width: '10px',
-                              },
-                              '&::-webkit-scrollbar-thumb': {
-                                background: scrollBarColor,
-                                borderRadius: '48px',
-                              },
-                            }}
-                          >
-                            {filteredRoomBoards.map((board) => (
-                                <Box key={board._id} ref={board._id === selectedBoard?._id ? scrollToBoardRef : undefined}>
-                                  <BoardCard
-                                    board={board}
-                                    room={selectedRoom}
-                                    onClick={() => handleBoardClick(board)}
-                                    selected={selectedBoard ? selectedBoard._id === board._id : false}
-                                    usersPresent={presenceByBoard.get(board._id) ?? []}
-                                    appInfo={boardPreviews.get(board._id) ?? []}
-                                  />
-                                </Box>
-                              ))}
-                          </Flex>
-                        )}
-
-                        {boardListView == 'list' && (
-                          <VStack
-                            gap="3"
-                            alignItems="left"
-                            pl="2"
-                            style={{ height: 'calc(100svh - 270px)' }}
-                            overflowY="scroll"
-                            overflowX="hidden"
-                            minWidth="420px"
-                            css={{
-                              '&::-webkit-scrollbar': {
-                                background: 'transparent',
-                                width: '5px',
-                              },
-                              '&::-webkit-scrollbar-thumb': {
-                                background: scrollBarColor,
-                                borderRadius: '48px',
-                              },
-                            }}
-                          >
-                            {filteredRoomBoards.map((board) => (
-                                <Box key={board._id} ref={board._id === selectedBoard?._id ? scrollToBoardRef : undefined}>
-                                  <BoardRow
-                                    key={board._id}
-                                    board={board}
-                                    room={selectedRoom}
-                                    onClick={() => handleBoardClick(board)}
-                                    selected={selectedBoard ? selectedBoard._id === board._id : false}
-                                    usersPresent={(presenceByBoard.get(board._id) ?? []).length}
-                                  />
-                                </Box>
-                              ))}
-                          </VStack>
-                        )}
-                      </Flex>
-                    </Box>
+                    {/* key={selectedRoom?._id} remounts the panel on room change, resetting search state */}
+                    <BoardListPanel
+                      key={selectedRoom?._id}
+                      boards={boards}
+                      selectedRoom={selectedRoom}
+                      selectedBoard={selectedBoard}
+                      presenceByBoard={presenceByBoard}
+                      boardPreviews={boardPreviews}
+                      previewsLoading={previewsLoading}
+                      canCreateBoards={canCreateBoards}
+                      scrollToBoardRef={scrollToBoardRef}
+                      onCreateBoard={createBoardModalOnOpen}
+                      onRefreshPreviews={refreshPreviews}
+                      onBoardClick={handleBoardClick}
+                    />
                   </TabPanel>
                   <TabPanel px="0">
                     <MembersList room={selectedRoom} />

--- a/webstack/apps/webapp/src/app/pages/home/components/BoardListPanel.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/components/BoardListPanel.tsx
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+/**
+ * BoardListPanel — owns board search and list-view toggle state.
+ * Keeping these states here means typing in the search box only re-renders
+ * this subtree, not the entire Home page.
+ *
+ * Mount with key={selectedRoom?._id} so that search resets automatically
+ * whenever the user switches rooms (React unmounts/remounts on key change).
+ */
+
+import { useMemo, useRef, useState } from 'react';
+import {
+  Box,
+  Flex,
+  IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Tooltip,
+  VStack,
+  useColorModeValue,
+} from '@chakra-ui/react';
+
+import { MdAdd, MdGridView, MdList, MdRefresh, MdSearch } from 'react-icons/md';
+
+import { Board, PresencePartial, Room } from '@sage3/shared/types';
+import { fuzzySearch } from '@sage3/shared';
+import { useHexColor, useUserSettings } from '@sage3/frontend';
+
+import { BoardCard } from './BoardCard';
+import { BoardRow } from './BoardRow';
+import { AppInfo } from './BoardPreview';
+
+type BoardListPanelProps = {
+  boards: Board[];
+  selectedRoom: Room | undefined;
+  selectedBoard: Board | undefined;
+  presenceByBoard: Map<string, PresencePartial[]>;
+  boardPreviews: Map<string, AppInfo[]>;
+  previewsLoading: boolean;
+  canCreateBoards: boolean;
+  scrollToBoardRef: React.RefObject<HTMLDivElement>;
+  onCreateBoard: () => void;
+  onRefreshPreviews: () => void;
+  onBoardClick: (board: Board) => void;
+};
+
+export function BoardListPanel(props: BoardListPanelProps) {
+  const { setBoardListView, settings } = useUserSettings();
+  const boardListView = settings.selectedBoardListView ?? 'grid';
+
+  // Debounced search — uncontrolled input so typing never re-renders this component
+  const [boardSearch, setBoardSearch] = useState('');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Color tokens
+  const scrollBarValue = useColorModeValue('gray.300', 'gray.600');
+  const scrollBarColor = useHexColor(scrollBarValue);
+  const searchBarColorValue = useColorModeValue('gray.100', '#2c2c2c');
+  const searchBarColor = useHexColor(searchBarColorValue);
+  const searchPlaceholderColorValue = useColorModeValue('gray.400', 'gray.100');
+  const searchPlaceholderColor = useHexColor(searchPlaceholderColorValue);
+
+  const filteredBoards = useMemo(
+    () =>
+      props.boards
+        .filter((b) => b.data.roomId === props.selectedRoom?._id)
+        .filter((b) => fuzzySearch(b.data.name + ' ' + b.data.description, boardSearch))
+        .sort((a, b) => a.data.name.localeCompare(b.data.name)),
+    [props.boards, props.selectedRoom?._id, boardSearch]
+  );
+
+  const scrollbarCss = {
+    '&::-webkit-scrollbar': { background: 'transparent', width: '10px' },
+    '&::-webkit-scrollbar-thumb': { background: scrollBarColor, borderRadius: '48px' },
+  };
+
+  return (
+    <Flex gap="2" flexDirection="column">
+      {/* Toolbar: create, search, view toggle, refresh */}
+      <Flex align="center" gap="2" justify="flex-start" ml="2">
+        <Tooltip label="Create New Board" placement="top" hasArrow>
+          <IconButton
+            size="sm"
+            bg="none"
+            aria-label="Create board"
+            fontSize="xl"
+            onFocus={(e) => e.preventDefault()}
+            onClick={props.onCreateBoard}
+            isDisabled={!props.canCreateBoards}
+            _hover={{ transform: 'scale(1.1)', bg: 'none' }}
+            icon={<MdAdd fontSize="24px" />}
+          />
+        </Tooltip>
+
+        <InputGroup size="md" width="425px" my="1">
+          <InputLeftElement pointerEvents="none">
+            <MdSearch />
+          </InputLeftElement>
+          <Input
+            placeholder="Search Boards"
+            _placeholder={{ opacity: 0.7, color: searchPlaceholderColor }}
+            defaultValue=""
+            onChange={(e) => {
+              const value = e.target.value;
+              if (debounceRef.current) clearTimeout(debounceRef.current);
+              debounceRef.current = setTimeout(() => setBoardSearch(value), 150);
+            }}
+            roundedTop="2xl"
+            _focusVisible={{ bg: searchBarColor, outline: 'none', transition: 'none' }}
+            bg="inherit"
+            roundedBottom="2xl"
+          />
+        </InputGroup>
+
+        <Tooltip label={boardListView === 'grid' ? 'Switch to List View' : 'Switch to Grid View'} placement="top" hasArrow>
+          <IconButton
+            size="sm"
+            bg="none"
+            aria-label={boardListView === 'grid' ? 'Switch to List View' : 'Switch to Grid View'}
+            onClick={() => setBoardListView(boardListView === 'grid' ? 'list' : 'grid')}
+            icon={boardListView === 'grid' ? <MdList fontSize="24px" /> : <MdGridView fontSize="24px" />}
+            _hover={{ transform: 'scale(1.1)', bg: 'none' }}
+          />
+        </Tooltip>
+
+        <Tooltip label="Refresh Board Previews" placement="top" hasArrow>
+          <IconButton
+            size="sm"
+            bg="none"
+            aria-label="Refresh board previews"
+            isLoading={props.previewsLoading}
+            onClick={props.onRefreshPreviews}
+            icon={<MdRefresh fontSize="24px" />}
+            _hover={{ transform: 'scale(1.1)', bg: 'none' }}
+          />
+        </Tooltip>
+      </Flex>
+
+      {/* Grid view */}
+      {boardListView === 'grid' && (
+        <Flex
+          gap="4"
+          pl="2"
+          py="1"
+          flexWrap="wrap"
+          justifyContent="left"
+          style={{ maxHeight: 'calc(100svh - 270px)', width: '100%', maxWidth: '2200px' }}
+          margin="0 auto"
+          overflowY="scroll"
+          overflowX="hidden"
+          minWidth="420px"
+          css={scrollbarCss}
+        >
+          {filteredBoards.map((board) => (
+            <Box key={board._id} ref={board._id === props.selectedBoard?._id ? props.scrollToBoardRef : undefined}>
+              <BoardCard
+                board={board}
+                room={props.selectedRoom!}
+                onClick={() => props.onBoardClick(board)}
+                selected={props.selectedBoard?._id === board._id}
+                usersPresent={props.presenceByBoard.get(board._id) ?? []}
+                appInfo={props.boardPreviews.get(board._id) ?? []}
+              />
+            </Box>
+          ))}
+        </Flex>
+      )}
+
+      {/* List view */}
+      {boardListView === 'list' && (
+        <VStack
+          gap="3"
+          alignItems="left"
+          pl="2"
+          style={{ height: 'calc(100svh - 270px)' }}
+          overflowY="scroll"
+          overflowX="hidden"
+          minWidth="420px"
+          css={{
+            '&::-webkit-scrollbar': { background: 'transparent', width: '5px' },
+            '&::-webkit-scrollbar-thumb': { background: scrollBarColor, borderRadius: '48px' },
+          }}
+        >
+          {filteredBoards.map((board) => (
+            <Box key={board._id} ref={board._id === props.selectedBoard?._id ? props.scrollToBoardRef : undefined}>
+              <BoardRow
+                key={board._id}
+                board={board}
+                room={props.selectedRoom!}
+                onClick={() => props.onBoardClick(board)}
+                selected={props.selectedBoard?._id === board._id}
+                usersPresent={(props.presenceByBoard.get(board._id) ?? []).length}
+              />
+            </Box>
+          ))}
+        </VStack>
+      )}
+    </Flex>
+  );
+}

--- a/webstack/apps/webapp/src/app/pages/home/components/index.ts
+++ b/webstack/apps/webapp/src/app/pages/home/components/index.ts
@@ -6,6 +6,7 @@
  * the file LICENSE, distributed as part of this software.
  */
 
+export * from './BoardListPanel';
 export * from './MembersList';
 export * from './BoardRow';
 export * from './BoardCard';

--- a/webstack/libs/frontend/src/lib/ui/components/general/MainButton.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/general/MainButton.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -57,7 +57,6 @@ import {
   useBoardStore,
   EnterBoardModal,
   useHexColor,
-  UserSearchModal,
   useAbility,
   FeedbackModal,
   useConfigStore,
@@ -88,9 +87,6 @@ export function MainButton(props: MainButtonProps) {
   const shortName = user ? truncateWithEllipsis(user.data.name, 10) : '';
   const isWall = user?.data.userType === 'wall';
 
-  const userColorValue = user?.data.color ? user.data.color : 'teal';
-  const userColor = useHexColor(userColorValue);
-
   const config = useConfigStore((state) => state.config);
   const isProduction = config.production;
   const feedbackUrl = config.feedback ? config.feedback.url : null;
@@ -106,8 +102,6 @@ export function MainButton(props: MainButtonProps) {
   // Modal panels
   const { isOpen: editIsOpen, onOpen: editOnOpen, onClose: editOnClose } = useDisclosure();
   const { isOpen: aboutIsOpen, onOpen: aboutOnOpen, onClose: aboutOnClose } = useDisclosure();
-  const { isOpen: userSearchIsOpen, onOpen: userSearchOnOpen, onClose: userSearchOnClose } = useDisclosure();
-
   // Alfred Modal
   const { isOpen: alfredIsOpen, onOpen: alfredOnOpen, onClose: alfredOnClose } = useDisclosure();
   // Help modal
@@ -228,7 +222,7 @@ export function MainButton(props: MainButtonProps) {
                 size="sm"
                 // maxWidth="150px"
                 variant={props.buttonStyle ? props.buttonStyle : 'outline'}
-                colorScheme={user?.data.color ? user.data.color : 'white'}
+                colorScheme="teal"
                 p={2}
               >
                 <Box
@@ -248,34 +242,28 @@ export function MainButton(props: MainButtonProps) {
             </Tooltip>
           </Flex>
         ) : (
-          <Flex gap="2">
-            <MenuButton
-              marginTop="auto"
-              display="flex"
-              as={Box}
-              backgroundColor={userColor}
-              height="32px"
-              alignItems={'center'}
-              justifyContent={'left'}
-              borderRadius="10"
-              width="100%"
-              transition={'all 0.5s'}
-              _hover={{ cursor: 'pointer' }}
-              overflow={'hidden'}
-            >
-              <Box display="flex" justifyContent={'space-between'} alignItems={'center'} width="100%">
-                <Box display="flex" pl="4" gap="1" alignItems={'center'} flex="1" minWidth="0" overflow="hidden">
-                  {isWall ? <RxGrid /> : <MdPerson />}
-                  <Text fontSize="md" fontWeight={'bold'} whiteSpace={'nowrap'} overflow="hidden" textOverflow={'ellipsis'}>
-                    {longName}
-                  </Text>
-                </Box>
-                <Box pr="3" fontSize="3xl" flexShrink={0}>
-                  {menuOpen ? <BiChevronUp /> : <BiChevronDown />}
-                </Box>
+          <MenuButton
+            as={Button}
+            colorScheme="teal"
+            variant="solid"
+            width="100%"
+            borderRadius="10"
+            size="sm"
+            px={4}
+            overflow="hidden"
+          >
+            <Box display="flex" justifyContent="space-between" alignItems="center" width="100%">
+              <Box display="flex" gap="1" alignItems="center" flex="1" minWidth="0" overflow="hidden">
+                <Box flexShrink={0}>{isWall ? <RxGrid /> : <MdPerson />}</Box>
+                <Text fontWeight="bold" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+                  {longName}
+                </Text>
               </Box>
-            </MenuButton>
-          </Flex>
+              <Box fontSize="2xl" flexShrink={0} ml={2}>
+                {menuOpen ? <BiChevronUp /> : <BiChevronDown />}
+              </Box>
+            </Box>
+          </MenuButton>
         )}
 
         <MenuList
@@ -419,11 +407,6 @@ export function MainButton(props: MainButtonProps) {
 
       <EditUserModal isOpen={editIsOpen} onOpen={editOnOpen} onClose={editOnClose}></EditUserModal>
       <AboutModal isOpen={aboutIsOpen} onClose={aboutOnClose}></AboutModal>
-
-      {
-        // The test forces the recreation of the modal when the userSearchIsOpen state changes
-        userSearchIsOpen && <UserSearchModal isOpen={userSearchIsOpen} onOpen={userSearchOnOpen} onClose={userSearchOnClose} />
-      }
     </>
   );
 }

--- a/webstack/libs/frontend/src/lib/ui/components/general/MainButton.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/general/MainButton.tsx
@@ -84,7 +84,7 @@ type MainButtonProps = {
  */
 export function MainButton(props: MainButtonProps) {
   const { user } = useUser();
-  const longName = user ? truncateWithEllipsis(user.data.name, 20) : '';
+  const longName = user ? user.data.name : '';
   const shortName = user ? truncateWithEllipsis(user.data.name, 10) : '';
   const isWall = user?.data.userType === 'wall';
 
@@ -263,14 +263,14 @@ export function MainButton(props: MainButtonProps) {
               _hover={{ cursor: 'pointer' }}
               overflow={'hidden'}
             >
-              <Box display="flex" justifyContent={'space-between'} alignItems={'center'}>
-                <Box display="flex" pl="4" gap="1" alignItems={'center'}>
+              <Box display="flex" justifyContent={'space-between'} alignItems={'center'} width="100%">
+                <Box display="flex" pl="4" gap="1" alignItems={'center'} flex="1" minWidth="0" overflow="hidden">
                   {isWall ? <RxGrid /> : <MdPerson />}
-                  <Text fontSize="md" fontWeight={'bold'} whiteSpace={'nowrap'} textOverflow={'clip'}>
+                  <Text fontSize="md" fontWeight={'bold'} whiteSpace={'nowrap'} overflow="hidden" textOverflow={'ellipsis'}>
                     {longName}
                   </Text>
                 </Box>
-                <Box pr="3" fontSize="3xl">
+                <Box pr="3" fontSize="3xl" flexShrink={0}>
                   {menuOpen ? <BiChevronUp /> : <BiChevronDown />}
                 </Box>
               </Box>

--- a/webstack/libs/frontend/src/lib/ui/components/modals/CreateBoardModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/CreateBoardModal.tsx
@@ -21,6 +21,8 @@ import {
   useToast,
   Button,
   Checkbox,
+  Box,
+  Text,
 } from '@chakra-ui/react';
 
 import { v5 as uuidv5 } from 'uuid';
@@ -38,6 +40,8 @@ interface CreateBoardModalProps {
   roomId: string;
   onClose: () => void;
 }
+
+const NAME_MAX = 50;
 
 export function CreateBoardModal(props: CreateBoardModalProps): JSX.Element {
   // Configuration information
@@ -95,8 +99,7 @@ export function CreateBoardModal(props: CreateBoardModalProps): JSX.Element {
 
   const create = async () => {
     if (name && user) {
-      // remove leading and trailing space, and limit name length to 32
-      const cleanedName = name.trim().substring(0, 31);
+      const cleanedName = name.trim().substring(0, NAME_MAX);
       // list of board names in the room
       const roomsBoards = boards.filter((board) => board.data.roomId === props.roomId);
       const boardNames = roomsBoards.map((board) => board.data.name);
@@ -193,20 +196,26 @@ export function CreateBoardModal(props: CreateBoardModalProps): JSX.Element {
       <ModalContent>
         <ModalHeader fontSize="3xl">Create a New Board</ModalHeader>
         <ModalBody>
-          <InputGroup mb="4">
-            <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
-            <Input
-              ref={initialRef}
-              type="text"
-              placeholder={'Board Name'}
-              _placeholder={{ opacity: 1, color: 'gray.600' }}
-              mr={0}
-              value={name}
-              onChange={handleNameChange}
-              onKeyDown={onSubmit}
-              isRequired={true}
-            />
-          </InputGroup>
+          <Box mb="4">
+            <InputGroup>
+              <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
+              <Input
+                ref={initialRef}
+                type="text"
+                placeholder={'Board Name'}
+                _placeholder={{ opacity: 1, color: 'gray.600' }}
+                mr={0}
+                value={name}
+                onChange={handleNameChange}
+                onKeyDown={onSubmit}
+                isRequired={true}
+                maxLength={NAME_MAX}
+              />
+            </InputGroup>
+            <Text fontSize="xs" textAlign="right" mt="1" color={name.length >= NAME_MAX ? 'red.400' : name.length >= NAME_MAX * 0.8 ? 'orange.400' : 'gray.400'}>
+              {name.length} / {NAME_MAX}
+            </Text>
+          </Box>
 
           <ColorPicker selectedColor={color} onChange={handleColorChange}></ColorPicker>
 

--- a/webstack/libs/frontend/src/lib/ui/components/modals/CreateBoardModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/CreateBoardModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in

--- a/webstack/libs/frontend/src/lib/ui/components/modals/CreateRoomModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/CreateRoomModal.tsx
@@ -20,6 +20,8 @@ import {
   useToast,
   Button,
   Checkbox,
+  Text,
+  Box,
 } from '@chakra-ui/react';
 
 import { v5 as uuidv5 } from 'uuid';
@@ -36,6 +38,9 @@ interface CreateRoomModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
+
+const NAME_MAX = 50;
+const DESC_MAX = 150;
 
 export function CreateRoomModal(props: CreateRoomModalProps): JSX.Element {
   // Configuration information
@@ -92,8 +97,7 @@ export function CreateRoomModal(props: CreateRoomModalProps): JSX.Element {
 
   const create = async () => {
     if (name && user) {
-      // remove leading and trailing space, and limit name length to 32
-      const cleanedName = name.trim().substring(0, 31);
+      const cleanedName = name.trim().substring(0, NAME_MAX);
       const roomNames = rooms.map((room) => room.data.name);
 
       if (cleanedName.split(' ').join('').length === 0) {
@@ -161,33 +165,45 @@ export function CreateRoomModal(props: CreateRoomModalProps): JSX.Element {
       <ModalContent>
         <ModalHeader fontSize="3xl">Create Room</ModalHeader>
         <ModalBody>
-          <InputGroup mb="4"  >
-            <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
-            <Input
-              ref={initialRef}
-              type="text"
-              placeholder={'Room Name'}
-              _placeholder={{ opacity: 1, color: 'gray.400' }}
-              mr={0}
-              value={name}
-              onChange={handleNameChange}
-              onKeyDown={onSubmit}
-              isRequired={true}
-            />
-          </InputGroup>
-          <InputGroup my={4}>
-            <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
-            <Input
-              type="text"
-              placeholder={'Room Description (optional)'}
-              _placeholder={{ opacity: 1, color: 'gray.400' }}
-              mr={0}
-              value={description}
-              onChange={handleDescription}
-              onKeyDown={onSubmit}
-              isRequired={false}
-            />
-          </InputGroup>
+          <Box mb="4">
+            <InputGroup>
+              <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
+              <Input
+                ref={initialRef}
+                type="text"
+                placeholder={'Room Name'}
+                _placeholder={{ opacity: 1, color: 'gray.400' }}
+                mr={0}
+                value={name}
+                onChange={handleNameChange}
+                onKeyDown={onSubmit}
+                isRequired={true}
+                maxLength={NAME_MAX}
+              />
+            </InputGroup>
+            <Text fontSize="xs" textAlign="right" mt="1" color={name.length >= NAME_MAX ? 'red.400' : name.length >= NAME_MAX * 0.8 ? 'orange.400' : 'gray.400'}>
+              {name.length} / {NAME_MAX}
+            </Text>
+          </Box>
+          <Box my="4">
+            <InputGroup>
+              <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
+              <Input
+                type="text"
+                placeholder={'Room Description (optional)'}
+                _placeholder={{ opacity: 1, color: 'gray.400' }}
+                mr={0}
+                value={description}
+                onChange={handleDescription}
+                onKeyDown={onSubmit}
+                isRequired={false}
+                maxLength={DESC_MAX}
+              />
+            </InputGroup>
+            <Text fontSize="xs" textAlign="right" mt="1" color={description.length >= DESC_MAX ? 'red.400' : description.length >= DESC_MAX * 0.8 ? 'orange.400' : 'gray.400'}>
+              {description.length} / {DESC_MAX}
+            </Text>
+          </Box>
 
           <ColorPicker selectedColor={color} onChange={handleColorChange}></ColorPicker>
 

--- a/webstack/libs/frontend/src/lib/ui/components/modals/CreateRoomModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/CreateRoomModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in

--- a/webstack/libs/frontend/src/lib/ui/components/modals/CreateUserModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/CreateUserModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in

--- a/webstack/libs/frontend/src/lib/ui/components/modals/CreateUserModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/CreateUserModal.tsx
@@ -18,6 +18,7 @@ import {
   InputLeftElement,
   Input,
   Button,
+  Box,
   FormControl,
   FormLabel,
   Text,
@@ -36,6 +37,8 @@ import { ColorPicker } from '../general';
 type CreateUserProps = {
   createUser: (user: UserSchema) => void;
 };
+
+const NAME_MAX = 50;
 
 export function CreateUserModal(props: CreateUserProps): JSX.Element {
   // get the user information
@@ -69,7 +72,7 @@ export function CreateUserModal(props: CreateUserProps): JSX.Element {
   function createAccount() {
     if (name) {
       const newUser = {
-        name: name.trim(),
+        name: name.trim().substring(0, NAME_MAX),
         email: auth?.email ? auth.email : '',
         color: color,
         userRole: auth?.provider === 'guest' ? 'guest' : 'user',
@@ -98,19 +101,25 @@ export function CreateUserModal(props: CreateUserProps): JSX.Element {
         <ModalBody>
           <FormControl isRequired mb={4}>
             <FormLabel htmlFor="htmlFor">Username</FormLabel>
-            <InputGroup>
-              <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
-              <Input
-                ref={initialRef}
-                type="string"
-                id="first-name"
-                placeholder="First name"
-                _placeholder={{ opacity: 1, color: 'gray.600' }}
-                value={name}
-                onChange={handleNameChange}
-                onKeyDown={onSubmit}
-              />
-            </InputGroup>
+            <Box>
+              <InputGroup>
+                <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
+                <Input
+                  ref={initialRef}
+                  type="string"
+                  id="first-name"
+                  placeholder="First name"
+                  _placeholder={{ opacity: 1, color: 'gray.600' }}
+                  value={name}
+                  onChange={handleNameChange}
+                  onKeyDown={onSubmit}
+                  maxLength={NAME_MAX}
+                />
+              </InputGroup>
+              <Text fontSize="xs" textAlign="right" mt="1" color={name.length >= NAME_MAX ? 'red.400' : name.length >= NAME_MAX * 0.8 ? 'orange.400' : 'gray.400'}>
+                {name.length} / {NAME_MAX}
+              </Text>
+            </Box>
           </FormControl>
           <FormControl isRequired mt="2">
             <FormLabel htmlFor="color">Color</FormLabel>

--- a/webstack/libs/frontend/src/lib/ui/components/modals/EditBoardModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/EditBoardModal.tsx
@@ -22,6 +22,7 @@ import {
   Checkbox,
   useDisclosure,
   useToast,
+  Text,
 } from '@chakra-ui/react';
 
 import { v5 as uuidv5 } from 'uuid';
@@ -38,6 +39,8 @@ interface EditBoardModalProps {
   onClose: () => void;
   board: Board;
 }
+
+const NAME_MAX = 50;
 
 export function EditBoardModal(props: EditBoardModalProps): JSX.Element {
   // Configuration information
@@ -136,8 +139,7 @@ export function EditBoardModal(props: EditBoardModalProps): JSX.Element {
   };
 
   function cleanNameCheckDoubles(name: string, roomId: string): string | null {
-    // Remove leading and trailing space, and limit name length to 32
-    const cleanedName = name.trim().substring(0, 31);
+    const cleanedName = name.trim().substring(0, NAME_MAX);
     // Get the names of all boards in the same room, excluding the current board
     const boardNames = boards.filter((r) => r.data.roomId === roomId && r._id !== props.board._id).map((board) => board.data.name);
     if (cleanedName.split(' ').join('').length === 0) {
@@ -201,21 +203,26 @@ export function EditBoardModal(props: EditBoardModalProps): JSX.Element {
       <ModalContent>
         <ModalHeader fontSize="3xl">Edit Board: {props.board.data.name}</ModalHeader>
         <ModalBody>
-          <InputGroup mb={4}>
-            <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
-            <Input
-              ref={initialRef}
-              type="text"
-              placeholder={props.board.data.name}
-              _placeholder={{ opacity: 1, color: 'gray.600' }}
-              mr={0}
-              value={name}
-              onChange={handleNameChange}
-              onKeyDown={onSubmit}
-              isRequired={true}
-              maxLength={20}
-            />
-          </InputGroup>
+          <Box mb={4}>
+            <InputGroup>
+              <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
+              <Input
+                ref={initialRef}
+                type="text"
+                placeholder={props.board.data.name}
+                _placeholder={{ opacity: 1, color: 'gray.600' }}
+                mr={0}
+                value={name}
+                onChange={handleNameChange}
+                onKeyDown={onSubmit}
+                isRequired={true}
+                maxLength={NAME_MAX}
+              />
+            </InputGroup>
+            <Text fontSize="xs" textAlign="right" mt="1" color={name.length >= NAME_MAX ? 'red.400' : name.length >= NAME_MAX * 0.8 ? 'orange.400' : 'gray.400'}>
+              {name.length} / {NAME_MAX}
+            </Text>
+          </Box>
 
           <ColorPicker selectedColor={color as SAGEColors} onChange={handleColorChange}></ColorPicker>
 

--- a/webstack/libs/frontend/src/lib/ui/components/modals/EditBoardModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/EditBoardModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in

--- a/webstack/libs/frontend/src/lib/ui/components/modals/EditRoomModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/EditRoomModal.tsx
@@ -22,6 +22,7 @@ import {
   Checkbox,
   useDisclosure,
   useToast,
+  Text,
 } from '@chakra-ui/react';
 
 import { v5 as uuidv5 } from 'uuid';
@@ -38,6 +39,9 @@ interface EditRoomModalProps {
   onClose: () => void;
   room: Room;
 }
+
+const NAME_MAX = 50;
+const DESC_MAX = 150;
 
 export function EditRoomModal(props: EditRoomModalProps): JSX.Element {
   const { toHome } = useRouteNav();
@@ -153,8 +157,7 @@ export function EditRoomModal(props: EditRoomModalProps): JSX.Element {
   };
 
   function cleanNameCheckDoubles(name: string): string | null {
-    // Remove leading and trailing space, and limit name length to 32
-    const cleanedName = name.trim().substring(0, 31);
+    const cleanedName = name.trim().substring(0, NAME_MAX);
     const roomNames = rooms.filter((r) => r._id !== props.room._id).map((room) => room.data.name);
     if (cleanedName.split(' ').join('').length === 0) {
       toast({
@@ -238,33 +241,45 @@ export function EditRoomModal(props: EditRoomModalProps): JSX.Element {
       <ModalContent>
         <ModalHeader fontSize="3xl">Edit Room: {props.room.data.name}</ModalHeader>
         <ModalBody>
-          <InputGroup mb={4}>
-            <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
-            <Input
-              ref={initialRef}
-              type="text"
-              placeholder={'Room Name'}
-              _placeholder={{ opacity: 1, color: 'gray.600' }}
-              mr={0}
-              value={name}
-              onChange={handleNameChange}
-              onKeyDown={onSubmit}
-              isRequired={true}
-            />
-          </InputGroup>
-          <InputGroup my={4}>
-            <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
-            <Input
-              type="text"
-              placeholder={'Room Description (optional)'}
-              _placeholder={{ opacity: 1, color: 'gray.600' }}
-              mr={0}
-              value={description}
-              onChange={handleDescriptionChange}
-              onKeyDown={onSubmit}
-              isRequired={false}
-            />
-          </InputGroup>
+          <Box mb={4}>
+            <InputGroup>
+              <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
+              <Input
+                ref={initialRef}
+                type="text"
+                placeholder={'Room Name'}
+                _placeholder={{ opacity: 1, color: 'gray.600' }}
+                mr={0}
+                value={name}
+                onChange={handleNameChange}
+                onKeyDown={onSubmit}
+                isRequired={true}
+                maxLength={NAME_MAX}
+              />
+            </InputGroup>
+            <Text fontSize="xs" textAlign="right" mt="1" color={name.length >= NAME_MAX ? 'red.400' : name.length >= NAME_MAX * 0.8 ? 'orange.400' : 'gray.400'}>
+              {name.length} / {NAME_MAX}
+            </Text>
+          </Box>
+          <Box my={4}>
+            <InputGroup>
+              <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
+              <Input
+                type="text"
+                placeholder={'Room Description (optional)'}
+                _placeholder={{ opacity: 1, color: 'gray.600' }}
+                mr={0}
+                value={description}
+                onChange={handleDescriptionChange}
+                onKeyDown={onSubmit}
+                isRequired={false}
+                maxLength={DESC_MAX}
+              />
+            </InputGroup>
+            <Text fontSize="xs" textAlign="right" mt="1" color={description.length >= DESC_MAX ? 'red.400' : description.length >= DESC_MAX * 0.8 ? 'orange.400' : 'gray.400'}>
+              {description.length} / {DESC_MAX}
+            </Text>
+          </Box>
 
           <ColorPicker selectedColor={color} onChange={handleColorChange}></ColorPicker>
 

--- a/webstack/libs/frontend/src/lib/ui/components/modals/EditRoomModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/EditRoomModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in

--- a/webstack/libs/frontend/src/lib/ui/components/modals/EditUserModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/EditUserModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in

--- a/webstack/libs/frontend/src/lib/ui/components/modals/EditUserModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/EditUserModal.tsx
@@ -18,6 +18,7 @@ import {
   InputLeftElement,
   Input,
   Button,
+  Box,
   Text,
   RadioGroup,
   Stack,
@@ -42,6 +43,8 @@ interface EditUserModalProps {
   onOpen: () => void;
   onClose: () => void;
 }
+
+const NAME_MAX = 50;
 
 export function EditUserModal(props: EditUserModalProps): JSX.Element {
   const { user, update } = useUser();
@@ -85,7 +88,7 @@ export function EditUserModal(props: EditUserModalProps): JSX.Element {
   };
 
   const updateAccount = () => {
-    const newname = name.trim();
+    const newname = name.trim().substring(0, NAME_MAX);
     if (newname !== user?.data.name && update) {
       update({ name: newname });
     }
@@ -107,21 +110,26 @@ export function EditUserModal(props: EditUserModalProps): JSX.Element {
         <ModalBody>
           <FormControl mt="2">
             <FormLabel htmlFor="color">Name</FormLabel>
-
-            <InputGroup>
-              <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
-              <Input
-                ref={initialRef}
-                type="string"
-                placeholder={'Enter a username'}
-                _placeholder={{ opacity: 1, color: 'gray.600' }}
-                mr={0}
-                value={name}
-                onChange={handleNameChange}
-                onKeyDown={onSubmit}
-                isRequired={true}
-              />
-            </InputGroup>
+            <Box>
+              <InputGroup>
+                <InputLeftElement pointerEvents="none" children={<MdPerson size={'24px'} />} />
+                <Input
+                  ref={initialRef}
+                  type="string"
+                  placeholder={'Enter a username'}
+                  _placeholder={{ opacity: 1, color: 'gray.600' }}
+                  mr={0}
+                  value={name}
+                  onChange={handleNameChange}
+                  onKeyDown={onSubmit}
+                  isRequired={true}
+                  maxLength={NAME_MAX}
+                />
+              </InputGroup>
+              <Text fontSize="xs" textAlign="right" mt="1" color={name.length >= NAME_MAX ? 'red.400' : name.length >= NAME_MAX * 0.8 ? 'orange.400' : 'gray.400'}>
+                {name.length} / {NAME_MAX}
+              </Text>
+            </Box>
           </FormControl>
 
           <FormControl mt="2">

--- a/webstack/libs/frontend/src/lib/ui/components/party/Party.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/party/Party.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2025. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -72,7 +72,6 @@ export function PartyButton(props: PartyIconProps): JSX.Element {
 
   // Styling
   const iconSize = props.iconSize || 'md';
-  const iconColor = 'teal';
   const fontSize = iconSize === 'xs' ? 'sm' : iconSize === 'sm' ? 'md' : 'lg';
   const badgeColor = useColorModeValue('red.500', 'red.200');
   const badgeHex = useHexColor(badgeColor);
@@ -136,7 +135,7 @@ export function PartyButton(props: PartyIconProps): JSX.Element {
             onClick={handleOnToggle}
             size={iconSize}
             fontSize={fontSize}
-            colorScheme={iconColor}
+            colorScheme="teal"
             icon={<LuPartyPopper fontSize="24px" />}
             aria-label="Party"
           />


### PR DESCRIPTION
  ### Summary                 

  - **Standardize button colors to `teal`** — removed all per-user color overrides across the toolbar,   
  interaction bar, context menu, and navigation menu. Multiple developers had implemented buttons using
  `user.data.color` with manual hex fallbacks, making the UI feel inconsistent and hard to read.         
  Everything now uses Chakra's `colorScheme="teal"` natively.                                          

  - **Convert `MainButton` and server selector to native Chakra `Button`** — previously rendered as      
  `as={Box}` with manual hover/color management. Now proper `as={Button} colorScheme="teal"` dropdowns
  that inherit all Chakra theming automatically (dark mode, hover, focus states).                        
                                                            
  - **Username no longer truncated at 20 chars** — the sidebar `MainButton` now lets the username fill   
  available CSS space and truncates naturally via `text-overflow: ellipsis`. The icon is `flexShrink={0}`
   so it never squishes.                                                                                 
                                                            
  - **Sidebar resize handle** — only the 5×150px pill is interactive, not the full page height. Cleaner  
  UX.
                                                                                                         
  - **Character limits on all create/edit modals** — `NAME_MAX=50` on boards, rooms, and users;          
  `DESC_MAX=150` on rooms. Live counter turns orange at 80% and red at 100%. Enforced via `maxLength` +
  trimmed on save.                                                                                       
                                                            
  - **Board preview race condition fix** — `recentBoards.length` and `savedBoards.length` added to       
  `useEffect` deps. Previously, user data (saved/recent boards) could arrive after the boards list,
  causing previews to render as "No Opened Applications" and never re-trigger.                           
                                                            
  - **Board search performance** — extracted a `BoardListPanel` component that owns search state,        
  list/grid view toggle, and filtered board rendering. Typing in the search box now only re-renders this
  subtree rather than the entire Home page. Input is uncontrolled (debounce-only) to eliminate           
  per-keystroke React updates. Panel is mounted with `key={selectedRoom?._id}` so search resets
  automatically on room switch.

  - **Dead code removal**:                                                                               
    - `EnterBoardModal` — `onOpen` was never called; modal never opened
    - `UserSearchModal` in `MainButton` — render block was never reachable                               
    - `handleJoinRoomMembership` — declared but never called
    - `enterBoardByURLRef` — ref declared but never attached to DOM
                                                                                                         
  ### Files Changed
  | Area | What changed |                                                                                
  |---|---|                                                 
  | `Home.tsx` | Server selector styling, sidebar resize pill, dead code removal, `BoardListPanel`
  extraction |
  | `BoardListPanel.tsx` | New component — owns board search, view toggle, filtered list rendering |
  | `MainButton.tsx` | Native Chakra button, username fill, dead `UserSearchModal` removed |             
  | `UILayer.tsx`, `Interactionbar.tsx`, `ToolbarButton.tsx`, `BoardContextMenu.tsx`,
  `NavigationMenu.tsx`, `Party.tsx` | Standardized to `colorScheme="teal"` |                             
  | `CreateBoardModal`, `EditBoardModal`, `CreateRoomModal`, `EditRoomModal`, `CreateUserModal`,
  `EditUserModal` | Character limits + live counters |                                                   
                                                       