### PR TITLE
feat: background grid visibility (hide with UI + dedicated toggle)

### DIFF
--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
@@ -68,9 +68,10 @@ export function Background(props: BackgroundProps) {
   const gc = useColorModeValue('gray.100', 'gray.700');
   const gridColor = useHexColor(gc);
 
-  // Hide the background grid when the UI is hidden
+  // Hide the background grid when the UI is hidden or the grid toggle is off
   const { settings } = useUserSettings();
   const showUI = settings.showUI;
+  const showGrid = settings.showGrid;
 
   // Subscribe to messages
   useEffect(() => {
@@ -207,7 +208,7 @@ export function Background(props: BackgroundProps) {
         height="100%"
         backgroundSize={'100px 100px'}
         bgImage={
-          showUI
+          showUI && showGrid
             ? `linear-gradient(to right, ${gridColor} ${1 / scale}px, transparent ${
                 1 / scale
               }px), linear-gradient(to bottom, ${gridColor} ${1 / scale}px, transparent ${1 / scale}px);`
@@ -234,7 +235,7 @@ export function Background(props: BackgroundProps) {
         <InteractionbarShortcuts />
       </Box>
     );
-  }, [gridColor, scale, showUI, dragProps, helpOnClose, helpIsOpen, renderContent]);
+  }, [gridColor, scale, showUI, showGrid, dragProps, helpOnClose, helpIsOpen, renderContent]);
 
   return MemoizedBoard;
 }

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
@@ -20,6 +20,7 @@ import {
   useCursorBoardPosition,
   setupApp,
   HelpModal,
+  useUserSettings,
 } from '@sage3/frontend';
 
 import { useDragAndDropBoard } from './DragAndDropBoard';
@@ -66,6 +67,10 @@ export function Background(props: BackgroundProps) {
   // Chakra Color Mode for grid color
   const gc = useColorModeValue('gray.100', 'gray.700');
   const gridColor = useHexColor(gc);
+
+  // Hide the background grid when the UI is hidden
+  const { settings } = useUserSettings();
+  const showUI = settings.showUI;
 
   // Subscribe to messages
   useEffect(() => {
@@ -117,7 +122,7 @@ export function Background(props: BackgroundProps) {
       return false;
     },
     // Depends on the cursor to get the correct position
-    { dependencies: [] }
+    { dependencies: [] },
   );
 
   // Move the board with the arrow keys
@@ -139,7 +144,7 @@ export function Background(props: BackgroundProps) {
       return false;
     },
     // Depends on the cursor to get the correct position
-    { dependencies: [selectedAppId, boardPosition.x, boardPosition.y] }
+    { dependencies: [selectedAppId, boardPosition.x, boardPosition.y] },
   );
 
   // Zoom in/out of the board with the -/+ keys
@@ -157,14 +162,14 @@ export function Background(props: BackgroundProps) {
       return false;
     },
     // Depends on the cursor to get the correct position
-    { dependencies: [selectedAppId] }
+    { dependencies: [selectedAppId] },
   );
 
   // Throttle stickie hotkey event
   const throttleStickieCreation = throttle(1000, (x: number, y: number) => {
     if (!user) return;
     createApp(
-      setupApp(user.data.name, 'Stickie', x, y, props.roomId, props.boardId, { w: 400, h: 420 }, { color: user.data.color || 'yellow' })
+      setupApp(user.data.name, 'Stickie', x, y, props.roomId, props.boardId, { w: 400, h: 420 }, { color: user.data.color || 'yellow' }),
     );
   });
   const throttleStickieCreationRef = useCallback(throttleStickieCreation, [user]);
@@ -191,7 +196,7 @@ export function Background(props: BackgroundProps) {
       }
     },
     // Depends on the cursor to get the correct position
