### PR TITLE
[Auth] Keycloak Passport.js Strategy Addition

### DIFF
--- a/webstack/apps/webapp/src/app/pages/login/Login.tsx
+++ b/webstack/apps/webapp/src/app/pages/login/Login.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2025. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -12,6 +12,7 @@ import { Button, ButtonGroup, IconButton, Box, useColorMode, Image, Text, VStack
 
 import { FcGoogle } from 'react-icons/fc';
 import { FaGhost, FaApple } from 'react-icons/fa';
+import { SiKeycloak } from 'react-icons/si';
 
 import { isElectron, useAuth, useRouteNav, GetServerInfo } from '@sage3/frontend';
 
@@ -22,7 +23,7 @@ import cilogonLogo from '../../../assets/cilogon.png';
  * Login page with authentication options and board context handling
  */
 export function LoginPage() {
-  const { auth, googleLogin, appleLogin, ciLogin, guestLogin, spectatorLogin, loading: authLoading } = useAuth();
+  const { auth, googleLogin, appleLogin, ciLogin, keycloakLogin, guestLogin, spectatorLogin, loading: authLoading } = useAuth();
   const { toCreateUser } = useRouteNav();
   const toast = useToast();
   
@@ -173,6 +174,22 @@ export function LoginPage() {
         case 'apple_oauth_error':
           title = 'Apple OAuth Error';
           description = 'Apple returned an authentication error. Please try again.';
+          break;
+        case 'keycloak_error':
+          title = 'Keycloak Login Failed';
+          description = 'There was an error with Keycloak authentication. Please try again.';
+          break;
+        case 'keycloak_no_user':
+          title = 'Keycloak Login Issue';
+          description = 'Keycloak authentication succeeded but no user data was received. Please try again.';
+          break;
+        case 'keycloak_login_failed':
+          title = 'Keycloak Session Error';
+          description = 'Unable to create your session after Keycloak login. Please try again.';
+          break;
+        case 'keycloak_oauth_error':
+          title = 'Keycloak OAuth Error';
+          description = 'Keycloak returned an authentication error. Please try again.';
           break;
         default:
           title = 'Authentication Error';
@@ -368,7 +385,7 @@ export function LoginPage() {
           <ButtonGroup isAttached size="lg" width="100%">
             <IconButton
               width="80px"
-              aria-label="Login with Google"
+              aria-label="Login with CILogon"
               icon={<Image w="36px" h="36px" src={cilogonLogo} alt="CILogon Logo" />}
               pointerEvents="none"
               borderRight={`3px solid`}
@@ -376,6 +393,21 @@ export function LoginPage() {
             />
             <Button width="100%" isDisabled={shouldDisable || !logins.includes('cilogon')} justifyContent="left" onClick={ciLogin}>
               Login with CILogon
+            </Button>
+          </ButtonGroup>
+
+          {/* Keycloak Auth Service */}
+          <ButtonGroup isAttached size="lg" width="100%">
+            <IconButton
+              width="80px"
+              aria-label="Login with Keycloak"
+              icon={<SiKeycloak size="30" width="50px" />}
+              pointerEvents="none"
+              borderRight={`3px solid`}
+              borderColor={colorMode === 'light' ? 'gray.50' : 'gray.800'}
+            />
+            <Button width="100%" isDisabled={shouldDisable || !logins.includes('keycloak')} justifyContent="left" onClick={keycloakLogin}>
+              Login with Keycloak
             </Button>
           </ButtonGroup>
 

--- a/webstack/apps/webapp/src/app/pages/login/Login.tsx
+++ b/webstack/apps/webapp/src/app/pages/login/Login.tsx
@@ -26,11 +26,11 @@ export function LoginPage() {
   const { auth, googleLogin, appleLogin, ciLogin, keycloakLogin, guestLogin, spectatorLogin, loading: authLoading } = useAuth();
   const { toCreateUser } = useRouteNav();
   const toast = useToast();
-  
+
   const [serverName, setServerName] = useState<string>('');
   const [shouldDisable, setShouldDisable] = useState(false);
   const [logins, setLogins] = useState<string[]>([]);
-  
+
   const logoUrl = '/assets/sage3_banner.webp';
   const thisIsElectron = isElectron();
 
@@ -40,7 +40,7 @@ export function LoginPage() {
   const getReturnToUrl = () => {
     const urlParams = new URLSearchParams(window.location.search);
     const returnTo = urlParams.get('returnTo');
-    
+
     // Validate returnTo URL to prevent open redirects
     if (returnTo) {
       if (returnTo.startsWith('/') && !returnTo.includes('://')) {
@@ -56,15 +56,15 @@ export function LoginPage() {
   const getSavedBoardContext = () => {
     try {
       const savedContext = localStorage.getItem('sage3_pending_board');
-      
+
       if (savedContext) {
         const context = JSON.parse(savedContext);
         console.log('Board Context: Retrieved from localStorage:', context);
-        
+
         // Check if context is not too old (24 hours)
         const isRecent = Date.now() - context.timestamp < 24 * 60 * 60 * 1000;
         const age = Date.now() - context.timestamp;
-        
+
         if (isRecent && context.roomId && context.boardId) {
           console.log(`Board Context: Valid context found (age: ${Math.round(age / 1000)}s)`);
           return context;
@@ -89,7 +89,7 @@ export function LoginPage() {
   const preserveBoardContext = useCallback(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const returnTo = urlParams.get('returnTo');
-    
+
     // Check if returnTo contains board information
     if (returnTo && returnTo.includes('/board/')) {
       const boardMatch = returnTo.match(/\/board\/([^\/]+)\/([^\/]+)/);
@@ -100,9 +100,9 @@ export function LoginPage() {
           boardId,
           timestamp: Date.now(),
           url: window.location.href,
-          source: 'login_returnTo'
+          source: 'login_returnTo',
         };
-        
+
         try {
           localStorage.setItem('sage3_pending_board', JSON.stringify(boardContext));
           console.log('Board Context: Preserved from returnTo parameter:', boardContext);
@@ -206,7 +206,7 @@ export function LoginPage() {
         title,
         description,
         details: details ? decodeURIComponent(details) : 'No additional details',
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       });
 
       // Show toast for user feedback (may be missed due to redirects)
@@ -216,7 +216,7 @@ export function LoginPage() {
         status: 'error',
         duration: 8000,
         isClosable: true,
-        position: 'top'
+        position: 'top',
       });
 
       // Clear error parameters from URL to prevent showing the error again
@@ -271,7 +271,7 @@ export function LoginPage() {
     console.log('Auth State Check:', {
       auth: auth ? { id: auth.id, provider: auth.provider, email: auth.email } : null,
       authLoading,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
 
     // Don't make decisions while still loading auth
@@ -282,7 +282,7 @@ export function LoginPage() {
 
     if (auth) {
       console.log('Auth Success: Authentication present, redirecting to account creation/validation');
-      
+
       // Check for saved board context first to preserve it
       const savedContext = getSavedBoardContext();
       if (savedContext) {
@@ -311,6 +311,11 @@ export function LoginPage() {
   }, [authNavCheck]);
 
   const { colorMode } = useColorMode();
+
+  const isGoogle = !shouldDisable && logins.includes('google');
+  const isApple = !shouldDisable && logins.includes('apple');
+  const isCILogon = !shouldDisable && logins.includes('cilogon');
+  const isKeycloak = !shouldDisable && logins.includes('keycloak');
 
   return (
     <Box display="flex" flexDir={'column'} justifyContent="center" alignItems="center" width="100%" height="100%" position="relative">
@@ -342,74 +347,82 @@ export function LoginPage() {
           </Button>
         </Box>
       ) : (
-              <Box left="2" bottom="2" position="absolute">
-        <Button colorScheme="teal" size="sm" onClick={goToClientDownload}>
-          Download Client
-        </Button>
-      </Box>
+        <Box left="2" bottom="2" position="absolute">
+          <Button colorScheme="teal" size="sm" onClick={goToClientDownload}>
+            Download Client
+          </Button>
+        </Box>
       )}
 
       <Box width="300px">
         <VStack spacing={4}>
           {/* Google Auth Service */}
-          <ButtonGroup isAttached size="lg" width="100%">
-            <IconButton
-              width="80px"
-              aria-label="Login with Google"
-              icon={<FcGoogle size="30" width="50px" />}
-              pointerEvents="none"
-              borderRight={`3px solid`}
-              borderColor={colorMode === 'light' ? 'gray.50' : 'gray.800'}
-            />
-            <Button width="100%" isDisabled={shouldDisable || !logins.includes('google')} justifyContent="left" onClick={googleLogin}>
-              Login with Google
-            </Button>
-          </ButtonGroup>
+          {isGoogle && (
+            <ButtonGroup isAttached size="lg" width="100%">
+              <IconButton
+                width="80px"
+                aria-label="Login with Google"
+                icon={<FcGoogle size="30" width="50px" />}
+                pointerEvents="none"
+                borderRight={`3px solid`}
+                borderColor={colorMode === 'light' ? 'gray.50' : 'gray.800'}
+              />
+              <Button width="100%" isDisabled={shouldDisable || !logins.includes('google')} justifyContent="left" onClick={googleLogin}>
+                Login with Google
+              </Button>
+            </ButtonGroup>
+          )}
 
           {/* Apple Auth Service */}
-          <ButtonGroup isAttached size="lg" width="100%">
-            <IconButton
-              width="80px"
-              aria-label="Login with Apple"
-              icon={<FaApple size="30" width="50px" />}
-              pointerEvents="none"
-              borderRight={`3px solid`}
-              borderColor={colorMode === 'light' ? 'gray.50' : 'gray.800'}
-            />
-            <Button width="100%" isDisabled={shouldDisable || !logins.includes('apple')} justifyContent="left" onClick={appleLogin}>
-              Login with Apple
-            </Button>
-          </ButtonGroup>
+          {isApple && (
+            <ButtonGroup isAttached size="lg" width="100%">
+              <IconButton
+                width="80px"
+                aria-label="Login with Apple"
+                icon={<FaApple size="30" width="50px" />}
+                pointerEvents="none"
+                borderRight={`3px solid`}
+                borderColor={colorMode === 'light' ? 'gray.50' : 'gray.800'}
+              />
+              <Button width="100%" isDisabled={shouldDisable || !logins.includes('apple')} justifyContent="left" onClick={appleLogin}>
+                Login with Apple
+              </Button>
+            </ButtonGroup>
+          )}
 
           {/* CILogon Auth Service */}
-          <ButtonGroup isAttached size="lg" width="100%">
-            <IconButton
-              width="80px"
-              aria-label="Login with CILogon"
-              icon={<Image w="36px" h="36px" src={cilogonLogo} alt="CILogon Logo" />}
-              pointerEvents="none"
-              borderRight={`3px solid`}
-              borderColor={colorMode === 'light' ? 'gray.50' : 'gray.800'}
-            />
-            <Button width="100%" isDisabled={shouldDisable || !logins.includes('cilogon')} justifyContent="left" onClick={ciLogin}>
-              Login with CILogon
-            </Button>
-          </ButtonGroup>
+          {isCILogon && (
+            <ButtonGroup isAttached size="lg" width="100%">
+              <IconButton
+                width="80px"
+                aria-label="Login with CILogon"
+                icon={<Image w="36px" h="36px" src={cilogonLogo} alt="CILogon Logo" />}
+                pointerEvents="none"
+                borderRight={`3px solid`}
+                borderColor={colorMode === 'light' ? 'gray.50' : 'gray.800'}
+              />
+              <Button width="100%" isDisabled={shouldDisable || !logins.includes('cilogon')} justifyContent="left" onClick={ciLogin}>
+                Login with CILogon
+              </Button>
+            </ButtonGroup>
+          )}
 
           {/* Keycloak Auth Service */}
-          <ButtonGroup isAttached size="lg" width="100%">
-            <IconButton
-              width="80px"
-              aria-label="Login with Keycloak"
-              icon={<SiKeycloak size="30" width="50px" />}
-              pointerEvents="none"
-              borderRight={`3px solid`}
-              borderColor={colorMode === 'light' ? 'gray.50' : 'gray.800'}
-            />
-            <Button width="100%" isDisabled={shouldDisable || !logins.includes('keycloak')} justifyContent="left" onClick={keycloakLogin}>
-              Login with Keycloak
-            </Button>
-          </ButtonGroup>
+          {isKeycloak && (
+            <ButtonGroup isAttached size="lg" width="100%">
+              <IconButton
+                width="80px"
+                aria-label="Login with Keycloak"
+                icon={<SiKeycloak size="30" width="50px" />}
+                pointerEvents="none"
+                borderRight={`3px solid`}
+                borderColor={colorMode === 'light' ? 'gray.50' : 'gray.800'}
+              />
+              <Button width="100%" isDisabled={shouldDisable || !logins.includes('keycloak')} justifyContent="left" onClick={keycloakLogin}>
+                Login with Keycloak
+              </Button>
+            </ButtonGroup>
+          )}
 
           {/* Guest Auth Service */}
           <ButtonGroup isAttached size="lg" width="100%">

--- a/webstack/libs/backend/src/lib/generics/permissions.ts
+++ b/webstack/libs/backend/src/lib/generics/permissions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -28,6 +28,7 @@ const providerToRoleMap = {
   google: 'user',
   apple: 'user',
   jwt: 'user',
+  keycloak: 'user',
   spectator: 'spectator',
   guest: 'guest',
 };

--- a/webstack/libs/frontend/src/lib/providers/useAuth.tsx
+++ b/webstack/libs/frontend/src/lib/providers/useAuth.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -41,6 +41,14 @@ function appleLogin(): void {
 }
 
 /**
+ * Endpoint to login with Keycloak (or any configured OIDC provider)
+ */
+function keycloakLogin(): void {
+  // return to host with the same protocol (http/https)
+  window.location.replace(`${window.location.protocol}//${window.location.host}/auth/keycloak`);
+}
+
+/**
  * Endpoint to login with Guest
  */
 async function guestLogin(): Promise<void> {
@@ -58,7 +66,7 @@ async function guestLogin(): Promise<void> {
 }
 
 /**
- * Endpoint to login with Guest
+ * Endpoint to login with Spectator
  */
 async function spectatorLogin(): Promise<void> {
   const res = await fetch('/auth/spectator', {
@@ -118,6 +126,7 @@ type AuthenticatedType = {
   googleLogin: () => void;
   appleLogin: () => void;
   ciLogin: () => void;
+  keycloakLogin: () => void;
   guestLogin: () => Promise<void>;
   spectatorLogin: () => Promise<void>;
 };
@@ -140,6 +149,7 @@ export function AuthProvider(props: React.PropsWithChildren<Record<string, unkno
     googleLogin,
     appleLogin,
     ciLogin,
+    keycloakLogin,
     guestLogin,
     spectatorLogin,
   });
@@ -157,11 +167,12 @@ export function AuthProvider(props: React.PropsWithChildren<Record<string, unkno
           googleLogin,
           appleLogin,
           ciLogin,
+          keycloakLogin,
           guestLogin,
           spectatorLogin,
         });
       } else {
-        setAuth({ auth: null, verify, loading: false, expire: 0, logout, googleLogin, appleLogin, ciLogin, guestLogin, spectatorLogin });
+        setAuth({ auth: null, verify, loading: false, expire: 0, logout, googleLogin, appleLogin, ciLogin, keycloakLogin, guestLogin, spectatorLogin });
       }
     }
 

--- a/webstack/libs/sagebase/src/lib/modules/auth/SBAuth.ts
+++ b/webstack/libs/sagebase/src/lib/modules/auth/SBAuth.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -29,12 +29,14 @@ import {
   SBAuthCILogonConfig,
   passportSpectatorSetup,
   SBAuthSpectatorConfig,
+  passportKeycloakSetup,
+  SBAuthKeycloakConfig,
 } from './adapters/';
 
 export type SBAuthConfig = {
   sessionMaxAge: number;
   sessionSecret: string;
-  strategies: ('google' | 'apple' | 'cilogon' | 'guest' | 'jwt' | 'spectator')[];
+  strategies: ('google' | 'apple' | 'cilogon' | 'guest' | 'jwt' | 'spectator' | 'keycloak')[];
   production: boolean;
   googleConfig?: SBAuthGoogleConfig;
   appleConfig?: SBAuthAppleConfig;
@@ -42,6 +44,7 @@ export type SBAuthConfig = {
   guestConfig?: SBAuthGuestConfig;
   cilogonConfig?: SBAuthCILogonConfig;
   spectatorConfig?: SBAuthSpectatorConfig;
+  keycloakConfig?: SBAuthKeycloakConfig;
 };
 
 /**
@@ -226,6 +229,20 @@ export class SBAuth {
             }),
           );
           express.get(config.cilogonConfig.callbackURL, this.createOAuthCallbackHandler('cilogon', 'openidconnect'));
+        }
+      }
+
+      // Keycloak Setup (generic OIDC — works with any Keycloak realm or compatible provider)
+      if (config.strategies.includes('keycloak') && config.keycloakConfig) {
+        const ready = await passportKeycloakSetup(config.keycloakConfig);
+        if (ready) {
+          express.get(
+            config.keycloakConfig.routeEndpoint,
+            passport.authenticate('keycloak', {
+              scope: ['openid', 'email', 'profile'],
+            }),
+          );
+          express.get(config.keycloakConfig.callbackURL, this.createOAuthCallbackHandler('keycloak', 'keycloak'));
         }
       }
     }

--- a/webstack/libs/sagebase/src/lib/modules/auth/adapters/KeycloakAdapter.ts
+++ b/webstack/libs/sagebase/src/lib/modules/auth/adapters/KeycloakAdapter.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+import * as passport from 'passport';
+import { Issuer, custom } from 'openid-client';
+import { Strategy, VerifyCallback } from 'passport-openidconnect';
+
+import { SBAuthDB } from '../SBAuthDatabase';
+
+export type SBAuthKeycloakConfig = {
+  // Full issuer URL including realm, e.g.:
+  //   http://localhost:8080/realms/sage3
+  //   https://keycloak.example.com/realms/my-realm
+  // Keycloak exposes its OIDC discovery document at:
+  //   {issuerURL}/.well-known/openid-configuration
+  issuerURL: string;
+  clientID: string;
+  clientSecret?: string;
+  routeEndpoint: string;
+  callbackURL: string;
+};
+
+/**
+ * Setup function for the Keycloak Passport strategy.
+ *
+ * Uses OpenID Connect dynamic discovery — the same mechanism as CILogon —
+ * but with a configurable issuer URL so any Keycloak realm (or any other
+ * standards-compliant OIDC provider) can be used without code changes.
+ *
+ * @param config  Keycloak connection settings from sage3-dev.hjson
+ * @returns true on success, false if the discovery request fails
+ */
+export async function passportKeycloakSetup(config: SBAuthKeycloakConfig): Promise<boolean> {
+  // Use the same generous timeout as the CILogon adapter
+  custom.setHttpOptionsDefaults({ timeout: 10000 });
+
+  // Fetch OIDC metadata from Keycloak's well-known discovery endpoint.
+  // Keycloak automatically exposes this at {issuerURL}/.well-known/openid-configuration
+  const issuer = await Issuer.discover(config.issuerURL).catch((err) => {
+    console.log('Keycloak> Failed to fetch OIDC discovery document:', err);
+  });
+
+  if (!issuer) {
+    console.log('Keycloak> Setup failed — could not reach issuer at', config.issuerURL);
+    return false;
+  }
+
+  console.log('Keycloak> Discovered issuer:', issuer.issuer);
+
+  const oidcConfig = {
+    issuer: issuer.issuer,
+    authorizationURL: issuer.authorization_endpoint,
+    tokenURL: issuer.token_endpoint,
+    userInfoURL: issuer.userinfo_endpoint,
+    clientID: config.clientID,
+    callbackURL: config.callbackURL,
+  } as any;
+
+  if (config.clientSecret) oidcConfig.clientSecret = config.clientSecret;
+
+  // Register as 'keycloak' (not 'openidconnect') so this strategy can coexist
+  // with a simultaneously enabled CILogon strategy, which also uses passport-openidconnect
+  // but registers itself under the name 'openidconnect'.
+  passport.use(
+    'keycloak',
+    new Strategy(
+      oidcConfig,
+      async (_issuer: string, profile: passport.Profile, _context: unknown, _refreshToken: unknown, done: VerifyCallback) => {
+        const email = profile.emails ? profile.emails[0].value : '';
+        // Keycloak often populates displayName; fall back to the email prefix if not
+        const displayName = profile.displayName ? profile.displayName : email.split('@')[0];
+        const picture = profile.photos ? profile.photos[0].value : '';
+
+        const extras = {
+          displayName: displayName ?? '',
+          email: email ?? '',
+          picture: picture ?? '',
+        };
+
+        const authRecord = await SBAuthDB.findOrAddAuth('keycloak', profile.id, extras);
+        if (authRecord != undefined) {
+          done(null, authRecord);
+        } else {
+          done(null, false);
+        }
+      }
+    )
+  );
+
+  console.log('Keycloak> Setup done');
+  return true;
+}

--- a/webstack/libs/sagebase/src/lib/modules/auth/adapters/index.ts
+++ b/webstack/libs/sagebase/src/lib/modules/auth/adapters/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -12,3 +12,4 @@ export * from './JWTAdapter';
 export * from './CILoginAdapter';
 export * from './AppleAdapter';
 export * from './SpectatorAdapter';
+export * from './KeycloakAdapter';

--- a/webstack/libs/shared/src/lib/types/server/serverconfig.ts
+++ b/webstack/libs/shared/src/lib/types/server/serverconfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -114,8 +114,8 @@ export interface AuthConfiguration {
   sessionMaxAge: number;
   sessionSecret: string;
 
-  // List of login strategies: guest, google, jwt, cilogon, ...
-  strategies: ('google' | 'cilogon' | 'guest' | 'jwt')[];
+  // List of login strategies: guest, google, apple, jwt, cilogon, keycloak, spectator
+  strategies: ('google' | 'apple' | 'cilogon' | 'guest' | 'jwt' | 'keycloak' | 'spectator')[];
 
   // Admin users
   admins: string[];
@@ -140,6 +140,15 @@ export interface AuthConfiguration {
   };
   // CILogon credentials
   cilogonConfig?: {
+    clientID: string;
+    clientSecret?: string;
+    routeEndpoint: string;
+    callbackURL: string;
+  };
+  // Keycloak / generic OIDC credentials
+  keycloakConfig?: {
+    // Full Keycloak realm URL, e.g. https://keycloak.example.com/realms/sage3
+    issuerURL: string;
     clientID: string;
     clientSecret?: string;
     routeEndpoint: string;

--- a/webstack/sage3-dev.hjson
+++ b/webstack/sage3-dev.hjson
@@ -131,11 +131,12 @@
     "sessionSecret": "SUPERSECRET!!$$",
     // Max age for a session per user. In milliseconds. 8 days
     "sessionMaxAge": 691200000,
-    // Which login strategies to enable for the server. Available: guest, jwt, google, cilogon
-    // If you enbable them ensure you add the relevant config information below.
+    // Which login strategies to enable for the server. Available: guest, jwt, google, cilogon, keycloak
+    // If you enable them ensure you add the relevant config information below.
     "strategies": [
       "guest",
       "jwt",
+      "keycloak",
       "google" // "spectator"       // "cilogon"
     ],
     // A List of emails to enable those users to be admins.
@@ -182,6 +183,21 @@
       "routeEndpoint": "/auth/cilogon",
       // Callback URL for the cilogon login
       "callbackURL": "/auth/cilogon/redirect"
+    },
+    // Keycloak (or any OpenID Connect provider) configuration
+    // To test locally, run: docker run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:latest start-dev
+    // Then create a realm and client at http://localhost:8080, set redirect URI to http://localhost:3000/auth/keycloak/redirect
+    "keycloakConfig": {
+      // Full Keycloak realm URL — Keycloak will autodiscover all OIDC endpoints from this
+      "issuerURL": "http://localhost:8080/realms/sage3",
+      // Client ID created in the Keycloak realm
+      "clientID": "sage3-local",
+      // Client Secret (leave empty for public clients)
+      "clientSecret": "",
+      // Endpoint to initiate Keycloak login
+      "routeEndpoint": "/auth/keycloak",
+      // Must match the redirect URI configured in your Keycloak client
+      "callbackURL": "/auth/keycloak/redirect"
     }
   },
 


### PR DESCRIPTION
### Summary                                                                                                                                                   
                                                                                                                                                                
  Adds Keycloak as a login provider for SAGE3 server deployments. Keycloak is a self-hosted,                                                                    
  open-source identity server that speaks standard OpenID Connect — this means the implementation                                                               
  also works with any other OIDC-compliant provider (Okta, Auth0, Authentik, etc.) just by                                                                      
  changing the `issuerURL`.                                                                                                                                     
                                                                                                                                                                
  This is aimed at institutions that run their own identity infrastructure and cannot use Google
  or CILogon.

<img width="443" height="539" alt="Screenshot 2026-03-30 at 10 50 48 AM" src="https://github.com/user-attachments/assets/5e6bdaee-9dbe-4c26-bdd8-083fb97f778b" />
                                                                                                                                                                
  ---
                                                                                                                                                                
  ### What Changed                                          

  **New: `KeycloakAdapter.ts`**
  - Uses `openid-client` OIDC dynamic discovery (`Issuer.discover(issuerURL)`) — no hardcoded endpoint URLs needed
  - Registered under the strategy name `'keycloak'` (not `'openidconnect'`) so it can coexist with CILogon, which uses the same `passport-openidconnect` package
  - Falls back to the email prefix as `displayName` if Keycloak doesn't provide one
  - Returns `false` gracefully on startup if the Keycloak server is unreachable (other strategies continue working)                                             
                                                            
  **`SBAuth.ts`**                                                                                                                                               
  - Added Keycloak to the strategy union type, config type, and the strategy registration block
                                                                                                                                                                
  **`serverconfig.ts`**
  - Added `keycloakConfig` block to `AuthConfiguration`                                                                                                         
  - Fixed a pre-existing gap where `'apple'` and `'spectator'` were missing from the strategies union type
                                                                                                                                                                
  **`permissions.ts`** — Bug Fix
  - Added `keycloak: 'user'` to `providerToRoleMap`                                                                                                             
  - This map is the gate for all REST and WebSocket API calls — without this entry, Keycloak users could authenticate successfully but every subsequent API call
   returned 403, silently blocking account creation and all other actions                                                                                       
  
  **`useAuth.tsx`**                                                                                                                                             
  - Added `keycloakLogin()` function and wired it into the auth context
                                                                                                                                                                
  **`Login.tsx`**
  - Added Keycloak login button (gated on `logins.includes('keycloak')` from server config)                                                                     
  - Added Keycloak-specific error toast cases for OAuth error handling
  - Fixed pre-existing wrong `aria-label` on the CILogon button
                                                                                                                                                                
  **`sage3-dev.hjson`**
  - Added `keycloakConfig` block with a Docker test command in the comments for local development                                                               
                                                            
  ---

  ### Testing Locally

  Start a local Keycloak instance with Docker:                                                                                                                  
  
  ```bash                                                                                                                                                       
  docker run -p 8080:8080 \                                 
    -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
    -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \                                                                                                                      
    quay.io/keycloak/keycloak:latest start-dev
                                                                                                                                                                
  1. Open http://localhost:8080, create a realm named sage3                                                                                                     
  2. Create a client named sage3-local, set redirect URI to http://localhost:3000/auth/keycloak/redirect
  3. Enable keycloak in the strategies array in sage3-dev.hjson                                                                                                 
  4. Start SAGE3 — the Keycloak button will appear on the login page                                                                                            
  
  ---                                                                                                                                                           
  Notes                                                     
       
  - Each provider+email combination is an independent SAGE3 identity — a user with the same email
  on Keycloak and Google will have two separate accounts. This is by design and consistent with                                                                 
  how all other providers work.
  - Keycloak strategy startup is non-blocking: if the Keycloak server is unreachable at boot time,                                                              
  the strategy is skipped and the remaining login methods continue to function normally.          