### PR TITLE
[Performance Fix]: Eliminate re-renders during sidebar resize 

### DIFF
--- a/webstack/apps/webapp/src/app/pages/home/Home.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/Home.tsx
@@ -156,6 +156,7 @@ export function HomePage() {
     return stored ? Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, parseInt(stored, 10))) : 240;
   });
   const sidebarDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const sidebarRef = useRef<HTMLDivElement>(null);
 
   // Toast to inform user that they are not a member of a room
   const toast = useToast();
@@ -747,6 +748,7 @@ export function HomePage() {
 
       {/* Sidebar Drawer */}
       <Box
+        ref={sidebarRef}
         borderRadius={cardRadius}
         width={`${sidebarWidth}px`}
         minWidth={`${SIDEBAR_MIN}px`}
@@ -965,7 +967,7 @@ export function HomePage() {
             if (!sidebarDragRef.current) return;
             const delta = e.clientX - sidebarDragRef.current.startX;
             const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
-            setSidebarWidth(next);
+            if (sidebarRef.current) sidebarRef.current.style.width = `${next}px`;
           }}
           onPointerUp={(e) => {
             if (!sidebarDragRef.current) return;
@@ -973,6 +975,7 @@ export function HomePage() {
             const delta = e.clientX - sidebarDragRef.current.startX;
             const final = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
             localStorage.setItem('sage3-sidebar-width', String(final));
+            setSidebarWidth(final);
             sidebarDragRef.current = null;
           }}
         />

--- a/webstack/apps/webapp/src/app/pages/home/Home.tsx
+++ b/webstack/apps/webapp/src/app/pages/home/Home.tsx
@@ -158,6 +158,32 @@ export function HomePage() {
   const sidebarDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const sidebarRef = useRef<HTMLDivElement>(null);
 
+  // Begin drag: capture pointer and record start position
+  const onSidebarDragHandlePointerDown = (e: React.PointerEvent) => {
+    e.preventDefault();
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
+  };
+
+  // During drag: mutate DOM directly to avoid re-rendering the whole page on every mouse move
+  const onSidebarDragHandlePointerMove = (e: React.PointerEvent) => {
+    if (!sidebarDragRef.current) return;
+    const delta = e.clientX - sidebarDragRef.current.startX;
+    const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
+    if (sidebarRef.current) sidebarRef.current.style.width = `${next}px`;
+  };
+
+  // End drag: sync final width into React state and persist to localStorage
+  const onSidebarDragHandlePointerUp = (e: React.PointerEvent) => {
+    if (!sidebarDragRef.current) return;
+    (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    const delta = e.clientX - sidebarDragRef.current.startX;
+    const final = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
+    localStorage.setItem('sage3-sidebar-width', String(final));
+    setSidebarWidth(final);
+    sidebarDragRef.current = null;
+  };
+
   // Toast to inform user that they are not a member of a room
   const toast = useToast();
 
@@ -958,26 +984,9 @@ export function HomePage() {
           cursor="col-resize"
           _hover={{ bg: dividerTabHoverColor }}
           transition="background 0.15s"
-          onPointerDown={(e) => {
-            e.preventDefault();
-            (e.target as HTMLElement).setPointerCapture(e.pointerId);
-            sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
-          }}
-          onPointerMove={(e) => {
-            if (!sidebarDragRef.current) return;
-            const delta = e.clientX - sidebarDragRef.current.startX;
-            const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
-            if (sidebarRef.current) sidebarRef.current.style.width = `${next}px`;
-          }}
-          onPointerUp={(e) => {
-            if (!sidebarDragRef.current) return;
-            (e.target as HTMLElement).releasePointerCapture(e.pointerId);
-            const delta = e.clientX - sidebarDragRef.current.startX;
-            const final = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarDragRef.current.startWidth + delta));
-            localStorage.setItem('sage3-sidebar-width', String(final));
-            setSidebarWidth(final);
-            sidebarDragRef.current = null;
-          }}
+          onPointerDown={onSidebarDragHandlePointerDown}
+          onPointerMove={onSidebarDragHandlePointerMove}
+          onPointerUp={onSidebarDragHandlePointerUp}
         />
       </Box>
 


### PR DESCRIPTION
## Problem                                                                                      
                                                                                               
  The home page sidebar is resizable via a drag handle. The previous implementation stored the 
  sidebar width in React state (sidebarWidth), meaning every onPointerMove event during a drag 
  called setSidebarWidth(). This triggered a full re-render of the entire HomePage component   
  tree — including BoardListPanel and all board cards — at ~60 events per second. With a large 
  number of boards loaded, this caused severe jank measured by react-scan.

  ### Solution

  Replace the setSidebarWidth call in onPointerMove with a direct DOM mutation via a ref       
  attached to the sidebar element:
                                                                                               
 ``` if (sidebarRef.current) sidebarRef.current.style.width = `${next}px`;   ```                     
  
  React state is now only updated once on pointerUp (drag release), so the full component tree 
  is reconciled a single time per drag operation instead of hundreds of times. The visual    
  result is identical — the sidebar still tracks the cursor in real time — but all intermediate
   frames bypass React entirely.                                                             

  ### Changes

  - Home.tsx: added sidebarRef = useRef<HTMLDivElement>(null) and attached it to the sidebar   
  <Box>
  - onPointerMove: writes width directly to sidebarRef.current.style.width (no React state     
  update)                                                                                      
  - onPointerUp: calls setSidebarWidth(final) once to sync React state after drag ends (ensures
   correctness on any subsequent re-render triggered by other state changes)   