### PR TITLE
[FIX] light mode for the logo in the login page

### DIFF
--- a/webstack/apps/webapp/src/app/pages/login/Login.tsx
+++ b/webstack/apps/webapp/src/app/pages/login/Login.tsx
@@ -320,7 +320,19 @@ export function LoginPage() {
   return (
     <Box display="flex" flexDir={'column'} justifyContent="center" alignItems="center" width="100%" height="100%" position="relative">
       <Box pb={'2rem'} alignItems="center">
-        <Image aspectRatio={2.55} width="20vw" minWidth="400px" maxWidth="35rem" src={logoUrl} alt="SAGE3 Logo" fit="contain" />
+        <Image
+          aspectRatio={2.55}
+          width="20vw"
+          minWidth="400px"
+          maxWidth="35rem"
+          // width="300px"
+          src={logoUrl}
+          alt="SAGE3 Logo"
+          fit="contain"
+          // background={colorMode === 'light' ? 'gray.800' : 'undefined'}
+          mixBlendMode={colorMode === 'light' ? 'difference' : 'normal'}
+          filter={colorMode === 'light' ? 'hue-rotate(200deg)' : 'none'}
+        />
       </Box>
 
       {/* Server Name */}


### PR DESCRIPTION
- Addresses #1348 
- Closes #1348 
- No change for dark mode

<img width="804" height="796" alt="Screenshot 2026-04-15 at 7 28 43 PM" src="https://github.com/user-attachments/assets/c11ef200-9f95-4850-a16c-518f7179167d" />