-    { dependencies: [] }
+    { dependencies: [] },
   );
 
   const MemoizedBoard = useMemo(() => {
@@ -201,9 +206,13 @@ export function Background(props: BackgroundProps) {
         width="100%"
         height="100%"
         backgroundSize={'100px 100px'}
-        bgImage={`linear-gradient(to right, ${gridColor} ${1 / scale}px, transparent ${
-          1 / scale
-        }px), linear-gradient(to bottom, ${gridColor} ${1 / scale}px, transparent ${1 / scale}px);`}
+        bgImage={
+          showUI
+            ? `linear-gradient(to right, ${gridColor} ${1 / scale}px, transparent ${
+                1 / scale
+              }px), linear-gradient(to bottom, ${gridColor} ${1 / scale}px, transparent ${1 / scale}px);`
+            : 'none'
+        }
         id="board"
         userSelect={'none'}
         draggable={false}
@@ -225,7 +234,7 @@ export function Background(props: BackgroundProps) {
         <InteractionbarShortcuts />
       </Box>
     );
-  }, [gridColor, scale, dragProps, helpOnClose, helpIsOpen, renderContent]);
+  }, [gridColor, scale, showUI, dragProps, helpOnClose, helpIsOpen, renderContent]);
 
   return MemoizedBoard;
 }

--- a/webstack/libs/frontend/src/lib/providers/useUserSettings.tsx
+++ b/webstack/libs/frontend/src/lib/providers/useUserSettings.tsx
@@ -20,6 +20,7 @@ import { isElectron } from 'libs/applications/src/lib/apps/Cobrowse/util';
  * @property {boolean} showAppTitles - Indicates whether application titles should be displayed.
  * @property {'none'| 'selected' | 'all'} showLinks - Indicates whether provenance information should be displayed (arrows).
  * @property {boolean} showUI - Indicates whether the user interface should be displayed.
+ * @property {boolean} showGrid - Indicates whether the background grid should be displayed.
  * @property {boolean} showTags - Indicates whether tags should be displayed.
  * @property {'grid' | 'list'} selectedBoardListView - The view mode for the board list, either 'grid' or 'list'.
  * @property {'lasso' | 'grab' | 'pen' | 'eraser' | 'linker' | 'shape' | 'circle' | 'rectangle'} primaryActionMode - The primary action mode, which can be 'lasso', 'grab', 'pen', or 'eraser'.
