### PR TITLE
[Perf] Optimization of drawing lines

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Line.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Line.tsx
@@ -11,7 +11,6 @@ import { useColorModeValue } from '@chakra-ui/react';
 import { getStroke } from 'perfect-freehand';
 import * as Y from 'yjs';
 
-
 import { useHexColor, useUserSettings, useAnnotationStore, useAppStore } from '@sage3/frontend';
 
 export interface LineProps {
@@ -23,7 +22,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
   const { settings } = useUserSettings();
   const primaryActionMode = settings.primaryActionMode;
 
-  const { points, color, isComplete, alpha, size, type, text } = useLine(line);
+  const { points, color, isComplete, alpha, size, type, text, cachedPath } = useLine(line);
 
   const c = useHexColor(color ? color : 'red');
   const hoverColor = useColorModeValue(`${color}.600`, `${color}.100`);
@@ -33,7 +32,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
 
   const handleTextChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
     line.set('text', ev.target.value);
-  }
+  };
 
   const handleClick = (ev: any) => {
     // Left-click while in eraser mode deletes this line/shape
@@ -67,23 +66,25 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
             stroke={hover ? hoverC : c}
             strokeOpacity={alpha ?? 0.6}
             strokeWidth={size ?? 5}
-            strokeLinejoin="miter"   // <-- sharp corners
-            strokeLinecap="butt"     // <-- flat line ends
+            strokeLinejoin="miter" // <-- sharp corners
+            strokeLinecap="butt" // <-- flat line ends
             shapeRendering="crispEdges"
             onMouseEnter={() => setHover(true)}
             onMouseLeave={() => setHover(false)}
             onMouseDown={handleClick}
           />
           <foreignObject x={minX} y={minY} width={maxX - minX} height={maxY - minY}>
-            <div style={{
-              width: '100%',
-              height: '100%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center'
-            }}>
+            <div
+              style={{
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
               <input
-                type='text'
+                type="text"
                 value={text}
                 style={{
                   width: '90%',
@@ -93,7 +94,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
                   color: c,
                   fontSize: '50px',
                   textAlign: 'center',
-                  outline: 'none'
+                  outline: 'none',
                 }}
                 onChange={handleTextChange}
               />
@@ -102,7 +103,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
         </g>
       );
     } catch (error) {
-      console.log(`${error}`)
+      console.log(`${error}`);
     }
   }
 
@@ -112,7 +113,10 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
     if (!points || points.length === 0) return null;
 
     // Compute bounding box from whatever points we have (robust to closed poly or 2-point form)
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
     for (const [x, y] of points) {
       if (x < minX) minX = x;
       if (y < minY) minY = y;
@@ -132,23 +136,25 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
           stroke={hover ? hoverC : c}
           strokeOpacity={alpha ?? 0.6}
           strokeWidth={size ?? 5}
-          strokeLinejoin="miter"   // Sharp corners
-          strokeLinecap="butt"     // Flat line ends
+          strokeLinejoin="miter" // Sharp corners
+          strokeLinecap="butt" // Flat line ends
           shapeRendering="crispEdges"
           onMouseEnter={() => setHover(true)}
           onMouseLeave={() => setHover(false)}
           onMouseDown={handleClick}
         />
         <foreignObject x={minX} y={minY} width={width} height={height}>
-          <div style={{
-            width: '100%',
-            height: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}>
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
             <input
-              type='text'
+              type="text"
               value={text}
               style={{
                 width: '90%',
@@ -158,7 +164,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
                 color: c,
                 fontSize: '50px',
                 textAlign: 'center',
-                outline: 'none'
+                outline: 'none',
               }}
               onChange={handleTextChange}
             />
@@ -167,20 +173,6 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
       </g>
     );
   }
-
-  // --- Render freehand lines with LESS rounding ----------------------------
-  // Use perfect-freehand to build the stroke outline, but:
-  //  - Lower smoothing and streamline to reduce roundness
-  //  - Build a polygonal path (M/L + Z) instead of quadratic curves
-  const strokeOutline = getStroke(points, {
-    size: size,
-    thinning: 0.35,     // a bit less 'brushy'
-    smoothing: 0.2,     // LOWER -> less rounding than your 0.6
-    streamline: 0.12,   // LOWER -> tracks pointer more tightly
-    last: isComplete,
-  });
-
-  const pathData = getSvgPathFromStrokePolygon(strokeOutline);
 
   if (type === 'arrow') {
     if (!points || points.length < 2) return null;
@@ -202,7 +194,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
               markerWidth="5"
               markerHeight="5"
               viewBox="0 0 10 10"
-              refX="5"   // place the tip (10,5) on the vertex
+              refX="5" // place the tip (10,5) on the vertex
               refY="5"
             >
               <path d="M0 0 L10 5 L0 10 Z" fill={hover ? hoverC : c} />
@@ -214,7 +206,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
             d={`M ${x1},${y1}, L ${x2},${y2}`}
             stroke={hover ? hoverC : c}
             strokeWidth={size}
-            strokeLinecap='round'
+            strokeLinecap="round"
             markerEnd={`url(#${x1},${y1},${x2},${y2})`}
             onMouseEnter={() => setHover(true)}
             onMouseLeave={() => setHover(false)}
@@ -223,7 +215,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
         </g>
       );
     } catch (e) {
-      console.log("Error rendering arrow:", e);
+      console.log('Error rendering arrow:', e);
     }
   }
 
