### PR TITLE
Improve large PDF processing and upload notifications

### DIFF
--- a/webstack/apps/homebase-files/src/api/assetsCollection.ts
+++ b/webstack/apps/homebase-files/src/api/assetsCollection.ts
@@ -47,6 +47,15 @@ class SAGE3AssetsCollection extends SAGE3Collection<AssetSchema> {
     UploadConnector.getInstance();
     // call the base class method
     await super.initialize(clear, ttl);
+    // This service owns the asset files on disk, but asset records are created
+    // and deleted by the main server. Subscribe to the shared ASSETS collection
+    // so that when a record is deleted (from any service), we remove its files
+    // (original upload + derived PDF pages / image sizes / extracted text / metadata).
+    await this.subscribeAll((message) => {
+      if (message.type === 'DELETE') {
+        this.deleteAssetFiles(message.doc.map((doc) => doc.data));
+      }
+    });
     // Upload files: POST /api/assets/upload
     this.router().post('/upload', uploadHandler);
     // Access to uploaded files: GET /api/assets/static/:filename
@@ -231,6 +240,35 @@ class SAGE3AssetsCollection extends SAGE3Collection<AssetSchema> {
     const assetIds = roomAssets ? roomAssets.map((asset) => asset._id) : [];
     const assetsDeleted = await this.deleteBatch(assetIds);
     return assetsDeleted ? assetsDeleted.length : 0;
+  }
+
+  /**
+   * Remove asset files from disk. Every file belonging to an asset is named after
+   * the original's UUID: "<uuid>.<ext>" (original), "<uuid>.<ext>.json" (metadata),
+   * and "<uuid>-...webp/.json" (rendered PDF pages, image sizes, extracted text).
+   * Best-effort: missing files are ignored and errors are logged, never thrown, so
+   * a filesystem problem can't block the (already committed) database delete.
+   */
+  private deleteAssetFiles(assets: AssetSchema[]): void {
+    if (assets.length === 0) return;
+    const dir = config.public;
+    // UUID basenames whose files should be removed (e.g. "<uuid>" from "<uuid>.pdf")
+    const bases = assets.map((a) => path.basename(a.file, path.extname(a.file)));
+    try {
+      if (!fs.existsSync(dir)) return;
+      for (const entry of fs.readdirSync(dir)) {
+        // "<uuid>." matches the original + metadata; "<uuid>-" matches derived files
+        if (bases.some((base) => entry.startsWith(`${base}.`) || entry.startsWith(`${base}-`))) {
+          try {
+            fs.unlinkSync(path.join(dir, entry));
+          } catch (err) {
+            console.warn('Assets> could not remove file', entry, err);
+          }
+        }
+      }
+    } catch (err) {
+      console.warn('Assets> failed to clean up asset files', err);
+    }
   }
 
   // Transfer all the assets of a user to another user

--- a/webstack/apps/homebase-files/src/api/assetsCollection.ts
+++ b/webstack/apps/homebase-files/src/api/assetsCollection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -187,14 +187,23 @@ class SAGE3AssetsCollection extends SAGE3Collection<AssetSchema> {
   /**
    * Process a file for conversion: pdf/image processing
    */
-  public async processFile(id: string, file: string, fileType: string) {
+  public async processFile(
+    id: string,
+    file: string,
+    fileType: string,
+    userId?: string,
+    originalFilename?: string,
+    uploadId?: string,
+    fileId?: string,
+    roomId?: string,
+  ) {
     let t2;
     // convert image to multiple sizes
     if (isImage(fileType) && !isGIF(fileType)) {
       t2 = await this.imgQ.addFile(id, file);
     } else if (isPDF(fileType)) {
       // convert PDF to images
-      t2 = await this.pdfQ.addFile(id, file).catch((err) => {
+      t2 = await this.pdfQ.addFile(id, file, userId, originalFilename, uploadId, fileId, roomId).catch((err) => {
         return Promise.reject(err);
       });
     }

--- a/webstack/apps/homebase-files/src/api/messageCollection.ts
+++ b/webstack/apps/homebase-files/src/api/messageCollection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -8,6 +8,17 @@
 
 import { MessageSchema } from '@sage3/shared/types';
 import { SAGE3Collection, sageRouter } from '@sage3/backend';
+
+type UploadMessageOptions = {
+  uploadId?: string;
+  fileId?: string;
+  roomId?: string;
+  assetId?: string;
+  filename?: string;
+  phase?: MessageSchema['phase'];
+  progress?: MessageSchema['progress'];
+  close?: boolean;
+};
 
 class SAGE3MessageCollection extends SAGE3Collection<MessageSchema> {
   constructor() {
@@ -18,3 +29,21 @@ class SAGE3MessageCollection extends SAGE3Collection<MessageSchema> {
 }
 
 export const MessageCollection = new SAGE3MessageCollection();
+
+export async function addUploadMessage(userId: string, payload: string, options: UploadMessageOptions = {}) {
+  return MessageCollection.add(
+    {
+      type: 'upload',
+      payload,
+      close: options.close || false,
+      uploadId: options.uploadId,
+      fileId: options.fileId,
+      roomId: options.roomId,
+      assetId: options.assetId,
+      filename: options.filename,
+      phase: options.phase,
+      progress: options.progress,
+    },
+    userId,
+  );
+}

--- a/webstack/apps/homebase-files/src/api/router.ts
+++ b/webstack/apps/homebase-files/src/api/router.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2025. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -25,7 +25,7 @@ export async function expressAPIRouter(): Promise<express.Router> {
   const router = express.Router();
 
   await AssetsCollection.initialize();
-  await MessageCollection.initialize();
+  await MessageCollection.initialize(true, 60);
 
   // Download the file from an Asset using a public route with a UUIDv5 token
   // route: /api/files/:id/:token

--- a/webstack/apps/homebase-files/src/api/uploadHandler.ts
+++ b/webstack/apps/homebase-files/src/api/uploadHandler.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -25,15 +25,17 @@ import { getFileType } from '@sage3/shared';
 import { UploadConnector } from '../connectors/upload-connector';
 // Asset model
 import { AssetsCollection } from './assetsCollection';
-import { MessageCollection } from './messageCollection';
+import { addUploadMessage } from './messageCollection';
 import { AssetSchema } from '@sage3/shared/types';
 
 // Google storage and AWS S3 storage
 // import { multerGoogleMiddleware, multerS3Middleware } from './middleware-upload';
 
 export async function uploadHandler(req: express.Request, res: express.Response) {
+  const uploadId = getUUID();
+  const headerRoomId = req.header('x-sage3-room') || undefined;
   // Signal the start of the upload
-  await MessageCollection.add({ type: 'upload', payload: `Uploading Assets`, close: false }, req.user.id);
+  await addUploadMessage(req.user.id, `Uploading Assets`, { uploadId, roomId: headerRoomId, phase: 'uploading' });
 
   return UploadConnector.getInstance().uploadMiddleware('files')(req, res, async (err) => {
     let hasError = false;
@@ -44,6 +46,7 @@ export async function uploadHandler(req: express.Request, res: express.Response)
       console.log('multerMiddleware>', err.message);
       hasError = true;
       processError = err.message;
+      await addUploadMessage(req.user.id, `Upload failed: ${processError}`, { uploadId, roomId: headerRoomId, phase: 'failed', close: true });
       return res.status(500).send(processError);
     }
     // destructure the request into an array of file objects
@@ -61,41 +64,91 @@ export async function uploadHandler(req: express.Request, res: express.Response)
 
     // Get the current uploader information
     const user = req.user as SBAuthSchema;
+    const roomId = req.body.room || headerRoomId || '-';
+    const messageRoomId = roomId === '-' ? undefined : roomId;
 
     // Signal the start of the processing
-    await MessageCollection.add({ type: 'upload', payload: `Processing Assets`, close: false }, user.id);
+    await addUploadMessage(user.id, `Processing Assets`, { uploadId, roomId: messageRoomId, phase: 'processing' });
 
     const newAssets: AssetSchema[] = [];
+    const newAssetMessages: { fileId: string; filename: string }[] = [];
     const newIds: string[] = [];
 
     // Do something with the files
     for await (const elt of files) {
+      let fileHasError = false;
       elt.originalname = decode8(elt.originalname);
       console.log('FileUpload>', elt.originalname, elt.mimetype, elt.filename, elt.size);
+      const fileMessageId = getUUID();
       // Normalize mime types using the mime package
       elt.mimetype = getFileType(elt.originalname) || elt.mimetype;
       // Put the new file into the collection
       const now = new Date().toISOString();
+      await addUploadMessage(user.id, `Processing ${elt.originalname}`, {
+        uploadId,
+        fileId: fileMessageId,
+        roomId: messageRoomId,
+        filename: elt.originalname,
+        phase: 'metadata',
+      });
       // Process the file for metadata
       const mdata = await AssetsCollection.metadataFile(getUUID(), elt.filename, elt.mimetype).catch((e) => {
-        processError = e.message as string;
+        processError = e instanceof Error ? e.message : String(e);
         hasError = true;
+        fileHasError = true;
         return;
       });
+      if (fileHasError) {
+        await addUploadMessage(user.id, `Processing failed for ${elt.originalname}: ${processError}`, {
+          uploadId,
+          fileId: fileMessageId,
+          roomId: messageRoomId,
+          filename: elt.originalname,
+          phase: 'failed',
+          close: true,
+        });
+        continue;
+      }
       // Process image and pdf
-      const pdata = await AssetsCollection.processFile(getUUID(), elt.filename, elt.mimetype).catch((e) => {
-        processError = e.message as string;
+      const pdata = await AssetsCollection.processFile(
+        getUUID(),
+        elt.filename,
+        elt.mimetype,
+        user.id,
+        elt.originalname,
+        uploadId,
+        fileMessageId,
+        messageRoomId,
+      ).catch((e) => {
+        processError = e instanceof Error ? e.message : String(e);
         hasError = true;
+        fileHasError = true;
         return;
       });
+      if (fileHasError) {
+        await addUploadMessage(user.id, `Processing failed for ${elt.originalname}: ${processError}`, {
+          uploadId,
+          fileId: fileMessageId,
+          roomId: messageRoomId,
+          filename: elt.originalname,
+          phase: 'failed',
+          close: true,
+        });
+        continue;
+      }
       if (mdata) {
-        // Signal the end of processing of the file
-        await MessageCollection.add({ type: 'process', payload: `Processing done for ${elt.originalname}`, close: false }, user.id);
+        await addUploadMessage(user.id, `Finalizing ${elt.originalname}`, {
+          uploadId,
+          fileId: fileMessageId,
+          roomId: messageRoomId,
+          filename: elt.originalname,
+          phase: 'processing',
+        });
         // Add the new file to a buffer
         newAssets.push({
           file: elt.filename,
           owner: user.id || '-',
-          room: req.body.room || '-',
+          room: roomId,
           originalfilename: elt.originalname,
           path: elt.path,
           destination: elt.destination,
@@ -105,6 +158,7 @@ export async function uploadHandler(req: express.Request, res: express.Response)
           derived: pdata || {},
           ...mdata,
         });
+        newAssetMessages.push({ fileId: fileMessageId, filename: elt.originalname });
       }
     }
 
@@ -114,15 +168,35 @@ export async function uploadHandler(req: express.Request, res: express.Response)
       // Collect the ids of the new files
       const ids = lots.map((l) => l._id);
       newIds.push(...ids);
+      for (const [index, lot] of lots.entries()) {
+        const fileMessage = newAssetMessages[index];
+        if (!fileMessage) continue;
+        await addUploadMessage(user.id, `Processing done for ${fileMessage.filename}`, {
+          uploadId,
+          fileId: fileMessage.fileId,
+          roomId: messageRoomId,
+          assetId: lot._id,
+          filename: fileMessage.filename,
+          phase: 'ready',
+          progress: { current: 1, total: 1, percent: 100, unit: 'files' },
+          close: true,
+        });
+      }
     }
 
-    // Signal the end of the processing
-    await MessageCollection.add({ type: 'upload', payload: `Assets Ready`, close: true }, user.id);
-
     if (hasError && processError) {
+      await addUploadMessage(user.id, `Upload failed: ${processError}`, { uploadId, roomId: messageRoomId, phase: 'failed', close: true });
       // Return error with the information
       res.status(500).send(processError);
     } else {
+      // Signal the end of the processing
+      await addUploadMessage(user.id, `Assets Ready`, {
+        uploadId,
+        roomId: messageRoomId,
+        phase: 'ready',
+        progress: { current: newIds.length, total: files.length, percent: 100, unit: 'files' },
+        close: true,
+      });
       // Return success with the ids of the new files
       res.status(200).send(newIds);
     }

--- a/webstack/apps/homebase-files/src/processors/processor-pdf.ts
+++ b/webstack/apps/homebase-files/src/processors/processor-pdf.ts
@@ -144,6 +144,21 @@ async function mapWithConcurrency<T>(count: number, concurrency: number, mapper:
   return results;
 }
 
+function getPDFResolutionOptions(maxWidth: number): { width: number; quality: number }[] {
+  const highWidth = Math.max(1, Math.floor(maxWidth));
+  const lowWidth = Math.max(1, Math.floor(highWidth / 2));
+
+  if (lowWidth === highWidth) {
+    return [{ width: highWidth, quality: 70 }];
+  }
+
+  // PDFs can have thousands of pages, so keep this to two variants per page.
+  return [
+    { width: highWidth, quality: 70 },
+    { width: lowWidth, quality: 75 },
+  ];
+}
+
 /**
  * Converting PDF to multiple resolutions using pdfjs and sharp
  *
@@ -310,15 +325,7 @@ async function pdfProcessing(job: any): Promise<ExtraPDFType> {
 
         canvasAndContext = canvasFactory.create(viewport.width, viewport.height);
 
-        const maxWidth = Math.floor(viewport.width);
-        // Maximum resolution
-        const options: { width: number; quality: number }[] = [{ width: maxWidth, quality: 70 }];
-        // Calculating downscale sizes down to 500pixel
-        let curW = Math.floor(maxWidth / 2);
-        while (curW > 500) {
-          options.push({ width: curW, quality: 75 });
-          curW = Math.floor(curW / 2);
-        }
+        const options = getPDFResolutionOptions(viewport.width);
 
         const renderContext = {
           canvasContext: canvasAndContext.context,

--- a/webstack/apps/homebase-files/src/processors/processor-pdf.ts
+++ b/webstack/apps/homebase-files/src/processors/processor-pdf.ts
@@ -144,19 +144,24 @@ async function mapWithConcurrency<T>(count: number, concurrency: number, mapper:
   return results;
 }
 
+// Fixed mid/thumbnail widths (px) added below the full render.
+const PDF_TIER_WIDTHS = [1000, 500];
+
 function getPDFResolutionOptions(maxWidth: number): { width: number; quality: number }[] {
-  const highWidth = Math.max(1, Math.floor(maxWidth));
-  const lowWidth = Math.max(1, Math.floor(highWidth / 2));
-
-  if (lowWidth === highWidth) {
-    return [{ width: highWidth, quality: 70 }];
+  const fullWidth = Math.max(1, Math.floor(maxWidth));
+  // Explicit tiers so every page yields a predictable set of sizes regardless of
+  // orientation. (Halving the width stopped after one step for portrait pages,
+  // whose width is the short edge, giving 2 tiers vs 3 for landscape.)
+  // The top tier is always the full render (keeps max quality); the fixed widths
+  // are added below it, skipping any that meet or exceed the full width so we
+  // never upscale or emit duplicate sizes.
+  const options: { width: number; quality: number }[] = [{ width: fullWidth, quality: 70 }];
+  for (const tierWidth of PDF_TIER_WIDTHS) {
+    if (tierWidth < fullWidth) {
+      options.push({ width: tierWidth, quality: 75 });
+    }
   }
-
-  // PDFs can have thousands of pages, so keep this to two variants per page.
-  return [
-    { width: highWidth, quality: 70 },
-    { width: lowWidth, quality: 75 },
-  ];
+  return options;
 }
 
 /**

--- a/webstack/apps/homebase-files/src/processors/processor-pdf.ts
+++ b/webstack/apps/homebase-files/src/processors/processor-pdf.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -13,6 +13,7 @@ import { strict as assert } from 'assert';
 
 // SAGEBase queue
 import { SBQueue } from '../connectors';
+import { addUploadMessage as addStructuredUploadMessage } from '../api/messageCollection';
 
 // PDF load legacy pdf build
 const pdfjs = require('pdfjs-dist/legacy/build/pdf.min.mjs');
@@ -21,13 +22,127 @@ pdfjs.GlobalWorkerOptions.workerSrc = './pdf.worker.min.mjs';
 // PDF fonts
 const CMAP_URL = './node_modules/pdfjs-dist/cmaps/';
 const FONT_URL = './node_modules/pdfjs-dist/standard_fonts/';
+const WASM_URL = './node_modules/pdfjs-dist/wasm/';
 const CMAP_PACKED = true;
+const DEFAULT_PDF_RENDER_CONCURRENCY = 1;
+const MAX_PDF_RENDER_CONCURRENCY = 8;
+const LARGE_PDF_PAGE_WARNING = 200;
+const PDF_PROGRESS_MIN_INTERVAL_MS = 5000;
 
 import { getStaticAssetUrl } from '@sage3/backend';
 import { ExtraPDFType } from '@sage3/shared/types';
 
 // Image processing tool
 import * as sharp from 'sharp';
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function getPDFRenderConcurrency(): number {
+  const configured = parsePositiveInteger(process.env.SAGE3_PDF_RENDER_CONCURRENCY);
+  return Math.min(configured || DEFAULT_PDF_RENDER_CONCURRENCY, MAX_PDF_RENDER_CONCURRENCY);
+}
+
+function getPDFMaxPages(): number | undefined {
+  return parsePositiveInteger(process.env.SAGE3_PDF_MAX_EAGER_PAGES);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function cleanupGeneratedPDFArtifacts(directory: string, filenameWithoutExt: string): void {
+  const generatedPagePattern = new RegExp(`^${escapeRegExp(filenameWithoutExt)}-\\d+-\\d+\\.webp$`);
+  const generatedTextFile = `${filenameWithoutExt}-text.json`;
+
+  try {
+    const files = fs.readdirSync(directory);
+    for (const file of files) {
+      if (generatedPagePattern.test(file) || file === generatedTextFile) {
+        try {
+          fs.unlinkSync(path.join(directory, file));
+        } catch (err) {
+          console.warn('PDF> failed to remove generated artifact', file, err);
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('PDF> failed to inspect generated artifacts for cleanup', err);
+  }
+}
+
+async function addUploadMessage(
+  userId: string | undefined,
+  payload: string,
+  options: {
+    uploadId?: string;
+    fileId?: string;
+    roomId?: string;
+    filename?: string;
+    phase?: 'uploading' | 'metadata' | 'processing' | 'rendering' | 'ready' | 'failed';
+    progress?: { current?: number; total?: number; percent?: number; unit?: 'files' | 'pages' | 'bytes' };
+    close?: boolean;
+  } = {},
+): Promise<void> {
+  if (!userId) return;
+  try {
+    await addStructuredUploadMessage(userId, payload, options);
+  } catch (err) {
+    console.warn('PDF> failed to send upload message', err);
+  }
+}
+
+function createPDFProgressReporter(
+  userId: string | undefined,
+  originalFilename: string,
+  totalPages: number,
+  uploadId: string | undefined,
+  fileId: string | undefined,
+  roomId: string | undefined,
+) {
+  let lastSentAt = 0;
+  let lastReportedPage = 0;
+  const filename = originalFilename || 'PDF';
+
+  return async (renderedPages: number, force = false) => {
+    const now = Date.now();
+    const isDone = renderedPages >= totalPages;
+    if (!force && !isDone && now - lastSentAt < PDF_PROGRESS_MIN_INTERVAL_MS) return;
+    if (!force && !isDone && renderedPages === lastReportedPage) return;
+
+    lastSentAt = now;
+    lastReportedPage = renderedPages;
+    const percent = totalPages > 0 ? Math.floor((renderedPages / totalPages) * 100) : 0;
+    await addUploadMessage(userId, `Rendering ${filename}: page ${renderedPages} of ${totalPages} (${percent}%)`, {
+      uploadId,
+      fileId,
+      roomId,
+      filename,
+      phase: renderedPages >= totalPages ? 'ready' : 'rendering',
+      progress: { current: renderedPages, total: totalPages, percent, unit: 'pages' },
+      close: renderedPages >= totalPages,
+    });
+  };
+}
+
+async function mapWithConcurrency<T>(count: number, concurrency: number, mapper: (index: number) => Promise<T>): Promise<T[]> {
+  const results = new Array<T>(count);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, count);
+
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < count) {
+      const currentIndex = nextIndex++;
+      results[currentIndex] = await mapper(currentIndex);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
 
 /**
  * Converting PDF to multiple resolutions using pdfjs and sharp
@@ -77,8 +192,8 @@ export class PDFProcessor {
    *
    * @memberOf TaskManager
    */
-  async addFile(id: string, filename: string) {
-    const job = await this.queue.addTask({ id, filename, pathname: this.output });
+  async addFile(id: string, filename: string, userId?: string, originalFilename?: string, uploadId?: string, fileId?: string, roomId?: string) {
+    const job = await this.queue.addTask({ id, filename, pathname: this.output, userId, originalFilename, uploadId, fileId, roomId });
     return job;
   }
 }
@@ -90,151 +205,234 @@ export class PDFProcessor {
  * @param filename {String} name of the file to be tested
  */
 async function pdfProcessing(job: any): Promise<ExtraPDFType> {
-  return new Promise((resolve, reject) => {
-    const filename: string = job.data.filename;
-    const pathname: string = path.join(job.data.pathname, filename);
-    const directory: string = job.data.pathname;
-    const filenameWithoutExt = filename.substring(0, filename.lastIndexOf('.'));
-    let pdfTask;
+  const filename: string = job.data.filename;
+  const pathname: string = path.join(job.data.pathname, filename);
+  const directory: string = job.data.pathname;
+  const filenameWithoutExt = filename.substring(0, filename.lastIndexOf('.'));
+  let pdfTask;
 
-    // @ts-ignore
-    // const canvasFactory = new NodeCanvasFactory();
+  // @ts-ignore
+  // const canvasFactory = new NodeCanvasFactory();
 
-    // Read the PDF file into a buffer
-    const data = new Uint8Array(fs.readFileSync(pathname));
+  // Read the PDF file into a buffer
+  const data = new Uint8Array(fs.readFileSync(pathname));
 
-    // Pass the data to the PDF.js library
-    try {
-      pdfTask = pdfjs.getDocument({
-        data,
-        // canvasFactory,
-        cMapUrl: CMAP_URL,
-        cMapPacked: CMAP_PACKED,
-        standardFontDataUrl: FONT_URL,
-      });
-    } catch (err) {
-      console.error('PDF> Error parsing file', err);
-      return reject(err);
+  // Pass the data to the PDF.js library
+  try {
+    pdfTask = pdfjs.getDocument({
+      data,
+      // canvasFactory,
+      cMapUrl: CMAP_URL,
+      cMapPacked: CMAP_PACKED,
+      standardFontDataUrl: FONT_URL,
+      wasmUrl: WASM_URL,
+      useWasm: true,
+    });
+  } catch (err) {
+    console.error('PDF> Error parsing file', err);
+    return Promise.reject(err);
+  }
+
+  // Array of pages
+  const allText: string[] = [];
+  const renderConcurrency = getPDFRenderConcurrency();
+  const maxPages = getPDFMaxPages();
+  const userId = job.data.userId as string | undefined;
+  const originalFilename = (job.data.originalFilename as string | undefined) || filename;
+  const uploadId = job.data.uploadId as string | undefined;
+  const fileId = job.data.fileId as string | undefined;
+  const roomId = job.data.roomId as string | undefined;
+  let completedPages = 0;
+  let pdf: any;
+
+  try {
+    pdf = await pdfTask.promise;
+
+    if (maxPages && pdf.numPages > maxPages) {
+      throw new Error(`PDF has ${pdf.numPages} pages, exceeding SAGE3_PDF_MAX_EAGER_PAGES=${maxPages}`);
     }
 
-    // Array of pages
-    const allText: string[] = [];
+    if (pdf.numPages > LARGE_PDF_PAGE_WARNING) {
+      console.log(`PDF> large document detected: ${pdf.numPages} pages, render concurrency ${renderConcurrency}`);
+    }
 
-    // Process each page
-    return pdfTask.promise
-      .then((pdf: any) => {
-        const arr = Array.from({ length: pdf.numPages }).map((_n, i) => {
-          return pdf.getPage(i + 1).then(async (page: any) => {
-            // Get the text content of the page
-            const text = await page.getTextContent();
-            let pageText = '';
-            for (let k = 0; k < text.items.length; k++) {
-              const item = text.items[k];
-              // Remove very small spaces
-              if (item.str === ' ' && item.width < 0.1) continue;
-              // Add the text
-              if (item.str) pageText += item.str;
-              // Add the end of line
-              if (item.hasEOL) pageText += '\n';
-            }
-            // Store the text into a page array
-            allText[i] = pageText;
+    await addUploadMessage(userId, `Rendering ${originalFilename}: 0 of ${pdf.numPages} pages`, {
+      uploadId,
+      fileId,
+      roomId,
+      filename: originalFilename,
+      phase: 'rendering',
+      progress: { current: 0, total: pdf.numPages, percent: 0, unit: 'pages' },
+    });
+    const reportProgress = createPDFProgressReporter(userId, originalFilename, pdf.numPages, uploadId, fileId, roomId);
 
-            // Instead of using a scaling factor, we try to get a given dimension
-            // on the long end (in pixels)
-            // Because different PDFs have different dimension defined (viewbox)
-            const desired = 2500;
-            const initialviewport = page.getViewport({ scale: 1 });
+    const renderPage = async (i: number): Promise<ExtraPDFType[number]> => {
+      let page;
+      let canvasAndContext;
+      const canvasFactory = pdf.canvasFactory;
 
-            // Calculate the scale
-            let scale = desired / initialviewport.width;
-            // If document is in portrait mode, we need to swap the dimensions
-            if (initialviewport.width < initialviewport.height) {
-              scale = desired / initialviewport.height;
-            }
-            // Limit the scale between 1 and 8
-            if (scale < 0) scale = 1;
-            if (scale > 8) scale = 8;
+      try {
+        page = await pdf.getPage(i + 1);
 
-            // Finally, get the viewport with the calculated scale
-            const viewport = page.getViewport({ scale: scale });
-            const canvasFactory = pdf.canvasFactory;
+        // Get the text content of the page
+        const text = await page.getTextContent();
+        let pageText = '';
+        for (let k = 0; k < text.items.length; k++) {
+          const item = text.items[k];
+          // Remove very small spaces
+          if (item.str === ' ' && item.width < 0.1) continue;
+          // Add the text
+          if (item.str) pageText += item.str;
+          // Add the end of line
+          if (item.hasEOL) pageText += '\n';
+        }
+        // Store the text into a page array
+        allText[i] = pageText;
 
-            const canvasAndContext = canvasFactory.create(viewport.width, viewport.height);
+        // Instead of using a scaling factor, we try to get a given dimension
+        // on the long end (in pixels)
+        // Because different PDFs have different dimension defined (viewbox)
+        const desired = 2500;
+        const initialviewport = page.getViewport({ scale: 1 });
 
-            const maxWidth = Math.floor(viewport.width);
-            // Maximum resolution
-            const options: { width: number; quality: number }[] = [{ width: maxWidth, quality: 70 }];
-            // Calculating downscale sizes down to 500pixel
-            let curW = Math.floor(maxWidth / 2);
-            while (curW > 500) {
-              options.push({ width: curW, quality: 75 });
-              curW = Math.floor(curW / 2);
-            }
+        // Calculate the scale
+        let scale = desired / initialviewport.width;
+        // If document is in portrait mode, we need to swap the dimensions
+        if (initialviewport.width < initialviewport.height) {
+          scale = desired / initialviewport.height;
+        }
+        // Limit the scale between 1 and 8
+        if (scale < 0) scale = 1;
+        if (scale > 8) scale = 8;
 
-            const renderContext = {
-              canvasContext: canvasAndContext.context,
-              viewport,
-            };
+        // Finally, get the viewport with the calculated scale
+        const viewport = page.getViewport({ scale: scale });
 
-            const renderResult = await page.render(renderContext).promise.then(async () => {
-              // Read the Image and pipe it into Sharp
+        canvasAndContext = canvasFactory.create(viewport.width, viewport.height);
 
-              // Get the buffer directly in PNG, low compression for speed
-              // const cdata = await canvasAndContext.canvas.toBuffer('png', {
-              //   compressionLevel: 1,
-              //   filters: canvasAndContext.canvas.PNG_FILTER_NONE,
-              // });
-              // const sharpStream = sharp(cdata, { failOnError: false });
+        const maxWidth = Math.floor(viewport.width);
+        // Maximum resolution
+        const options: { width: number; quality: number }[] = [{ width: maxWidth, quality: 70 }];
+        // Calculating downscale sizes down to 500pixel
+        let curW = Math.floor(maxWidth / 2);
+        while (curW > 500) {
+          options.push({ width: curW, quality: 75 });
+          curW = Math.floor(curW / 2);
+        }
 
-              // Round the dimensions to the nearest integer for sharp library
-              const vw = Math.floor(viewport.width);
-              const vh = Math.floor(viewport.height);
+        const renderContext = {
+          canvasContext: canvasAndContext.context,
+          viewport,
+        };
 
-              // Get RGBA buffer
-              const cdata = await canvasAndContext.context.getImageData(0, 0, vw, vh).data;
-              const sharpStream = sharp(cdata, { raw: { width: vw, height: vh, channels: 4 }, failOnError: false });
+        await page.render(renderContext).promise;
 
-              // Generate the WebP in multiple resolutions
-              return Promise.all<sharp.OutputInfo>([
-                // resize multiple versions based on the option set
-                ...options.map(({ width, quality }) =>
-                  sharpStream
-                    .clone()
-                    .resize({ width, kernel: 'lanczos2' })
-                    .webp({ quality, effort: 0 })
-                    .toFile(path.join(directory, `${filenameWithoutExt}-${i}-${width}.webp`)),
-                ),
-              ]);
-            });
-            // combine all the results for that page
-            return options.map(({ width }) => {
-              // information from sharp
-              const info = renderResult.find((r: any) => r.width === width);
-              // url of the page image
-              const url = getStaticAssetUrl(`${filenameWithoutExt}-${i}-${width}.webp`);
-              return { url, ...info };
-            });
-          });
+        // Read the Image and pipe it into Sharp
+
+        // Get the buffer directly in PNG, low compression for speed
+        // const cdata = await canvasAndContext.canvas.toBuffer('png', {
+        //   compressionLevel: 1,
+        //   filters: canvasAndContext.canvas.PNG_FILTER_NONE,
+        // });
+        // const sharpStream = sharp(cdata, { failOnError: false });
+
+        // Round the dimensions to the nearest integer for sharp library
+        const vw = Math.floor(viewport.width);
+        const vh = Math.floor(viewport.height);
+
+        // Get RGBA buffer
+        const cdata = await canvasAndContext.context.getImageData(0, 0, vw, vh).data;
+        const sharpStream = sharp(cdata, { raw: { width: vw, height: vh, channels: 4 }, failOnError: false });
+
+        // Generate the WebP in multiple resolutions
+        const renderResult = await Promise.all<sharp.OutputInfo>([
+          // resize multiple versions based on the option set
+          ...options.map(({ width, quality }) =>
+            sharpStream
+              .clone()
+              .resize({ width, kernel: 'lanczos2' })
+              .webp({ quality, effort: 0 })
+              .toFile(path.join(directory, `${filenameWithoutExt}-${i}-${width}.webp`)),
+          ),
+        ]);
+
+        // combine all the results for that page
+        return options.map(({ width }, optionIndex) => {
+          // information from sharp
+          const info = renderResult[optionIndex];
+          assert(info, `Missing rendered output for PDF page ${i + 1} at width ${width}`);
+          // url of the page image
+          const url = getStaticAssetUrl(`${filenameWithoutExt}-${i}-${width}.webp`);
+          return { url, ...info };
         });
-        return Promise.all(arr).then((pdfres) => {
-          // Get all the text data
-          const textdata = {
-            count: allText.length,
-            pages: allText,
-          };
-          // Save the text to a file
-          console.log('PDF> saving text content');
-          const f = job.data.filename;
-          const fn = path.join(job.data.pathname, path.basename(f, path.extname(f))) + '-text.json';
-          fs.writeFileSync(fn, JSON.stringify(textdata, null, 2));
-          // Return the result
-          console.log('PDF> processing done');
-          resolve(pdfres);
-        });
-      })
-      .catch((err: Error) => {
-        return reject(err);
-      });
-  });
+      } finally {
+        if (canvasAndContext && canvasFactory && typeof canvasFactory.destroy === 'function') {
+          try {
+            canvasFactory.destroy(canvasAndContext);
+          } catch (err) {
+            console.warn('PDF> canvas cleanup failed', err);
+          }
+        }
+        if (page && typeof page.cleanup === 'function') {
+          try {
+            page.cleanup();
+          } catch (err) {
+            console.warn('PDF> page cleanup failed', err);
+          }
+        }
+      }
+    };
+
+    const pdfres = await mapWithConcurrency(pdf.numPages, renderConcurrency, async (i) => {
+      const result = await renderPage(i);
+      completedPages++;
+      await reportProgress(completedPages);
+      return result;
+    });
+    // Get all the text data
+    const textdata = {
+      count: allText.length,
+      pages: allText,
+    };
+    // Save the text to a file
+    console.log('PDF> saving text content');
+    const f = job.data.filename;
+    const fn = path.join(job.data.pathname, path.basename(f, path.extname(f))) + '-text.json';
+    fs.writeFileSync(fn, JSON.stringify(textdata, null, 2));
+    // Return the result
+    console.log('PDF> processing done');
+    await reportProgress(completedPages, true);
+    return pdfres;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('PDF> processing failed', originalFilename, message);
+    cleanupGeneratedPDFArtifacts(directory, filenameWithoutExt);
+    await addUploadMessage(
+      userId,
+      `Rendering failed for ${originalFilename} after ${completedPages} page${completedPages === 1 ? '' : 's'}: ${message}`,
+      {
+        uploadId,
+        fileId,
+        roomId,
+        filename: originalFilename,
+        phase: 'failed',
+        progress: {
+          current: completedPages,
+          total: pdf?.numPages,
+          percent: pdf?.numPages ? Math.floor((completedPages / pdf.numPages) * 100) : undefined,
+          unit: 'pages',
+        },
+        close: true,
+      },
+    );
+    throw err;
+  } finally {
+    if (pdf && typeof pdf.destroy === 'function') {
+      try {
+        await pdf.destroy();
+      } catch (err) {
+        console.warn('PDF> document cleanup failed', err);
+      }
+    }
+  }
 }

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Background.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -7,7 +7,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Box, useColorModeValue, useToast, ToastId, useDisclosure } from '@chakra-ui/react';
+import { Box, useColorModeValue, useToast, useDisclosure } from '@chakra-ui/react';
 import { throttle } from 'throttle-debounce';
 
 import {
@@ -15,7 +15,6 @@ import {
   useAppStore,
   useUser,
   useHexColor,
-  useMessageStore,
   useHotkeys,
   useCursorBoardPosition,
   setupApp,
@@ -34,19 +33,11 @@ type BackgroundProps = {
 export function Background(props: BackgroundProps) {
   // display some notifications
   const toast = useToast();
-  // Handle to a toast
-  const toastIdRef = useRef<ToastId>();
   // Help modal
   const { isOpen: helpIsOpen, onOpen: helpOnOpen, onClose: helpOnClose } = useDisclosure();
 
   // Drag and Drop On Board
   const { dragProps, renderContent } = useDragAndDropBoard({ roomId: props.roomId, boardId: props.boardId });
-
-  // Messsages
-  const subMessage = useMessageStore((state) => state.subscribe);
-  const unsubMessage = useMessageStore((state) => state.unsubscribe);
-  const message = useMessageStore((state) => state.lastone);
-  // const messages = useMessageStore((state) => state.messages);
 
   // How to create some applications
   const createApp = useAppStore((state) => state.create);
@@ -72,45 +63,6 @@ export function Background(props: BackgroundProps) {
   const { settings } = useUserSettings();
   const showUI = settings.showUI;
   const showGrid = settings.showGrid;
-
-  // Subscribe to messages
-  useEffect(() => {
-    subMessage();
-    return () => {
-      unsubMessage();
-    };
-  }, []);
-
-  // Get the last new message
-  useEffect(() => {
-    if (!user) return;
-    if (!message) return;
-    if (message._createdBy === user._id) {
-      const title = message.data.type.charAt(0).toUpperCase() + message.data.type.slice(1);
-      // Update the toast if we can
-      if (toastIdRef.current && toast.isActive(toastIdRef.current)) {
-        toast.update(toastIdRef.current, {
-          title: title,
-          status: message.data.close ? 'info' : 'loading',
-          description: message.data.payload,
-          duration: message.data.close ? 5000 : null,
-          isClosable: true,
-        });
-      } else {
-        // or create a new one
-        toastIdRef.current = toast({
-          title: title,
-          description: message.data.payload,
-          status: message.data.close ? 'info' : 'loading',
-          duration: message.data.close ? 5000 : null,
-          isClosable: true,
-        });
-      }
-    } else if (message.data.type === 'upload' && message.data.payload === 'Assets Ready') {
-      // Update the asset store when someones uploads an asset
-      // useAssetStore.getState().update();
-    }
-  }, [message]);
 
   // Question mark character for help
   useHotkeys(

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/UILayer.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/UILayer.tsx
@@ -84,6 +84,7 @@ import {
   UsersMenu,
   AssetsMenu,
   EscapeApp,
+  UploadNotificationCenter,
 } from './components';
 
 type UILayerProps = {
@@ -509,6 +510,11 @@ export function UILayer(props: UILayerProps) {
       {/* The clock Top Right */}
       <Box position="absolute" right="1" top="1" backdropFilter="blur(5px)">
         <Clock isBoard={true} />
+      </Box>
+
+      {/* Upload notifications under the clock */}
+      <Box position="absolute" right="1" top="42px" zIndex="1000" display={showUI ? 'initial' : 'none'}>
+        <UploadNotificationCenter roomId={props.roomId} boardId={props.boardId} />
       </Box>
 
       {/* App Toolbar to show when the user selects an app */}

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Menus/Menus/Asset/Files.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/Menus/Menus/Asset/Files.tsx
@@ -332,7 +332,7 @@ export function Files(props: FilesProps): JSX.Element {
             // search in the owner name
             item.ownerName.toUpperCase().indexOf(term.toUpperCase()) !== -1
           );
-        })
+        }),
       );
     } else {
       // Full list if no search term

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/UploadNotificationCenter.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/UploadNotificationCenter.tsx
@@ -1,0 +1,400 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Box,
+  Button,
+  CloseButton,
+  Flex,
+  HStack,
+  IconButton,
+  Progress,
+  SlideFade,
+  Spinner,
+  Text,
+  VStack,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import { MdAdd, MdCheckCircle, MdChevronLeft, MdChevronRight, MdError, MdFileUpload } from 'react-icons/md';
+
+import { useAppStore, useAssetStore, useFiles, useMessageStore, useUIStore, useUser } from '@sage3/frontend';
+import { Message } from '@sage3/shared/types';
+
+type UploadNoticeStatus = 'loading' | 'success' | 'error' | 'info';
+
+type UploadNotice = {
+  id: string;
+  key: string;
+  uploadId?: string;
+  assetId?: string;
+  title: string;
+  description: string;
+  status: UploadNoticeStatus;
+  progress?: number;
+  close: boolean;
+  startedAt: number;
+  updatedAt: number;
+};
+
+type UploadNotificationCenterProps = {
+  roomId: string;
+  boardId: string;
+};
+
+function dismissedStorageKey(userId: string, roomId: string): string {
+  return `sage3-upload-notifications-dismissed:${userId}:${roomId}`;
+}
+
+function readDismissedKeys(userId: string | undefined, roomId: string): string[] {
+  if (!userId || typeof window === 'undefined') return [];
+  try {
+    const stored = window.localStorage.getItem(dismissedStorageKey(userId, roomId));
+    if (!stored) return [];
+    const keys = JSON.parse(stored);
+    return Array.isArray(keys) ? keys.filter((key) => typeof key === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeDismissedKeys(userId: string | undefined, roomId: string, keys: string[]) {
+  if (!userId || typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(dismissedStorageKey(userId, roomId), JSON.stringify(keys.slice(-200)));
+  } catch {
+    // Local storage is best-effort UI state.
+  }
+}
+
+function boundedPercent(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.min(100, value));
+}
+
+function extractProgress(payload: string): number | undefined {
+  const match = payload.match(/\((\d+)%\)/);
+  if (!match) return undefined;
+  const value = Number.parseInt(match[1], 10);
+  return boundedPercent(value);
+}
+
+function fileKeyFromPayload(payload: string): string | undefined {
+  if (payload === 'Uploading Assets' || payload === 'Processing Assets' || payload === 'Assets Ready') {
+    return undefined;
+  }
+
+  const patterns = [
+    /^Processing done for (.+)$/,
+    /^Processing failed for (.+?):/,
+    /^Processing (.+)$/,
+    /^Rendering failed for (.+?) after /,
+    /^Rendering (.+?):/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = payload.match(pattern);
+    if (match?.[1]) return match[1];
+  }
+  return undefined;
+}
+
+function statusFromPhase(phase: Message['data']['phase']): UploadNoticeStatus | undefined {
+  if (phase === 'failed') return 'error';
+  if (phase === 'ready') return 'success';
+  if (phase === 'uploading' || phase === 'metadata' || phase === 'processing' || phase === 'rendering') return 'loading';
+  return undefined;
+}
+
+function noticeFromMessage(message: Message, roomId: string): UploadNotice | null {
+  const { type, payload, close, uploadId, fileId, roomId: messageRoomId, assetId, filename, phase, progress } = message.data;
+  if (type !== 'upload' && type !== 'process') return null;
+  if (messageRoomId !== roomId) return null;
+
+  const fallbackFileKey = fileKeyFromPayload(payload);
+  const structuredFileKey = fileId || filename;
+  const fileKey = structuredFileKey || fallbackFileKey;
+  const status: UploadNoticeStatus =
+    statusFromPhase(phase) || (/failed/i.test(payload) ? 'error' : close || /done|ready/i.test(payload) ? 'success' : 'loading');
+
+  if (fileKey) {
+    return {
+      id: message._id,
+      key: `file:${fileKey}`,
+      uploadId,
+      assetId,
+      title: filename || fallbackFileKey || 'File',
+      description: payload,
+      status,
+      progress: boundedPercent(progress?.percent) ?? extractProgress(payload),
+      close,
+      startedAt: message._createdAt,
+      updatedAt: message._createdAt,
+    };
+  }
+
+  return {
+    id: message._id,
+    key: uploadId ? `upload:${uploadId}` : 'upload',
+    uploadId,
+    title: 'Upload',
+    description: payload,
+    status,
+    progress: boundedPercent(progress?.percent) ?? extractProgress(payload),
+    close,
+    startedAt: message._createdAt,
+    updatedAt: message._createdAt,
+  };
+}
+
+function StatusIcon(props: { status: UploadNoticeStatus }) {
+  if (props.status === 'loading') return <Spinner size="xs" />;
+  if (props.status === 'error') return <MdError size="16px" />;
+  if (props.status === 'success') return <MdCheckCircle size="16px" />;
+  return <MdFileUpload size="16px" />;
+}
+
+export function UploadNotificationCenter(props: UploadNotificationCenterProps) {
+  const { user } = useUser();
+  const subscribe = useMessageStore((state) => state.subscribe);
+  const unsubscribe = useMessageStore((state) => state.unsubscribe);
+  const messages = useMessageStore((state) => state.messages);
+  const updateAssets = useAssetStore((state) => state.update);
+  const createApp = useAppStore((state) => state.create);
+  const { openAppForFile } = useFiles();
+  const [dismissedKeys, setDismissedKeys] = useState<string[]>([]);
+  const [isOpen, setIsOpen] = useState(true);
+  const [creatingKeys, setCreatingKeys] = useState<string[]>([]);
+  const previousNoticeKeysRef = useRef<Set<string> | null>(null);
+
+  const bg = useColorModeValue('whiteAlpha.900', 'gray.800');
+  const border = useColorModeValue('gray.200', 'whiteAlpha.300');
+  const muted = useColorModeValue('gray.600', 'gray.300');
+  const rowHover = useColorModeValue('gray.50', 'whiteAlpha.100');
+  const headerBg = useColorModeValue('gray.50', 'whiteAlpha.100');
+
+  useEffect(() => {
+    if (!user) return;
+    subscribe();
+    return () => {
+      unsubscribe();
+    };
+  }, [subscribe, unsubscribe, user?._id]);
+
+  useEffect(() => {
+    setDismissedKeys(readDismissedKeys(user?._id, props.roomId));
+    previousNoticeKeysRef.current = null;
+  }, [props.roomId, user?._id]);
+
+  useEffect(() => {
+    writeDismissedKeys(user?._id, props.roomId, dismissedKeys);
+  }, [dismissedKeys, props.roomId, user?._id]);
+
+  useEffect(() => {
+    setDismissedKeys((keys) => {
+      if (!user || keys.length === 0) return keys;
+      const activeKeys = new Set<string>();
+      for (const message of messages) {
+        if (message._createdBy !== user._id) continue;
+        const notice = noticeFromMessage(message, props.roomId);
+        if (notice) activeKeys.add(notice.key);
+      }
+      const nextKeys = keys.filter((key) => activeKeys.has(key) || key.startsWith('file:') || key.startsWith('upload:'));
+      return nextKeys.length === keys.length ? keys : nextKeys;
+    });
+  }, [messages, props.roomId, user]);
+
+  const notices = useMemo(() => {
+    const byKey = new Map<string, UploadNotice>();
+    const uploadIdsWithFileMessages = new Set<string>();
+    let hasLegacyFileMessage = false;
+
+    for (const message of messages) {
+      if (!user || message._createdBy !== user._id) continue;
+      const notice = noticeFromMessage(message, props.roomId);
+      if (!notice) continue;
+      if (notice.key.startsWith('file:')) {
+        hasLegacyFileMessage = true;
+        if (notice.uploadId) uploadIdsWithFileMessages.add(notice.uploadId);
+      }
+      if (dismissedKeys.includes(notice.key)) continue;
+
+      const existing = byKey.get(notice.key);
+      if (!existing || notice.updatedAt >= existing.updatedAt) {
+        byKey.set(notice.key, {
+          ...notice,
+          assetId: notice.assetId || existing?.assetId,
+          startedAt: existing ? Math.min(existing.startedAt, notice.startedAt) : notice.startedAt,
+        });
+      }
+    }
+
+    const groupedNotices = Array.from(byKey.values());
+
+    // Keep file-level cards as the source of truth once they exist, even if the user dismisses them.
+    return groupedNotices
+      .filter((notice) => {
+        const isUploadNotice = notice.key === 'upload' || notice.key.startsWith('upload:');
+        if (!isUploadNotice) return true;
+        if (notice.uploadId) return !uploadIdsWithFileMessages.has(notice.uploadId);
+        return !hasLegacyFileMessage;
+      })
+      .sort((a, b) => a.startedAt - b.startedAt)
+      .slice(0, 8);
+  }, [dismissedKeys, messages, props.roomId, user]);
+
+  useEffect(() => {
+    const currentKeys = new Set(notices.map((notice) => notice.key));
+    const previousKeys = previousNoticeKeysRef.current;
+    if (!previousKeys) {
+      if (notices.some((notice) => notice.status === 'loading')) setIsOpen(true);
+      previousNoticeKeysRef.current = currentKeys;
+      return;
+    }
+
+    if (notices.some((notice) => notice.status === 'loading' && !previousKeys.has(notice.key))) {
+      setIsOpen(true);
+    }
+    previousNoticeKeysRef.current = currentKeys;
+  }, [notices]);
+
+  const dismissNotice = useCallback((key: string) => {
+    setDismissedKeys((keys) => (keys.includes(key) ? keys : [...keys, key]));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setDismissedKeys((keys) => Array.from(new Set([...keys, ...notices.map((notice) => notice.key)])));
+    setIsOpen(false);
+  }, [notices]);
+
+  const handleCreateApp = useCallback(
+    async (notice: UploadNotice) => {
+      if (!notice.assetId || creatingKeys.includes(notice.key)) return;
+      setCreatingKeys((keys) => [...keys, notice.key]);
+      try {
+        await updateAssets(props.roomId);
+        const ui = useUIStore.getState();
+        const x = Math.floor(-ui.boardPosition.x + window.innerWidth / ui.scale / 2);
+        const y = Math.floor(-ui.boardPosition.y + window.innerHeight / ui.scale / 2);
+        const app = await openAppForFile(notice.assetId, x, y, props.roomId, props.boardId);
+        if (app) await createApp(app);
+      } finally {
+        setCreatingKeys((keys) => keys.filter((key) => key !== notice.key));
+      }
+    },
+    [createApp, creatingKeys, openAppForFile, props.boardId, props.roomId, updateAssets],
+  );
+
+  if (!user) return null;
+
+  return (
+    <Flex align="flex-start" justify="flex-end" gap={1} pointerEvents="auto">
+      <IconButton
+        aria-label={isOpen ? 'Hide upload notifications' : 'Show upload notifications'}
+        icon={isOpen ? <MdChevronRight /> : <MdChevronLeft />}
+        size="sm"
+        minW="28px"
+        width="28px"
+        height="32px"
+        mt={1}
+        bg={bg}
+        border="1px solid"
+        borderColor={border}
+        boxShadow="md"
+        onClick={() => setIsOpen((open) => !open)}
+      />
+      <SlideFade in={isOpen} offsetX="20px" unmountOnExit>
+        <Box
+          bg={bg}
+          border="1px solid"
+          borderColor={border}
+          borderRadius="md"
+          boxShadow="md"
+          overflow="hidden"
+          width={{ base: 'min(88vw, 380px)', md: '380px' }}
+        >
+          <HStack px={3} py={2} bg={headerBg} borderBottom="1px solid" borderColor={border} justify="space-between">
+            <Text fontSize="sm" fontWeight="semibold">
+              Uploads
+            </Text>
+            <Button size="xs" variant="ghost" onClick={clearAll}>
+              Clear All
+            </Button>
+          </HStack>
+          {notices.length === 0 ? (
+            <Box px={3} py={3}>
+              <Text fontSize="xs" color={muted}>
+                No uploads
+              </Text>
+            </Box>
+          ) : (
+            <VStack align="stretch" spacing={0} maxH="min(54vh, 440px)" overflowY="auto">
+              {notices.map((notice) => (
+                <Box
+                  key={notice.key}
+                  px={3}
+                  py={2}
+                  borderBottom="1px solid"
+                  borderColor={border}
+                  _last={{ borderBottom: '0' }}
+                  _hover={{ bg: rowHover }}
+                >
+                  <HStack align="flex-start" spacing={2}>
+                    <Box
+                      pt="3px"
+                      color={notice.status === 'error' ? 'red.500' : notice.status === 'success' ? 'green.500' : 'teal.500'}
+                    >
+                      <StatusIcon status={notice.status} />
+                    </Box>
+                    <Box minW={0} flex="1">
+                      <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
+                        {notice.title}
+                      </Text>
+                      <Text fontSize="xs" color={muted} noOfLines={2}>
+                        {notice.description}
+                      </Text>
+                      {notice.progress !== undefined && (
+                        <Progress
+                          mt={2}
+                          size="xs"
+                          borderRadius="sm"
+                          colorScheme={notice.status === 'error' ? 'red' : 'teal'}
+                          value={notice.progress}
+                        />
+                      )}
+                      {notice.assetId && notice.status === 'success' && (
+                        <Button
+                          mt={2}
+                          size="xs"
+                          leftIcon={<MdAdd />}
+                          colorScheme="teal"
+                          variant="outline"
+                          isLoading={creatingKeys.includes(notice.key)}
+                          onClick={() => handleCreateApp(notice)}
+                        >
+                          Create App
+                        </Button>
+                      )}
+                    </Box>
+                    <CloseButton
+                      size="sm"
+                      mt="-1"
+                      mr="-1"
+                      aria-label={`Dismiss ${notice.title}`}
+                      onClick={() => dismissNotice(notice.key)}
+                    />
+                  </HStack>
+                </Box>
+              ))}
+            </VStack>
+          )}
+        </Box>
+      </SlideFade>
+    </Flex>
+  );
+}

--- a/webstack/apps/webapp/src/app/pages/board/layers/ui/components/index.ts
+++ b/webstack/apps/webapp/src/app/pages/board/layers/ui/components/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -17,3 +17,4 @@ export * from './Interactionbar';
 export * from './InteractionbarShortcuts';
 export * from './Menus';
 export * from './EscapeApp';
+export * from './UploadNotificationCenter';

--- a/webstack/libs/applications/src/lib/apps/PDFViewer/PDFViewer.tsx
+++ b/webstack/libs/applications/src/lib/apps/PDFViewer/PDFViewer.tsx
@@ -29,8 +29,18 @@ import {
 import { BsFiletypePdf } from 'react-icons/bs';
 
 // SAGE3 utility functions and types
-import { useAssetStore, useAppStore, useUser, downloadFile, apiUrls, useUIStore, useHexColor } from '@sage3/frontend';
-import { Asset, ExtraPDFType } from '@sage3/shared/types';
+import {
+  useAssetStore,
+  useAppStore,
+  useUser,
+  downloadFile,
+  apiUrls,
+  useUIStore,
+  useHexColor,
+  useMeasure,
+  useThrottleScale,
+} from '@sage3/frontend';
+import { Asset, ExtraPDFType, ImageInfoType } from '@sage3/shared/types';
 
 // App components and types
 import { App, AppGroup } from '../../schema';
@@ -49,10 +59,13 @@ function AppComponent(props: App): JSX.Element {
   const s = props.data.state as AppState;
   
   // Local state for PDF rendering
-  const [urls, setUrls] = useState([] as string[]);
+  const [pages, setPages] = useState<ExtraPDFType>([]);
   const [file, setFile] = useState<Asset>();
   const [aspectRatio, setAspectRatio] = useState(1);
   const [displayRatio, setDisplayRatio] = useState(1);
+  const [failedPageUrls, setFailedPageUrls] = useState<Record<string, boolean>>({});
+  const scale = useThrottleScale(250);
+  const [displayRef, displaySize] = useMeasure<HTMLDivElement>();
   
   // App creation function for spawning new apps
   const createApp = useAppStore((state) => state.create);
@@ -64,6 +77,7 @@ function AppComponent(props: App): JSX.Element {
   // UI state management
   const [processing, setProcessing] = useState(false);
   const setSelectedApp = useUIStore((state) => state.setSelectedApp);
+  const boardDragging = useUIStore((state) => state.boardDragging);
   const backgroundColor = useHexColor('gray.400');
   const [navigating, setNavigating] = useState("");
 
@@ -114,25 +128,24 @@ function AppComponent(props: App): JSX.Element {
     }
   }, [s.assetid, assets, user]);
 
-  // Effect: Process PDF pages and extract image URLs
+  // Effect: Store PDF pages and calculate aspect ratio
   useEffect(() => {
     if (file) {
-      const pages = file.data.derived as ExtraPDFType;
-      if (pages) {
-        // Extract highest resolution image URL for each page
-        const allurls = pages.map((page) => {
-          const res = page.reduce(function (p, v) {
-            return p.width > v.width ? p : v;
-          });
-          return res.url;
-        });
-        setUrls(allurls);
+      const derivedPages = file.data.derived as ExtraPDFType;
+      if (derivedPages) {
+        setPages(derivedPages);
+        setFailedPageUrls({});
         
         // Calculate aspect ratio from first page
-        const firstpage = pages[0];
-        const ar = firstpage[0].width / firstpage[0].height;
-        setAspectRatio(ar);
-        setDisplayRatio(ar * Math.max(1, s.displayPages));
+        const firstpage = derivedPages[0];
+        if (firstpage && firstpage.length > 0) {
+          const firstResolution = firstpage.reduce(function (p, v) {
+            return p.width > v.width ? p : v;
+          });
+          const ar = firstResolution.width / firstResolution.height;
+          setAspectRatio(ar);
+          setDisplayRatio(ar * Math.max(1, s.displayPages));
+        }
       }
     }
   }, [file]);
@@ -212,6 +225,14 @@ function AppComponent(props: App): JSX.Element {
       });
     }
   }, [s.analyzed]);
+
+  const handlePDFImageError = useCallback((url?: string) => {
+    if (!url) return;
+    setFailedPageUrls((prev) => {
+      if (prev[url]) return prev;
+      return { ...prev, [url]: true };
+    });
+  }, []);
 
   // Keyboard event handler for navigation and actions
   const handleUserKeyPress = useCallback(
@@ -376,7 +397,7 @@ function AppComponent(props: App): JSX.Element {
 
   return (
     <AppWindow app={props} lockAspectRatio={displayRatio} processing={processing} hideBackgroundIcon={BsFiletypePdf}>
-      <Box m={0} p={0} width="100%" height="100%">
+      <Box ref={displayRef} m={0} p={0} width="100%" height="100%">
         {/* Navigation animation overlay - forward direction */}
         <Fade in={navigating === "forward"} transition={{ exit: { duration: 0.5 } }} unmountOnExit={true}>
           <Box
@@ -435,28 +456,64 @@ function AppComponent(props: App): JSX.Element {
           onTouchEnd={ontouchend}
         >
           {/* Render PDF pages based on current page and display count */}
-          {urls
-            .filter((u, i) => i >= s.currentPage && i < s.currentPage + s.displayPages)
-            .map((url, idx) => (
-              <Box id={'pane~' + props._id + idx} key={idx} p={1} m={1}
-                rounded="lg" bg="white" color="gray.800" shadow="base"
-                width="100%" height="100%"
-              >
-                <Image
-                  src={url}
-                  userSelect={'none'}
-                  draggable={false}
+          {pages
+            .map((page, pageIndex) => ({ page, pageIndex }))
+            .filter(({ pageIndex }) => pageIndex >= s.currentPage && pageIndex < s.currentPage + s.displayPages)
+            .map(({ page, pageIndex }, idx) => {
+              const targetWidth = getPDFTargetPageWidth(displaySize.width, s.displayPages, scale, boardDragging);
+              const selectedImage = getPDFPageImage(page, targetWidth, failedPageUrls);
+              const url = selectedImage?.url;
+              return (
+                <Box
+                  id={'pane~' + props._id + idx}
+                  key={pageIndex}
+                  p={1}
+                  m={1}
+                  rounded="lg"
+                  bg="white"
+                  color="gray.800"
+                  shadow="base"
                   width="100%"
                   height="100%"
-                  objectFit="contain"
-                  alt={file?.data.originalfilename}
-                />
-              </Box>
-            ))}
+                >
+                  <Image
+                    src={url}
+                    onError={() => handlePDFImageError(url)}
+                    userSelect={'none'}
+                    draggable={false}
+                    width="100%"
+                    height="100%"
+                    objectFit="contain"
+                    alt={file?.data.originalfilename}
+                  />
+                </Box>
+              );
+            })}
         </HStack>
       </Box>
     </AppWindow >
   );
+}
+
+function getPDFTargetPageWidth(totalDisplayWidth: number, displayPages: number, scale: number, boardDragging: boolean): number {
+  if (boardDragging) return 1;
+  const safeDisplayPages = Math.max(1, displayPages);
+  const pageWidth = totalDisplayWidth > 0 ? totalDisplayWidth / safeDisplayPages : 0;
+  const devicePixelRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio;
+  return Math.max(1, pageWidth * devicePixelRatio * scale);
+}
+
+function getPDFPageImage(page: ImageInfoType[] | undefined, targetWidth: number, failedUrls: Record<string, boolean>): ImageInfoType | undefined {
+  if (!page || page.length === 0) return undefined;
+
+  const candidates = page.filter((image) => image.url && Number.isFinite(image.width));
+  if (candidates.length === 0) return undefined;
+
+  // Old PDFs may have one or many variants. Pick the closest usable image and
+  // fall back to another variant when the selected file is missing.
+  const sorted = [...candidates].sort((a, b) => Math.abs(a.width - targetWidth) - Math.abs(b.width - targetWidth));
+  const available = sorted.find((image) => !failedUrls[image.url]);
+  return available || sorted[0];
 }
 
 /**

--- a/webstack/libs/backend/src/lib/generics/SAGECollection.ts
+++ b/webstack/libs/backend/src/lib/generics/SAGECollection.ts
@@ -260,7 +260,7 @@ export class SAGE3Collection<T extends SBJSON> {
   public async subscribeByQuery(
     field: keyof T,
     value: string,
-    callback: (message: SBDocumentMessage<T>) => void
+    callback: (message: SBDocumentMessage<T>) => void,
   ): Promise<(() => Promise<void>) | undefined> {
     try {
       const unsubscribe = await this._collection.subscribeToQuery(field, value, callback);

--- a/webstack/libs/frontend/src/lib/hooks/useFiles.tsx
+++ b/webstack/libs/frontend/src/lib/hooks/useFiles.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2023. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -385,7 +385,7 @@ async function openSession(a: Asset, xDrop: number, yDrop: number, roomId: strin
         // Add fields to the upload form
         fd.append('room', roomId);
         // Upload with a POST request
-        const up = await fetch(apiUrls.assets.upload, { method: 'POST', body: fd });
+        const up = await fetch(apiUrls.assets.upload, { method: 'POST', headers: { 'x-sage3-room': roomId }, body: fd });
         const result = await up.json();
         const newasset = result[0];
         // Rebuild the app with the new asset
@@ -455,8 +455,6 @@ export function useFiles(): UseFiles {
   const toastIdRef = useRef<ToastId>();
   // User store
   const { user } = useUser();
-  // Assets store
-  const assets = useAssetStore((state) => state.assets);
   // Upload success
   const [uploadSuccess, setUploadSuccess] = useState<string[]>([]);
   // Save the drop position
@@ -591,6 +589,7 @@ export function useFiles(): UseFiles {
         // Upload with a POST request
         const response = await fetch(apiUrls.assets.upload, {
           method: 'POST',
+          headers: { 'x-sage3-room': roomId },
           body: fd,
         });
 
@@ -658,7 +657,7 @@ export function useFiles(): UseFiles {
    */
   async function openAppForFile(fileID: string, xDrop: number, yDrop: number, roomId: string, boardId: string): Promise<AppSchema | null> {
     if (!user) return null;
-    for (const a of assets) {
+    for (const a of useAssetStore.getState().assets) {
       if (a._id === fileID) {
         return openApplication(a, xDrop, yDrop, roomId, boardId);
       }

--- a/webstack/libs/frontend/src/lib/stores/message.ts
+++ b/webstack/libs/frontend/src/lib/stores/message.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -62,15 +62,23 @@ const MessageStore = create<MessageState>()((set, get) => {
       if (msgSub) {
         msgSub();
         msgSub = null;
-        const interval = get().interval;
-        if (interval) window.clearInterval(interval);
       }
+      const interval = get().interval;
+      if (interval) window.clearInterval(interval);
+      set({ interval: null });
     },
     subscribe: async () => {
       if (!SAGE3Ability.canCurrentUser('read', 'message')) return;
-      set({ ...get(), messages: [] });
+      if (msgSub) {
+        msgSub();
+        msgSub = null;
+      }
+      const existingInterval = get().interval;
+      if (existingInterval) window.clearInterval(existingInterval);
+      set({ ...get(), messages: [], interval: null });
 
-      const msg = await APIHttp.GET<Message>('/message');
+      const route = '/message';
+      const msg = await APIHttp.GET<Message>(route);
       if (msg.success) {
         set({ messages: msg.data });
       } else {
@@ -96,15 +104,6 @@ const MessageStore = create<MessageState>()((set, get) => {
       }, 5 * 1000);
       set({ interval: interval });
 
-      // Unsubscribe old subscription
-      if (msgSub) {
-        msgSub();
-        msgSub = null;
-        if (interval) window.clearInterval(interval);
-      }
-
-      // Socket Subscribe Message
-      const route = '/message';
       // Socket Listenting to updates from server
       msgSub = await SocketAPI.subscribe<Message>(route, (message) => {
         switch (message.type) {

--- a/webstack/libs/frontend/src/lib/ui/components/modals/UploadModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/UploadModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -51,6 +51,7 @@ export function UploadModal(props: UploadModalProps): JSX.Element {
   // selected files
   const [input, setInput] = useState<File[]>([]);
   const [allowFolder, setAllowFolder] = useState(false);
+  const [uploading, setUploading] = useState(false);
 
   // Files have been selected
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -68,7 +69,9 @@ export function UploadModal(props: UploadModalProps): JSX.Element {
 
   // Perform the actual upload
   const upload = () => {
-    if (input) {
+    if (input.length > 0 && roomId && !uploading) {
+      setUploading(true);
+      props.onClose();
       // Uploaded with a Form object
       const fd = new FormData();
       // Add each file to the form
@@ -83,14 +86,15 @@ export function UploadModal(props: UploadModalProps): JSX.Element {
       // Upload with a POST request
       fetch(apiUrls.assets.upload, {
         method: 'POST',
+        headers: { 'x-sage3-room': roomId },
         body: fd,
       })
         .catch((error: Error) => {
           console.log('Upload> Error: ', error);
         })
         .finally(() => {
-          // Close the modal UI
-          props.onClose();
+          setInput([]);
+          setUploading(false);
         });
     }
   };
@@ -135,7 +139,7 @@ export function UploadModal(props: UploadModalProps): JSX.Element {
           </FormControl>
         </ModalBody>
         <ModalFooter>
-          <Button type="submit" colorScheme="green" mr={5} onClick={upload} isDisabled={input.length === 0}>
+          <Button type="submit" colorScheme="green" mr={5} onClick={upload} isDisabled={input.length === 0 || uploading}>
             Upload
           </Button>
           <Button mr={3} onClick={props.onClose}>

--- a/webstack/libs/shared/src/lib/types/schemas/message.ts
+++ b/webstack/libs/shared/src/lib/types/schemas/message.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) SAGE3 Development Team 2022. All Rights Reserved
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
  * University of Hawaii, University of Illinois Chicago, Virginia Tech
  *
  * Distributed under the terms of the SAGE3 License.  The full license is in
@@ -17,6 +17,20 @@ const schema = z.object({
   type: z.string(),
   payload: z.string(),
   close: z.boolean(),
+  uploadId: z.string().optional(),
+  fileId: z.string().optional(),
+  roomId: z.string().optional(),
+  assetId: z.string().optional(),
+  filename: z.string().optional(),
+  phase: z.enum(['uploading', 'metadata', 'processing', 'rendering', 'ready', 'failed']).optional(),
+  progress: z
+    .object({
+      current: z.number().optional(),
+      total: z.number().optional(),
+      percent: z.number().optional(),
+      unit: z.enum(['files', 'pages', 'bytes']).optional(),
+    })
+    .optional(),
 });
 
 export type MessageSchema = z.infer<typeof schema>;


### PR DESCRIPTION
## Summary
- add bounded PDF page rendering with cleanup on failure and structured render progress messages
- add room/file/asset-aware upload messages and transient message cleanup for homebase-files
- replace upload/process toasts with a board-scoped upload notification center under the clock
- close the asset upload modal immediately after submit and prevent repeated upload clicks

## Compatibility
- no new runtime dependencies
- existing uploaded PDFs keep the same derived data/page asset naming format
- legacy upload/process message parsing remains as a fallback in the notification center

## Validation
- git diff --check
- nx build homebase-files
- nx build webapp

Note: webapp build still reports existing Sass legacy JS API deprecation warnings.