@@ -31,6 +32,7 @@ type UserSettings = {
   showAppTitles: boolean;
   showLinks: 'none' | 'selected' | 'selected-path' | 'all';
   showUI: boolean;
+  showGrid: boolean;
   showTags: boolean;
   selectedBoardListView: 'grid' | 'list';
   primaryActionMode: 'lasso' | 'grab' | 'pen' | 'eraser' | 'linker' | 'shape' | 'circle' | 'rectangle' | 'arrow' | 'doubleArrow';
@@ -52,6 +54,7 @@ const defaultSettings: UserSettings = {
   showAppTitles: false,
   showLinks: 'all',
   showUI: true,
+  showGrid: true,
   showTags: false,
   selectedBoardListView: 'grid',
   primaryActionMode: 'lasso',
@@ -68,6 +71,7 @@ type UserSettingsContextType = {
   toggleShowAppTitles: () => void;
   setShowLinks: (value: UserSettings['showLinks']) => void;
   toggleShowUI: () => void;
+  toggleShowGrid: () => void;
   toggleShowTags: () => void;
   setBoardListView: (value: UserSettings['selectedBoardListView']) => void;
   setPrimaryActionMode: (value: UserSettings['primaryActionMode']) => void;
@@ -84,6 +88,7 @@ const UserSettingsContext = createContext<UserSettingsContextType>({
   toggleShowAppTitles: () => { },
   setShowLinks: (value: UserSettings['showLinks']) => { },
   toggleShowUI: () => { },
+  toggleShowGrid: () => { },
   toggleShowTags: () => { },
   setBoardListView: (value: UserSettings['selectedBoardListView']) => { },
   setPrimaryActionMode: (value: UserSettings['primaryActionMode']) => { },
@@ -171,6 +176,15 @@ export function UserSettingsProvider(props: React.PropsWithChildren<Record<strin
     setSettings((prev) => {
       const newSettings = { ...prev };
       newSettings.showUI = !prev.showUI;
+      setUserSettings(newSettings);
+      return newSettings;
+    });
+  }, [setSettings]);
+
+  const toggleShowGrid = useCallback(() => {
+    setSettings((prev) => {
+      const newSettings = { ...prev };
+      newSettings.showGrid = !prev.showGrid;
       setUserSettings(newSettings);
       return newSettings;
     });
@@ -269,6 +283,7 @@ export function UserSettingsProvider(props: React.PropsWithChildren<Record<strin
         toggleShowViewports,
         toggleShowAppTitles,
         toggleShowUI,
+        toggleShowGrid,
         setShowLinks,
         toggleShowTags,
         setBoardListView,

--- a/webstack/libs/frontend/src/lib/ui/components/modals/Alfred.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/Alfred.tsx
@@ -88,7 +88,7 @@ export function Alfred(props: props) {
   const config = useConfigStore((state) => state.config);
 
   // User Settings
-  const { toggleShowUI } = useUserSettings();
+  const { toggleShowUI, toggleShowGrid } = useUserSettings();
 
   // chakra color mode
   const { colorMode, toggleColorMode } = useColorMode();
@@ -139,8 +139,7 @@ export function Alfred(props: props) {
     if (appName === 'Timer') {
       w = 330;
       h = 226;
-    }
-    else if (appName === 'Clock') {
+    } else if (appName === 'Clock') {
       w = 320 * 1.5;
       h = 130 * 1.5;
     }
@@ -289,6 +288,8 @@ export function Alfred(props: props) {
         newApplication('SageCell');
       } else if (terms[0] === 'toggleui') {
         toggleShowUI();
+      } else if (terms[0] === 'togglegrid') {
+        toggleShowGrid();
       } else if (terms[0] === 'light') {
         if (colorMode !== 'light') toggleColorMode();
       } else if (terms[0] === 'dark') {
@@ -364,7 +365,7 @@ export function Alfred(props: props) {
         });
       }
     },
-    [user, apps, props.boardId, colorMode]
+    [user, apps, props.boardId, colorMode],
   );
 
   return (
@@ -439,7 +440,7 @@ function AlfredUI(props: AlfredUIProps): JSX.Element {
             // search in the owner name
             item.ownerName.toUpperCase().indexOf(term.toUpperCase()) !== -1
           );
-        })
+        }),
       );
     } else {
       // Full list if no search term
@@ -574,7 +575,6 @@ function AlfredUI(props: AlfredUIProps): JSX.Element {
     }
   }, [filteredList]);
 