@@ -247,7 +239,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
               markerWidth="5"
               markerHeight="5"
               viewBox="0 0 10 10"
-              refX="4"   // place the tip (10,5) on the vertex
+              refX="4" // place the tip (10,5) on the vertex
               refY="5"
             >
               <path d="M0 0 L10 5 L0 10 Z" fill={hover ? hoverC : c} />
@@ -259,7 +251,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
             d={`M ${x1},${y1}, L ${x2},${y2}`}
             stroke={hover ? hoverC : c}
             strokeWidth={size}
-            strokeLinecap='round'
+            strokeLinecap="round"
             markerEnd={`url(#${x1},${y1},${x2},${y2})`}
             markerStart={`url(#${x1},${y1},${x2},${y2})`}
             onMouseEnter={() => setHover(true)}
@@ -269,9 +261,22 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
         </g>
       );
     } catch (e) {
-      console.log("Error rendering double arrow:", e);
+      console.log('Error rendering double arrow:', e);
     }
   }
+
+  const pathData =
+    isComplete && cachedPath
+      ? cachedPath
+      : getSvgPathFromStrokePolygon(
+          getStroke(points, {
+            size: size,
+            thinning: 0.35, // a bit less 'brushy'
+            smoothing: 0.2, // LOWER -> less rounding than your 0.6
+            streamline: 0.12, // LOWER -> tracks pointer more tightly
+            last: isComplete,
+          })
+        );
 
   return (
     <g>
@@ -308,6 +313,7 @@ export function useLine(line: Y.Map<any>) {
   const [size, setSize] = useState<number>(5);
   const [type, setType] = useState<string>('line');
   const [text, setText] = useState<string>('');
+  const [cachedPath, setCachedPath] = useState<string>('');
 
   // Subscribe to changes to the line itself and sync into React state.
   useEffect(() => {
@@ -319,6 +325,7 @@ export function useLine(line: Y.Map<any>) {
       setSize(current.size);
       setType(current.type || 'line'); // read 'type' ('line' | 'rectangle')
       setText(current.text);
+      setCachedPath(current.cachedPath || '');
     }
 
     handleChange();
@@ -348,12 +355,12 @@ export function useLine(line: Y.Map<any>) {
     };
   }, [line]);
 
-  return { points: pts, color, isComplete, alpha, size, type, text };
+  return { points: pts, color, isComplete, alpha, size, type, text, cachedPath };
 }
 
 /**
  * Converts an array into an array of pairs by grouping consecutive elements.
- * 
+ *
  * @template T - The type of elements in the input array
  * @param arr - The input array to be converted into pairs
  * @returns An array of pairs, where each pair is a two-element array containing consecutive elements from the input array

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Line.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Line.tsx
@@ -38,7 +38,6 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
     // Left-click while in eraser mode deletes this line/shape
     if (ev.button === 0 && primaryActionMode === 'eraser') {
       onClick(id);
-      console.log(`LINE |click: primaryActionMode=${primaryActionMode}`);
     }
   };
 
@@ -275,7 +274,7 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
             smoothing: 0.2, // LOWER -> less rounding than your 0.6
             streamline: 0.12, // LOWER -> tracks pointer more tightly
             last: isComplete,
-          })
+          }),
         );
 
   return (

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -331,10 +331,7 @@ export function Whiteboard(props: WhiteboardProps) {
       if (type === 'line') {
         const nextPoint: [number, number] = [x, y];
         if (shouldAddPoint(current.points, nextPoint)) {
-          console.log(`Adding point: ${nextPoint[0]},${nextPoint[1]}`);
           current.points = [...current.points, nextPoint];
-        } else {
-          console.log(`          Skipping point: ${nextPoint[0]},${nextPoint[1]}`);
         }
         // current.points = [...current.points, [x, y]];
       } else if (type === 'rectangle' || type === 'circle' || type === 'arrow' || type === 'doubleArrow') {

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -679,6 +679,7 @@ function DraftLine({ line }: { line: DraftShape }) {
     smoothing: 0.2,
     streamline: 0.12,
     last: line.isComplete,
+    simulatePressure: false,
   });
 
   const pathData = getSvgPathFromStrokePolygon(strokeOutline);
@@ -687,10 +688,18 @@ function DraftLine({ line }: { line: DraftShape }) {
 
 function getSvgPathFromStrokePolygon(stroke: number[][]) {
   if (!stroke || stroke.length === 0) return '';
-  let d = `M${stroke[0][0].toFixed(1)},${stroke[0][1].toFixed(1)}`;
+  const xx = stroke[0][0];
+  const yy = stroke[0][1];
+  let cx = xx;
+  let cy = yy;
+  let d = `M${xx.toFixed(0)},${yy.toFixed(0)}`; // asbolute move to the first point
   for (let i = 1; i < stroke.length; i++) {
     const [x, y] = stroke[i];
-    d += ` L${x.toFixed(1)},${y.toFixed(1)}`;
+    const dx = x - cx; // relative line to the next point
+    const dy = y - cy;
+    d += ` l${dx.toFixed(1)},${dy.toFixed(1)}`;
+    cx = x;
+    cy = y;
   }
   d += ' Z';
   return d;

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -7,13 +7,13 @@
  */
 
 // This is a complete React component for the SAGE whiteboard.  It supports
-// drawing free‑hand lines and rectangles using pointer events.  Lines and
+// drawing free-hand lines and rectangles using pointer events.  Lines and
 // rectangles are stored in Yjs maps and synchronised with other users via
 // the SAGE annotation store.  Rectangles are drawn by clicking once to
 // set the first corner, dragging to the opposite corner, and releasing to
 // finalise the shape.  Lines are drawn by pressing down and moving.
 
-/* 
+/*
 <--------------------------------------------------------------------------------------------TODO-------------------------------------------------------------------------------------------->
 When making rectangle, thickness of marker does not reflect the 'start' point
 Implement circle drawing tool
@@ -21,9 +21,9 @@ Can't select and move lines/shapes
 <--------------------------------------------------------------------------------------------TODO-------------------------------------------------------------------------------------------->
 */
 
-
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as Simplify from 'simplify-js';
+import { getStroke } from 'perfect-freehand';
 
 // Yjs Imports
 import * as Y from 'yjs';
@@ -49,8 +49,30 @@ type WhiteboardProps = {
   roomId: string;
 };
 
+type DraftShape = {
+  id: string;
+  type: string;
+  points: [number, number][];
+  userColor: string;
+  alpha: number;
+  size: number;
+  isComplete: boolean;
+  userId?: string;
+  text: string;
+};
+
+const MIN_POINT_DISTANCE = 15; // Minimum distance in pixels between points in a freehand line to reduce density and improve performance
+
+function shouldAddPoint(points: [number, number][], next: [number, number]) {
+  const last = points[points.length - 1];
+  if (!last) return true;
+  const dx = next[0] - last[0];
+  const dy = next[1] - last[1];
+  return dx * dx + dy * dy >= MIN_POINT_DISTANCE * MIN_POINT_DISTANCE;
+}
+
 /**
- * Whiteboard component supporting free‑hand and rectangle drawing.
+ * Whiteboard component supporting free-hand and rectangle drawing.
  */
 export function Whiteboard(props: WhiteboardProps) {
   // Settings
@@ -91,8 +113,9 @@ export function Whiteboard(props: WhiteboardProps) {
   const [yDoc, setYdoc] = useState<Y.Doc | null>(null);
   const [yLines, setYlines] = useState<Y.Array<Y.Map<any>> | null>(null);
   const [lines, setLines] = useState<Y.Map<any>[]>([]);
-  const rCurrentLine = useRef<Y.Map<any>>();
+  const rCurrentLine = useRef<DraftShape>();
   const activeTouchCount = useRef(0);
+  const [draftLine, setDraftLine] = useState<DraftShape | null>(null);
 
   // Preview cursor state
   const [cursorPosition, setCursorPosition] = useState<{ x: number; y: number } | null>(null);
@@ -101,9 +124,8 @@ export function Whiteboard(props: WhiteboardProps) {
   const { dragProps, renderContent } = useDragAndDropBoard({ roomId: props.roomId, boardId: props.boardId });
 
   /**
-   * Persist the Yjs lines array to the SAGE annotation store.  Called after
-   * completing a stroke or clearing markers.  Only runs when yLines and
-   * boardId are defined.
+   * Persist the Yjs lines array to the SAGE annotation store. Called after
+   * completing a stroke or clearing markers.
    */
   function updateBoardLines() {
     if (yLines && props.boardId) {
@@ -113,42 +135,36 @@ export function Whiteboard(props: WhiteboardProps) {
   }
 
   /**
-   * Cancel and remove the in-progress stroke (if any).  Called when a second
+   * Cancel and remove the in-progress stroke (if any). Called when a second
    * touch finger arrives so the initial single-finger touch doesn't leave a
    * tiny dot behind during a pan/zoom gesture.
    */
   function cancelInProgressStroke() {
-    const current = rCurrentLine.current;
-    if (!current || !yLines) {
+    if (!rCurrentLine.current) {
       rCurrentLine.current = undefined;
       return;
     }
-    // Remove the incomplete shape from the Yjs array
-    const index = yLines.toArray().indexOf(current);
-    if (index >= 0) {
-      yLines.delete(index, 1);
-    }
     rCurrentLine.current = undefined;
+    setDraftLine(null);
     setCursorPosition(null);
   }
 
   /**
    * Convert pointer coordinates from client space to board space, accounting
-   * for board position and current scale.  Returns an array [x, y].
+   * for board position and current scale. Returns an array [x, y].
    */
   const getPoint = useCallback(
     (x: number, y: number) => {
       const localX = x / scale - boardPosition.x;
       const localY = y / scale - boardPosition.y;
-      return [localX, localY];
+      return [localX, localY] as [number, number];
     },
-    [boardPosition.x, boardPosition.y, scale]
+    [boardPosition.x, boardPosition.y, scale],
   );
 
   /**
-   * Yjs observer registration: whenever the Yjs array changes, update
-   * local React state.  This keeps the component in sync with remote
-   * collaborators.
+   * Yjs observer registration: whenever the Yjs array changes, update local
+   * React state. This keeps the component in sync with remote collaborators.
    */
   useEffect(() => {
     function handleChange() {
@@ -168,10 +184,7 @@ export function Whiteboard(props: WhiteboardProps) {
   }, [yLines]);
 
   /**
-   * Connect to the Yjs room and load persisted annotations.  On first
-   * connection (when the only user is the current one), clear any existing
-   * strokes and load those saved in the database.  Otherwise just hook
-   * into the Yjs doc.
+   * Connect to the Yjs room and load persisted annotations.
    */
   useEffect(() => {
     async function connectYjs(yRoom: YjsRoomConnection) {
@@ -182,23 +195,32 @@ export function Whiteboard(props: WhiteboardProps) {
       setYlines(yLinesArr);
       setLines(yLinesArr.toArray());
 
-      // If I'm the only user connected, sync lines from the DB
       const users = yRoom.provider.awareness.getStates();
       if (users.size === 1) {
         const dbLines = getAnnotations();
         if (dbLines && ydoc) {
-          // Clear the Yjs array
           yLinesArr.delete(0, yLinesArr.length);
-          // Push each persisted line/rectangle into the Yjs array
-          dbLines.data.whiteboardLines.forEach((line: any) => {
+          let didBackfillCachedPaths = false;
+          const serializedLines = dbLines.data.whiteboardLines.map((line: any) => {
+            if (line.type === 'line' && !line.cachedPath) {
+              const cachedPath = getCachedPathFromStoredLine(line.points, line.size);
+              if (cachedPath) {
+                didBackfillCachedPaths = true;
+                return { ...line, cachedPath };
+              }
+            }
+            return line;
+          });
+
+          serializedLines.forEach((line: any) => {
             const pts = new Y.Array<number>();
-            // If the persisted line stores points as nested arrays, push them
             pts.push(line.points);
             const yLine = new Y.Map<any>();
             ydoc.transact(() => {
               yLine.set('id', line.id);
               yLine.set('type', line.type ?? 'line');
               yLine.set('points', pts);
+              yLine.set('cachedPath', line.cachedPath);
               yLine.set('userColor', line.userColor);
               yLine.set('alpha', line.alpha);
               yLine.set('size', line.size);
@@ -208,8 +230,11 @@ export function Whiteboard(props: WhiteboardProps) {
             });
             yLinesArr.push([yLine]);
           });
-          // Update local state
           setLines(yLinesArr.toArray());
+
+          if (didBackfillCachedPaths) {
+            updateAnnotation(props.boardId, { whiteboardLines: serializedLines });
+          }
         }
       }
     }
@@ -224,32 +249,35 @@ export function Whiteboard(props: WhiteboardProps) {
     return () => {
       unsubAnnotations();
     };
-  }, [yAnnotations, props.boardId]);
+  }, [getAnnotations, props.boardId, subAnnotations, unsubAnnotations, updateAnnotation, yAnnotations]);
 
   /**
-   * Begin drawing a new stroke or rectangle on pointer down.  This function
-   * handles both pen and rectangle tools by examining primaryActionMode.  It
-   * creates a Yjs map with the appropriate metadata and stores the start
-   * coordinates in the points array.  It also captures the pointer so
-   * subsequent move/up events continue to target this element.
+   * Begin drawing a new stroke or shape on pointer down. The in-progress
+   * shape stays local so pointer moves do not update the shared Yjs array.
    */
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
-      // Track active touch pointers to distinguish between single-finger draw
-      // and multi-touch gestures (handled by BackgroundLayer for pan/zoom).
       if (e.pointerType === 'touch') {
         activeTouchCount.current += 1;
       }
 
-      // When a second finger arrives, cancel any in-progress stroke from the
-      // first finger so it doesn't leave a tiny dot behind.  Multi-touch is
-      // used for pan/zoom and should not create or modify strokes.
       if (e.pointerType === 'touch' && activeTouchCount.current > 1) {
         cancelInProgressStroke();
         return;
       }
-      // Determine type based on current tool
-      const type = primaryActionMode === 'rectangle' ? 'rectangle' : primaryActionMode === 'pen' ? 'line' : primaryActionMode === 'circle' ? 'circle' : primaryActionMode === 'arrow' ? 'arrow' : primaryActionMode === 'doubleArrow' ? 'doubleArrow' : 'eraser';
+
+      const type =
+        primaryActionMode === 'rectangle'
+          ? 'rectangle'
+          : primaryActionMode === 'pen'
+            ? 'line'
+            : primaryActionMode === 'circle'
+              ? 'circle'
+              : primaryActionMode === 'arrow'
+                ? 'arrow'
+                : primaryActionMode === 'doubleArrow'
+                  ? 'doubleArrow'
+                  : 'eraser';
       if (type === 'eraser') return;
       if (!yLines || !yDoc || !canAnnotate || !boardSynced) return;
       if (!e.isPrimary || e.button !== 0) return;
@@ -257,52 +285,39 @@ export function Whiteboard(props: WhiteboardProps) {
       const id = Date.now().toString();
       const [x0, y0] = getPoint(e.clientX, e.clientY);
 
-      // Capture pointer events
       e.currentTarget.setPointerCapture(e.pointerId);
 
-      // Prepare a shared Yjs array for storing points
-      const pts = new Y.Array<number>();
-      pts.push([x0, y0]);
-      // Circle needs to have at least two points to correctly render
-      // Extra point gets deleted when the pointer moves
-      if (type === 'circle' || type === 'arrow' || type === 'doubleArrow') {
-        pts.push([x0 + .000001, y0 + .000001]);
-      }
-      // Create a Yjs map for this shape
-      const yShape = new Y.Map();
+      const draft: DraftShape = {
+        id,
+        type,
+        points: [[x0, y0]],
+        userColor: color,
+        alpha: markerOpacity,
+        size: markerSize,
+        isComplete: false,
+        userId: user?._id,
+        text: '',
+      };
 
-      yDoc.transact(() => {
-        yShape.set('id', id);
-        yShape.set('type', type);
-        yShape.set('points', pts);
-        yShape.set('userColor', color);
-        yShape.set('alpha', markerOpacity);
-        yShape.set('size', markerSize);
-        yShape.set('isComplete', false);
-        yShape.set('userId', user?._id);
-        yShape.set('text', '');
-      });
-      rCurrentLine.current = yShape;
-      yLines.push([yShape]);
+      if (type === 'circle' || type === 'arrow' || type === 'doubleArrow') {
+        draft.points.push([x0 + 0.000001, y0 + 0.000001]);
+      }
+
+      rCurrentLine.current = draft;
+      setDraftLine(draft);
       setCursorPosition({ x: x0, y: y0 });
     },
-    [yLines, yDoc, canAnnotate, boardSynced, primaryActionMode, color, markerOpacity, markerSize, user, getPoint]
+    [boardSynced, canAnnotate, color, getPoint, markerOpacity, markerSize, primaryActionMode, user, yDoc, yLines],
   );
 
   /**
-   * Update the current stroke or rectangle on pointer move.  For lines, this
-   * simply appends each new point; for rectangles, it replaces the end point
-   * with the most recent coordinates.  The preview cursor is updated for
-   * all tools except eraser.
+   * Update the current stroke or shape on pointer move.
    */
   const handlePointerMove = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
       if (!rCurrentLine.current) return;
-      // For mouse / pen / touch we require an active pointer capture to avoid stray moves.
       if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
 
-      // If multiple touch points are active, cancel the in-progress stroke
-      // and delegate to background pan/zoom logic.
       if (e.pointerType === 'touch' && activeTouchCount.current > 1) {
         cancelInProgressStroke();
         return;
@@ -311,124 +326,83 @@ export function Whiteboard(props: WhiteboardProps) {
       setCursorPosition(primaryActionMode !== 'eraser' ? { x, y } : null);
 
       const current = rCurrentLine.current;
-      const type = current.get('type') as string;
-      const pts = current.get('points') as Y.Array<number>;
-      if (!pts) return;
+      const type = current.type;
 
       if (type === 'line') {
-        // Append new point for freehand line
-        pts.push([x, y]);
-      }
-      // use same logic to track circle and rectangle movements 
-      else if (type === 'rectangle' || type === 'circle' || type === 'arrow' || type === 'doubleArrow') {
-        // Replace the last end point (if exists) with the current coordinates
-        // A rectangle stores two points: start and current drag end
-        if (pts.length >= 4) {
-          pts.delete(2, 2);
+        const nextPoint: [number, number] = [x, y];
+        if (shouldAddPoint(current.points, nextPoint)) {
+          console.log(`Adding point: ${nextPoint[0]},${nextPoint[1]}`);
+          current.points = [...current.points, nextPoint];
+        } else {
+          console.log(`          Skipping point: ${nextPoint[0]},${nextPoint[1]}`);
         }
-        pts.push([x, y]);
-      }
-      else {
+        // current.points = [...current.points, [x, y]];
+      } else if (type === 'rectangle' || type === 'circle' || type === 'arrow' || type === 'doubleArrow') {
+        current.points = current.points.length > 1 ? [current.points[0], [x, y]] : [[x, y]];
+      } else {
         setCursorPosition(null);
       }
+      setDraftLine({ ...current, points: [...current.points] });
     },
-    [primaryActionMode, getPoint, rCurrentLine.current]
+    [getPoint, primaryActionMode],
   );
 
   /**
-   * Finalise the current stroke or rectangle on pointer up.  Lines are
-   * simplified via simplify-js for storage efficiency; rectangles are
-   * converted from start/end points into a closed polygon (five points,
-   * including the starting point repeated).  After finalisation, the
-   * shape is marked complete and persisted to the annotation store.
+   * Finalise the current stroke or shape on pointer up and commit once to Yjs.
    */
   const handlePointerUp = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
       if (e.pointerType === 'touch' && activeTouchCount.current > 0) {
         activeTouchCount.current -= 1;
       }
-      e.currentTarget.releasePointerCapture(e.pointerId);
+
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      }
+
       const current = rCurrentLine.current;
       if (!current) return;
 
-      const type = current.get('type') as string;
-      const pts = current.get('points') as Y.Array<number>;
-      if (!pts) {
-        rCurrentLine.current = undefined;
-        return;
-      }
+      const type = current.type;
+      let finalPoints = [...current.points];
+      let cachedPath = '';
 
       if (type === 'line') {
-        // Simplify freehand stroke
-        if (pts.length >= 4) {
-          const xyPoints: { x: number; y: number }[] = [];
-          for (let i = 0; i < pts.length / 2; i++) {
-            xyPoints.push({ x: pts.get(i * 2), y: pts.get(i * 2 + 1) });
-          }
-          // Simplify the stroke; tolerance 0.5, high quality
+        if (finalPoints.length >= 2) {
+          const xyPoints = finalPoints.map(([x, y]) => ({ x, y }));
           const simpler = Simplify.default(xyPoints, 0.5, true);
-          pts.delete(0, pts.length);
-          for (const p of simpler) {
-            pts.push([Math.round(p.x), Math.round(p.y)]);
-          }
+          finalPoints = simpler.map((p) => [Math.round(p.x), Math.round(p.y)] as [number, number]);
+          const strokeOutline = getStroke(finalPoints, {
+            size: current.size,
+            thinning: 0.35,
+            smoothing: 0.2,
+            streamline: 0.12,
+            last: true,
+          });
+          cachedPath = getSvgPathFromStrokePolygon(strokeOutline);
         }
-        current.set('isComplete', true);
       } else if (type === 'rectangle') {
-        // Finalise rectangle: convert two endpoints to a closed rectangle
-        // If the user never moved, remove the shape
-        if (pts.length < 4) {
-          // Remove incomplete rectangle
-          const index = yLines?.toArray().indexOf(current) ?? -1;
-          if (index >= 0 && yLines) {
-            yLines.delete(index, 1);
-          }
+        if (finalPoints.length < 2) {
+          finalPoints = [];
         } else {
-          const x0 = pts.get(0);
-          const y0 = pts.get(1);
-          const x1 = pts.get(2);
-          const y1 = pts.get(3);
-          // Determine top-left corner and dimensions【992428044196702†L130-L147】
+          const [[x0, y0], [x1, y1]] = finalPoints;
           const xMin = Math.min(x0, x1);
           const yMin = Math.min(y0, y1);
           const width = Math.abs(x1 - x0);
           const height = Math.abs(y1 - y0);
-          // Build a closed rectangle path: TL, TR, BR, BL, back to TL
-          const rectPoints = [
-            xMin,
-            yMin,
-            xMin + width,
-            yMin,
-            xMin + width,
-            yMin + height,
-            xMin,
-            yMin + height,
-            xMin,
-            yMin,
+          finalPoints = [
+            [xMin, yMin],
+            [xMin + width, yMin],
+            [xMin + width, yMin + height],
+            [xMin, yMin + height],
+            [xMin, yMin],
           ];
-          pts.delete(0, pts.length);
-          for (let i = 0; i < rectPoints.length; i += 2) {
-            pts.push([rectPoints[i], rectPoints[i + 1]]);
-          }
-          current.set('isComplete', true);
         }
-      }
-      else if (type === 'circle') {
-        if (pts.length < 4) {
-          try {
-            const index = yLines?.toArray().indexOf(current) ?? -1;
-            if (index >= 0 && yLines) {
-              yLines.delete(index, 1);
-            }
-          }
-          catch {
-            console.log(`array not long enough circle points: ${pts}`)
-          }
-        }
-        else {
-          const x0 = pts.get(0);
-          const y0 = pts.get(1);
-          const x1 = pts.get(2);
-          const y1 = pts.get(3);
+      } else if (type === 'circle') {
+        if (finalPoints.length < 2) {
+          finalPoints = [];
+        } else {
+          const [[x0, y0], [x1, y1]] = finalPoints;
           const maxX = Math.max(x0, x1);
           const minX = Math.min(x0, x1);
           const maxY = Math.max(y0, y1);
@@ -441,48 +415,41 @@ export function Whiteboard(props: WhiteboardProps) {
           const vert1y = cy + ry * Math.sin(Math.PI / 2);
           const vert2x = cx + rx * Math.cos((3 * Math.PI) / 2);
           const vert2y = cy + ry * Math.sin((3 * Math.PI) / 2);
-          const circlePoints = [
-            x0,
-            y0,
-            x1,
-            y1,
-            vert1x,
-            vert1y,
-            vert2x,
-            vert2y,
+          finalPoints = [
+            [x0, y0],
+            [x1, y1],
+            [vert1x, vert1y],
+            [vert2x, vert2y],
           ];
-          pts.delete(0, pts.length);
-          for (let i = 0; i < circlePoints.length; i += 2) {
-            pts.push([circlePoints[i], circlePoints[i + 1]]);
-          }
-          current.set('isComplete', true);
         }
+      } else if (type === 'arrow' || type === 'doubleArrow') {
+        finalPoints = finalPoints.length >= 2 ? [finalPoints[0], finalPoints[1]] : [];
       }
-      else if (type === 'arrow' || type === 'doubleArrow') {
-        console.log(type)
-        if (pts.length < 4) {
-          const index = yLines?.toArray().indexOf(current) ?? -1;
-          if (index >= 0 && yLines) {
-            yLines.delete(index, 1);
-          }
-        }
-        else {
-          const x0 = pts.get(0);
-          const y0 = pts.get(1);
-          const x1 = pts.get(2);
-          const y1 = pts.get(3);
-          const points = [x0, y0, x1, y1];
-          pts.delete(0, pts.length);
-          for (let i = 0; i < points.length; i += 2) {
-            pts.push([points[i], points[i + 1]]);
-          }
-          current.set('isComplete', true);
-        }
+
+      if (finalPoints.length > 0 && yDoc && yLines) {
+        const pts = new Y.Array<number>();
+        pts.push(finalPoints.flat());
+        const yShape = new Y.Map<any>();
+        yDoc.transact(() => {
+          yShape.set('id', current.id);
+          yShape.set('type', current.type);
+          yShape.set('points', pts);
+          yShape.set('cachedPath', cachedPath);
+          yShape.set('userColor', current.userColor);
+          yShape.set('alpha', current.alpha);
+          yShape.set('size', current.size);
+          yShape.set('isComplete', true);
+          yShape.set('userId', current.userId);
+          yShape.set('text', current.text);
+          yLines.push([yShape]);
+        });
+        updateBoardLines();
       }
-      updateBoardLines();
+
       rCurrentLine.current = undefined;
+      setDraftLine(null);
     },
-    [updateBoardLines, yLines]
+    [yDoc, yLines],
   );
 
   /**
@@ -494,7 +461,7 @@ export function Whiteboard(props: WhiteboardProps) {
       setClearAllMarkers(false);
       updateBoardLines();
     }
-  }, [clearAllMarkers]);
+  }, [clearAllMarkers, setClearAllMarkers, yLines]);
 
   /**
    * Effect for clearing only the current user's markers.
@@ -510,10 +477,10 @@ export function Whiteboard(props: WhiteboardProps) {
       updateBoardLines();
       setClearMarkers(false);
     }
-  }, [clearMarkers]);
+  }, [clearMarkers, setClearMarkers, user, yLines]);
 
   /**
-   * Effect for undoing the last marker (pen only).
+   * Effect for undoing the last marker.
    */
   useEffect(() => {
     if (yLines && undoLastMarker) {
@@ -527,7 +494,7 @@ export function Whiteboard(props: WhiteboardProps) {
       updateBoardLines();
       setUndoLastMarker(false);
     }
-  }, [undoLastMarker]);
+  }, [setUndoLastMarker, undoLastMarker, user, yLines]);
 
   /**
    * Remove a shape when clicked on.
@@ -546,7 +513,6 @@ export function Whiteboard(props: WhiteboardProps) {
     if (deleted) updateBoardLines();
   };
 
-  // Hotkeys: undo last line (Pen only)
   useHotkeys(
     'alt+z',
     () => {
@@ -554,8 +520,9 @@ export function Whiteboard(props: WhiteboardProps) {
         setUndoLastMarker(true);
       }
     },
-    { dependencies: [primaryActionMode] }
+    { dependencies: [primaryActionMode] },
   );
+
   useHotkeys(
     'cmd+z',
     () => {
@@ -563,19 +530,15 @@ export function Whiteboard(props: WhiteboardProps) {
         setUndoLastMarker(true);
       }
     },
-    { dependencies: [primaryActionMode] }
+    { dependencies: [primaryActionMode] },
   );
 
   return (
     <div
       className="canvas-container"
       style={{
-        pointerEvents: ['pen', 'eraser', 'rectangle', 'circle', 'arrow', 'doubleArrow'].includes(primaryActionMode)
-          ? 'auto'
-          : 'none',
-        touchAction: ['pen', 'eraser', 'rectangle', 'circle', 'arrow', 'doubleArrow'].includes(primaryActionMode)
-          ? 'none'
-          : 'auto',
+        pointerEvents: ['pen', 'eraser', 'rectangle', 'circle', 'arrow', 'doubleArrow'].includes(primaryActionMode) ? 'auto' : 'none',
+        touchAction: ['pen', 'eraser', 'rectangle', 'circle', 'arrow', 'doubleArrow'].includes(primaryActionMode) ? 'none' : 'auto',
       }}
     >
       <svg
@@ -588,17 +551,14 @@ export function Whiteboard(props: WhiteboardProps) {
           left: 0,
           top: 0,
           zIndex: 1000,
-        // Use a consistent crosshair cursor for all annotation tools
-        cursor: 'crosshair',
+          cursor: 'crosshair',
         }}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onTouchMove={(e) => {
-          // For touch events, delegate to handlePointerMove if only one finger
           if (e.touches.length === 1) {
             const touch = e.touches[0];
-            // Construct a synthetic pointer event-like object for coordinates
             handlePointerMove({
               ...e,
               clientX: touch.clientX,
@@ -612,11 +572,10 @@ export function Whiteboard(props: WhiteboardProps) {
         {...dragProps}
       >
         <g>
-          {/* Render all shapes */}
-          {lines.map((line, i) => (
-            <Line key={i} line={line} onClick={lineClicked} />
+          {lines.map((line) => (
+            <Line key={line.get('id') as string} line={line} onClick={lineClicked} />
           ))}
-          {/* Preview cursor for pen */}
+          {draftLine && <DraftLine line={draftLine} />}
           {cursorPosition && primaryActionMode === 'pen' && (
             <circle
               cx={cursorPosition.x}
@@ -634,4 +593,146 @@ export function Whiteboard(props: WhiteboardProps) {
       {renderContent()}
     </div>
   );
+}
+
+function DraftLine({ line }: { line: DraftShape }) {
+  const c = line.userColor;
+  const points = line.points;
+
+  if (line.type === 'rectangle') {
+    if (points.length < 2) return null;
+    const [[x0, y0], [x1, y1]] = points;
+    const minX = Math.min(x0, x1);
+    const minY = Math.min(y0, y1);
+    return (
+      <rect
+        x={minX}
+        y={minY}
+        width={Math.abs(x1 - x0)}
+        height={Math.abs(y1 - y0)}
+        fill="none"
+        stroke={c}
+        strokeOpacity={line.alpha ?? 0.6}
+        strokeWidth={line.size ?? 5}
+        strokeLinejoin="miter"
+        strokeLinecap="butt"
+        shapeRendering="crispEdges"
+      />
+    );
+  }
+
+  if (line.type === 'circle') {
+    if (points.length < 2) return null;
+    const [[x0, y0], [x1, y1]] = points;
+    const maxX = Math.max(x0, x1);
+    const minX = Math.min(x0, x1);
+    const maxY = Math.max(y0, y1);
+    const minY = Math.min(y0, y1);
+    return (
+      <ellipse
+        cx={(maxX + minX) / 2}
+        cy={(maxY + minY) / 2}
+        rx={(maxX - minX) / 2}
+        ry={(maxY - minY) / 2}
+        fill="none"
+        stroke={c}
+        strokeOpacity={line.alpha ?? 0.6}
+        strokeWidth={line.size ?? 5}
+        strokeLinejoin="miter"
+        strokeLinecap="butt"
+        shapeRendering="crispEdges"
+      />
+    );
+  }
+
+  if (line.type === 'arrow' || line.type === 'doubleArrow') {
+    if (points.length < 2) return null;
+    const [[x1, y1], [x2, y2]] = points;
+    const markerId = `draft-${line.type}-${line.id}`;
+    return (
+      <g opacity={line.alpha}>
+        <defs>
+          <marker
+            id={markerId}
+            orient={line.type === 'doubleArrow' ? 'auto-start-reverse' : 'auto'}
+            markerWidth="5"
+            markerHeight="5"
+            viewBox="0 0 10 10"
+            refX={line.type === 'doubleArrow' ? '4' : '5'}
+            refY="5"
+          >
+            <path d="M0 0 L10 5 L0 10 Z" fill={c} />
+          </marker>
+        </defs>
+        <path
+          d={`M ${x1},${y1}, L ${x2},${y2}`}
+          stroke={c}
+          strokeWidth={line.size}
+          strokeLinecap="round"
+          markerEnd={`url(#${markerId})`}
+          markerStart={line.type === 'doubleArrow' ? `url(#${markerId})` : undefined}
+        />
+      </g>
+    );
+  }
+
+  const strokeOutline = getStroke(points, {
+    size: line.size,
+    thinning: 0.35,
+    smoothing: 0.2,
+    streamline: 0.12,
+    last: line.isComplete,
+  });
+
+  const pathData = getSvgPathFromStrokePolygon(strokeOutline);
+  return <path className="canvas-line" d={pathData} fill={c} fillOpacity={line.alpha} />;
+}
+
+function getSvgPathFromStrokePolygon(stroke: number[][]) {
+  if (!stroke || stroke.length === 0) return '';
+  let d = `M${stroke[0][0].toFixed(1)},${stroke[0][1].toFixed(1)}`;
+  for (let i = 1; i < stroke.length; i++) {
+    const [x, y] = stroke[i];
+    d += ` L${x.toFixed(1)},${y.toFixed(1)}`;
+  }
+  d += ' Z';
+  return d;
+}
+
+function getCachedPathFromStoredLine(points: unknown, size: number | undefined) {
+  const normalizedPoints = normalizeStoredPoints(points);
+  if (normalizedPoints.length < 2) return '';
+
+  const strokeOutline = getStroke(normalizedPoints, {
+    size: size ?? 5,
+    thinning: 0.35,
+    smoothing: 0.2,
+    streamline: 0.12,
+    last: true,
+  });
+
+  return getSvgPathFromStrokePolygon(strokeOutline);
+}
+
+function normalizeStoredPoints(points: unknown): [number, number][] {
+  if (!Array.isArray(points)) return [];
+
+  if (points.length > 0 && Array.isArray(points[0])) {
+    return (points as unknown[])
+      .filter((point): point is [number, number] => {
+        return Array.isArray(point) && point.length >= 2 && typeof point[0] === 'number' && typeof point[1] === 'number';
+      })
+      .map((point) => [point[0], point[1]]);
+  }
+
+  const flatPoints = points as unknown[];
+  const normalized: [number, number][] = [];
+  for (let i = 0; i < flatPoints.length - 1; i += 2) {
+    const x = flatPoints[i];
+    const y = flatPoints[i + 1];
+    if (typeof x === 'number' && typeof y === 'number') {
+      normalized.push([x, y]);
+    }
+  }
+  return normalized;
 }


### PR DESCRIPTION
Summary 

Worked with Codex

Improves whiteboard annotation rendering performance by removing per-move Yjs writes for in-progress strokes and caching finalized freehand stroke geometry for reuse, including lazy backfill for older stored annotations.

Changes

- Refactored whiteboard drawing so in-progress annotations stay local to the client until pointer-up.
- Added a local draftLine preview path for active drawing instead of mutating the shared Yjs annotation array on every pointer move.
- Changed completed annotation insertion to commit once to Yjs on pointer-up.
- Switched rendered annotation keys from array indices to stable annotation ids.
- Added cached SVG path generation for completed freehand strokes (cachedPath) at commit time.
- Updated freehand rendering to reuse cachedPath for completed strokes instead of recomputing perfect-freehand geometry on every render.
- Preserved cachedPath when loading annotations from persisted board data.
- Added lazy backfill for existing stored freehand annotations that do not yet have cachedPath.
- Persisted backfilled caches back to annotation storage after load so subsequent board opens can use the fast path immediately.
- Added normalization for stored point formats so cache backfill works with both nested [x, y] pairs and flat coordinate arrays.
