### PR TITLE
bug fixes

### DIFF
--- a/webstack/apps/homebase/src/api/routers/custom/kernels.ts
+++ b/webstack/apps/homebase/src/api/routers/custom/kernels.ts
@@ -52,8 +52,6 @@ export function KernelsRouter() {
 
   // selfHandleResponse: relay the upstream response ourselves
   proxy.on('proxyRes', (proxyRes: IncomingMessage, req: IncomingMessage, res: ServerResponse) => {
-    let data = '';
-
     // Only for SSE routes
     if ((req as Request).path.includes('stream')) {
       res.writeHead(200, {
@@ -61,14 +59,13 @@ export function KernelsRouter() {
         Connection: 'keep-alive',
         'Content-Type': 'text/event-stream',
       });
+      // Relay each chunk as it arrives. Do NOT also buffer and re-write on end,
+      // or the client receives the whole stream twice (duplicated SSE output).
       proxyRes.on('data', (chunk) => {
-        data += chunk;
         res.write(chunk);
-        // res.flush();
       });
 
       proxyRes.on('end', () => {
-        res.write(data);
         res.end();
       });
     } else {

--- a/webstack/apps/homebase/src/api/routers/custom/kernels.ts
+++ b/webstack/apps/homebase/src/api/routers/custom/kernels.ts
@@ -6,9 +6,11 @@
  * the file LICENSE, distributed as part of this software.
  */
 
-import { ClientRequest } from 'http';
-import { Request } from 'express';
-import { createProxyMiddleware } from 'http-proxy-middleware';
+import { ClientRequest, IncomingMessage, ServerResponse } from 'http';
+import { Socket } from 'net';
+import * as express from 'express';
+import { Request, Response } from 'express';
+import { createProxyServer } from 'http-proxy-3';
 
 import { config } from '../../../config';
 
@@ -32,47 +34,72 @@ const logger = {
 export function KernelsRouter() {
   console.log('Kernels> router for sage kernels', config.kernels.url);
 
-  const router = createProxyMiddleware({
+  // The router is mounted at /api/kernels, so Express strips that prefix and the
+  // proxy forwards req.url (e.g. /execute) onto the target — same effect as the
+  // previous pathRewrite of '^/api/kernels' -> ''.
+  const router = express.Router();
+
+  const proxy = createProxyServer({
     target: config.kernels.url,
     changeOrigin: true,
-    pathRewrite: { '^/api/kernels': '' },
-    logger: logger,
-    selfHandleResponse: true, // Add this to handle the response manually
-    // request handler making sure the body is parsed before proxying
-    on: {
-      proxyReq: restream,
-      proxyRes: (proxyRes, req, res) => {
-        let data = '';
+    selfHandleResponse: true, // handle the response manually
+  });
 
-        // Only for SSE routes
-        if (req.path.includes('stream')) {
-          res.writeHead(200, {
-            'Cache-Control': 'no-cache',
-            Connection: 'keep-alive',
-            'Content-Type': 'text/event-stream',
-          });
-          proxyRes.on('data', (chunk) => {
-            data += chunk;
-            res.write(chunk);
-            // res.flush();
-          });
+  // request handler making sure the body is parsed before proxying
+  proxy.on('proxyReq', (proxyReq: ClientRequest, req: IncomingMessage) => {
+    restream(proxyReq, req as Request);
+  });
 
-          proxyRes.on('end', () => {
-            res.write(data);
-            res.end();
-          });
-        } else {
-          // Handle other routes normally
-          proxyRes.on('data', (chunk) => {
-            res.write(chunk);
-          });
+  // selfHandleResponse: relay the upstream response ourselves
+  proxy.on('proxyRes', (proxyRes: IncomingMessage, req: IncomingMessage, res: ServerResponse) => {
+    let data = '';
 
-          proxyRes.on('end', () => {
-            res.end();
-          });
-        }
-      },
-    },
+    // Only for SSE routes
+    if ((req as Request).path.includes('stream')) {
+      res.writeHead(200, {
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream',
+      });
+      proxyRes.on('data', (chunk) => {
+        data += chunk;
+        res.write(chunk);
+        // res.flush();
+      });
+
+      proxyRes.on('end', () => {
+        res.write(data);
+        res.end();
+      });
+    } else {
+      // Handle other routes normally
+      proxyRes.on('data', (chunk) => {
+        res.write(chunk);
+      });
+
+      proxyRes.on('end', () => {
+        res.end();
+      });
+    }
+  });
+
+  proxy.on('error', (err: Error, _req: IncomingMessage, res: ServerResponse | Socket) => {
+    logger.error(err);
+    // Errors can come from HTTP proxying (ServerResponse) or a ws upgrade (Socket)
+    if (res instanceof ServerResponse) {
+      if (!res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'text/plain' });
+      }
+      res.end('Bad Gateway');
+    } else {
+      res.destroy();
+    }
+  });
+
+  // http-proxy-3's web() is callback/event-based; failures surface via the
+  // 'error' handler above rather than a rejected promise.
+  router.use((req: Request, res: Response) => {
+    proxy.web(req, res);
   });
 
   return router;

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/InteractionbarShortcuts.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/InteractionbarShortcuts.tsx
@@ -11,6 +11,20 @@ import { useUserSettings, useHotkeys, useUIStore, useKeyPress, useLinkStore } fr
 
 // keywords: interaction hotkeys
 
+// True when the user is typing into an editable element, so global single-key
+// shortcuts (1/2/3/4) must not fire. Covers plain inputs/textareas/contentEditable
+// and the Monaco code editor, whose focused element slips past hotkeys-js's
+// default form-tag filter (unlike the Stickie textarea, which it blocks).
+function isEditingTarget(): boolean {
+  const el = document.activeElement as HTMLElement | null;
+  if (!el) return false;
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (el.isContentEditable) return true;
+  if (el.closest && el.closest('.monaco-editor')) return true;
+  return false;
+}
+
 export function InteractionbarShortcuts() {
   // Settings
   const { settings, setPrimaryActionMode } = useUserSettings();
@@ -54,6 +68,7 @@ export function InteractionbarShortcuts() {
   useHotkeys(
     '1',
     (event: KeyboardEvent): void | boolean => {
+      if (isEditingTarget()) return;
       event.stopPropagation();
       setPrimaryActionMode('lasso');
       clearLinkAppId();
@@ -64,6 +79,7 @@ export function InteractionbarShortcuts() {
   useHotkeys(
     '2',
     (event: KeyboardEvent): void | boolean => {
+      if (isEditingTarget()) return;
       event.stopPropagation();
       setPrimaryActionMode('grab');
       setSelectedApp('');
@@ -75,6 +91,7 @@ export function InteractionbarShortcuts() {
   useHotkeys(
     '3',
     (event: KeyboardEvent): void | boolean => {
+      if (isEditingTarget()) return;
       event.stopPropagation();
       setPrimaryActionMode('pen');
       setSelectedApp('');
@@ -87,6 +104,7 @@ export function InteractionbarShortcuts() {
   useHotkeys(
     '4',
     (event: KeyboardEvent): void | boolean => {
+      if (isEditingTarget()) return;
       event.stopPropagation();
       setPrimaryActionMode('eraser');
       setSelectedApp('');

--- a/webstack/package.json
+++ b/webstack/package.json
@@ -67,7 +67,7 @@
     "highlight.js": "^11.10.0",
     "hjson": "^3.2.2",
     "hotkeys-js": "^3.10.0",
-    "http-proxy-middleware": "^3.0.5",
+    "http-proxy-3": "^1.23.3",
     "jsonwebtoken": "^9.0.2",
     "jszip": "^3.10.1",
     "ky": "^1.8.2",

--- a/webstack/yarn.lock
+++ b/webstack/yarn.lock
@@ -4975,7 +4975,7 @@
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
   integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
 
-"@types/http-proxy@^1.17.15", "@types/http-proxy@^1.17.8":
+"@types/http-proxy@^1.17.8":
   version "1.17.17"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.17.tgz#d9e2c4571fe3507343cb210cd41790375e59a533"
   integrity sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==
@@ -9618,6 +9618,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.15.11:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
+
 font-atlas@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/font-atlas/-/font-atlas-2.1.0.tgz#aa2d6dcf656a6c871d66abbd3dfbea2f77178348"
@@ -10465,6 +10470,14 @@ http-parser-js@>=0.5.1:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.10.tgz#b3277bd6d7ed5588e20ea73bf724fcbe44609075"
   integrity sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==
 
+http-proxy-3@^1.23.3:
+  version "1.23.3"
+  resolved "https://registry.yarnpkg.com/http-proxy-3/-/http-proxy-3-1.23.3.tgz#afdf6123fa878d47b3d47368d8412e7255cdeca0"
+  integrity sha512-zm8JCrJUwB3Rn0HJypwwDraljDt7YbF+r7Gz0exDRlaT8Yimjs5VRfwug1GrhoasMna1DjwHeEs48+iKxCozyA==
+  dependencies:
+    debug "^4.4.0"
+    follow-redirects "^1.16.0"
+
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
@@ -10492,18 +10505,6 @@ http-proxy-middleware@^2.0.3:
     is-glob "^4.0.1"
     is-plain-obj "^3.0.0"
     micromatch "^4.0.2"
-
-http-proxy-middleware@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz#9dcde663edc44079bc5a9c63e03fe5e5d6037fab"
-  integrity sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==
-  dependencies:
-    "@types/http-proxy" "^1.17.15"
-    debug "^4.3.6"
-    http-proxy "^1.18.1"
-    is-glob "^4.0.3"
-    is-plain-object "^5.0.0"
-    micromatch "^4.0.8"
 
 http-proxy@^1.18.1:
   version "1.18.1"


### PR DESCRIPTION
## Summary

Three independent bug fixes / chores, unrelated to the model-list refactor (PR #1322), grouped here so they can land on `dev` on their own.

## Changes

### 1. Replace unmaintained `http-proxy-middleware` with `http-proxy-3`
`webstack/apps/homebase/src/api/routers/custom/kernels.ts`, `package.json`, `yarn.lock`

The kernels proxy was the only consumer of `http-proxy-middleware`. Switch to `http-proxy-3` (a maintained fork of node-http-proxy with the same API and CJS + TypeScript types), wrapped in a small Express router. Behavior preserved: `changeOrigin`, `selfHandleResponse`, the SSE response relay, and the parsed-body restream. `pathRewrite` is dropped because the router mounts at `/api/kernels`, so Express already strips the prefix.

### 2. Kernel SSE stream output duplicated
`webstack/apps/homebase/src/api/routers/custom/kernels.ts`

The `stream` branch buffered every chunk into `data` **and** relayed each chunk as it arrived, then re-wrote the entire buffer on `end` — so clients received the whole event stream twice and notebook/SageCell streaming output rendered every message twice. Now it relays chunks only.

### 3. Interaction mode switches while typing in CodeEditor
`webstack/apps/webapp/src/app/pages/board/layers/ui/components/InteractionbarShortcuts.tsx`

The global `1`/`2`/`3`/`4` interaction-mode shortcuts fired while typing in the Monaco CodeEditor, whose focused element slips past `hotkeys-js`'s default form-tag filter (a plain Stickie `<textarea>` is correctly blocked). Each handler now checks `isEditingTarget()` and bails when focus is in an `input`/`textarea`/`select`, a `contentEditable` element, or a `.monaco-editor`.

## Testing

- SSE: kernel/notebook streaming output is no longer duplicated.
- Hotkeys: in CodeEditor, typing `1`/`2`/`3`/`4` inserts digits and does not switch interaction mode; on the empty board the shortcuts still switch modes; Stickie unchanged.
- Proxy: kernel routes (execute, stream, etc.) forward correctly via `http-proxy-3`.

## Notes

All three issues pre-existed on `dev` independent of the model-list work. The `http-proxy-3` swap and its SSE fix were extracted out of PR #1322 so that #1322 no longer touches `kernels.ts`/`package.json`/`yarn.lock` — there is no longer a merge conflict between the two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)