-
   // Voice command
   const triggerVoice = () => {
     // Check if the browser supports speech recognition
@@ -639,7 +639,6 @@ function AlfredUI(props: AlfredUIProps): JSX.Element {
         blockScrollOnMount={false}
         scrollBehavior={'inside'}
         isCentered
-
       >
         <ModalOverlay />
         <ModalContent maxH={'30vh'} top={'4rem'} minWidth="800px">
@@ -665,9 +664,13 @@ function AlfredUI(props: AlfredUIProps): JSX.Element {
             </InputGroup>
 
             <Tooltip fontSize={'xs'} placement="top" hasArrow={true} label={'Voice to text - Click and speak'} openDelay={400}>
-              <Button p={0} m={'8px 0px 8px 0px'} disabled={!('webkitSpeechRecognition' in window)} onClick={triggerVoice}
-                colorScheme={recording ? 'red' : 'gray'}>
-
+              <Button
+                p={0}
+                m={'8px 0px 8px 0px'}
+                disabled={!('webkitSpeechRecognition' in window)}
+                onClick={triggerVoice}
+                colorScheme={recording ? 'red' : 'gray'}
+              >
                 {recording ? <MdStop size="24px" /> : <MdMic size="24px" />}
               </Button>
             </Tooltip>
@@ -679,7 +682,7 @@ function AlfredUI(props: AlfredUIProps): JSX.Element {
                   <MdInfoOutline fontSize={'24px'} />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent fontSize={'sm'} width={'300px'}>
+              <PopoverContent fontSize={'sm'} width={'310px'}>
                 <PopoverArrow />
                 <PopoverCloseButton />
                 <PopoverHeader>Quick Actions</PopoverHeader>
@@ -706,6 +709,9 @@ function AlfredUI(props: AlfredUIProps): JSX.Element {
                     </ListItem>
                     <ListItem>
                       <b>hideui</b> : Hide the panels
+                    </ListItem>
+                    <ListItem>
+                      <b>togglegrid</b> : Show/Hide the grid
                     </ListItem>
                     <ListItem>
                       <b>light</b> : Switch to light mode

--- a/webstack/libs/frontend/src/lib/ui/components/modals/EditUserSettingsModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/EditUserSettingsModal.tsx
@@ -71,6 +71,7 @@ export function EditUserSettingsModal(props: EditUserSettingsModalProps): JSX.El
     toggleShowViewports,
     toggleShowAppTitles,
     toggleShowUI,
+    toggleShowGrid,
     setShowLinks,
     toggleShowTags,
     setAIModel,
@@ -82,6 +83,7 @@ export function EditUserSettingsModal(props: EditUserSettingsModalProps): JSX.El
   const showViewports = userSettings.showViewports;
   const showAppTitles = userSettings.showAppTitles;
   const showUI = userSettings.showUI;
+  const showGrid = userSettings.showGrid;
   const showTags = userSettings.showTags;
   const showLinks = userSettings.showLinks;
   const uiScale = userSettings.uiScale;
@@ -196,6 +198,14 @@ export function EditUserSettingsModal(props: EditUserSettingsModalProps): JSX.El
                   </FormLabel>
 
                   <Switch id="other-cursors" colorScheme="teal" isChecked={showAppTitles} onChange={toggleShowAppTitles} />
+                </FormControl>
+
+                <FormControl display="flex" my="2" alignItems="center" justifyContent="space-between">
+                  <FormLabel htmlFor="hide-grid" mb="0">
+                    Background Grid
+                    <InfoTooltip label={'Show/Hide the background grid. Must enable User Interface.'} />
+                  </FormLabel>
+                  <Switch id="hide-grid" colorScheme="teal" isChecked={showGrid} onChange={toggleShowGrid} isDisabled={!showUI} />
                 </FormControl>
 
                 <FormControl display="flex" mt="2" alignItems="center" justifyContent="space-between">


### PR DESCRIPTION
## Summary

Addresses #1362

Gives users control over the board's background grid.

1. **Grid follows the UI.** When *Show User Interface* (`showUI`) is turned off, the grid is no longer drawn — matching the intent of hiding the panels for a clean presentation board. Previously, hiding the UI left the grid visible.

2. **Dedicated grid toggle.** A new `showGrid` setting lets users show/hide the grid independently, without hiding the rest of the UI.

## Changes

- **`useUserSettings.tsx`** — new `showGrid` setting (default `true`) with `toggleShowGrid`, context type, defaults, and provider wiring.
- **`EditUserSettingsModal.tsx`** — new "Background Grid" switch in the *Board Visibility* tab (disabled when the UI is hidden, like Tags/Links).
- **`Alfred.tsx`** — new `togglegrid` command + help-list entry.
- **`Background.tsx`** — grid `bgImage` renders only when `showUI && showGrid`; otherwise `none`.

## Behavior

| Show User Interface | Background Grid toggle | Grid |
|---|---|---|
| On  | On  | visible |
| On  | Off | hidden |
| Off | (either) | hidden |

The grid can be controlled from the *Board Visibility* settings tab or via Alfred's `togglegrid` command.

## Testing

- Verified locally: hiding the UI hides the grid; the *Background Grid* toggle shows/hides the grid while the UI stays visible; `togglegrid` in Alfred works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)