### PR TITLE
perf(whiteboard): faster annotation drawing, rendering, and persistence at scale

### DIFF
--- a/webstack/apps/homebase/src/api/collections/annotations.ts
+++ b/webstack/apps/homebase/src/api/collections/annotations.ts
@@ -17,7 +17,38 @@ class SAGE3AnnotationsCollection extends SAGE3Collection<AnnotationSchema> {
     // re-broadcast the entire whiteboardLines array to every subscriber.
     super('ANNOTATIONS', {}, { publishUpdates: false });
     const router = sageRouter<AnnotationSchema>(this);
+
+    // Incremental append: add whiteboard strokes without rewriting the whole
+    // array.  Committing a stroke sends only the new shape(s) (O(stroke))
+    // instead of the full whiteboardLines array (O(board)).  Removes/clears
+    // still go through the generic full-array PUT, which also reconciles drift.
+    router.post('/:id/lines', async ({ params, body, user }, res) => {
+      const userId = (user as { id?: string })?.id || '-';
+      const lines = body?.lines;
+      if (!Array.isArray(lines) || lines.length === 0) {
+        res.status(400).send({ success: false, message: 'Body must include a non-empty "lines" array.' });
+        return;
+      }
+      const ok = await this.appendLines(params.id, lines, userId);
+      if (ok) res.status(200).send({ success: true, message: 'Successfully appended lines.' });
+      else res.status(500).send({ success: false, message: 'Failed to append lines.' });
+    });
+
     this.httpRouter = router;
+  }
+
+  /**
+   * Append whiteboard strokes to a board's annotation document without
+   * rewriting the existing array.  Broadcast is suppressed (live sync is Yjs).
+   */
+  public async appendLines(id: string, lines: unknown[], by: string): Promise<boolean> {
+    try {
+      const response = await this.collection.docRef(id).arrayAppend('whiteboardLines', lines, by, false);
+      return !!response.success;
+    } catch (error) {
+      console.error('AnnotationsCollection appendLines error:', error);
+      return false;
+    }
   }
 
   /**

--- a/webstack/apps/homebase/src/api/collections/annotations.ts
+++ b/webstack/apps/homebase/src/api/collections/annotations.ts
@@ -12,7 +12,10 @@ import { BoardsCollection } from './boards';
 
 class SAGE3AnnotationsCollection extends SAGE3Collection<AnnotationSchema> {
   constructor() {
-    super('ANNOTATIONS', {});
+    // Live annotation sync is handled by Yjs; the collection is only cold
+    // storage.  Opt out of per-update broadcasts so a stroke commit doesn't
+    // re-broadcast the entire whiteboardLines array to every subscriber.
+    super('ANNOTATIONS', {}, { publishUpdates: false });
     const router = sageRouter<AnnotationSchema>(this);
     this.httpRouter = router;
   }

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Line.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Line.tsx
@@ -6,42 +6,92 @@
  * the file LICENSE, distributed as part of this software.
  */
 
-import { useEffect, useState, memo } from 'react';
+import { useEffect, useState, useMemo, memo } from 'react';
 import { useColorModeValue } from '@chakra-ui/react';
 import { getStroke } from 'perfect-freehand';
 import * as Y from 'yjs';
 
 
-import { useHexColor, useUserSettings, useAnnotationStore, useAppStore } from '@sage3/frontend';
+import { useHexColor, useUserSettings } from '@sage3/frontend';
 
-export interface LineProps {
-  line: Y.Map<any>;
-  onClick: (id: string) => void;
+/**
+ * The presentational data needed to render a single annotation shape.  This is
+ * intentionally decoupled from Yjs so the same renderer can draw both
+ * finalized shapes (backed by a Y.Map) and the local, in-progress draft stroke
+ * held in React state while the user is drawing.
+ */
+export interface ShapeViewProps {
+  points: number[][];
+  color?: string;
+  isComplete?: boolean;
+  alpha?: number;
+  size?: number;
+  type?: string;
+  text?: string;
+  /** When false, the shape is a non-interactive preview (no hover/erase/text edit). */
+  interactive?: boolean;
+  onErase?: () => void;
+  onTextChange?: (value: string) => void;
 }
 
-export const Line = memo(function Line({ line, onClick }: LineProps) {
+/**
+ * Pure renderer for an annotation shape.  Contains no Yjs coupling; all inputs
+ * arrive as plain props.  Freehand stroke geometry is memoized so that finalized
+ * strokes are not re-tessellated on every render (e.g. on hover).
+ */
+export const ShapeView = memo(function ShapeView(props: ShapeViewProps) {
+  const {
+    points,
+    color,
+    isComplete,
+    alpha,
+    size,
+    type = 'line',
+    text = '',
+    interactive = true,
+    onErase,
+    onTextChange,
+  } = props;
+
   const { settings } = useUserSettings();
   const primaryActionMode = settings.primaryActionMode;
-
-  const { points, color, isComplete, alpha, size, type, text } = useLine(line);
 
   const c = useHexColor(color ? color : 'red');
   const hoverColor = useColorModeValue(`${color}.600`, `${color}.100`);
   const hoverC = useHexColor(hoverColor);
-  const id = line.get('id') as string;
   const [hover, setHover] = useState(false);
+  const strokeColor = interactive && hover ? hoverC : c;
 
-  const handleTextChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    line.set('text', ev.target.value);
-  }
+  // Memoize the freehand stroke outline so finalized strokes are computed once
+  // and reused across re-renders (hover, sibling updates).  For an in-progress
+  // draft this recomputes as points change, which is expected and local-only.
+  const strokeOutline = useMemo(
+    () =>
+      getStroke(points, {
+        size: size,
+        thinning: 0.35, // a bit less 'brushy'
+        smoothing: 0.2, // LOWER -> less rounding
+        streamline: 0.12, // LOWER -> tracks pointer more tightly
+        last: isComplete,
+      }),
+    [points, size, isComplete]
+  );
+  const pathData = useMemo(() => getSvgPathFromStrokePolygon(strokeOutline), [strokeOutline]);
 
-  const handleClick = (ev: any) => {
-    // Left-click while in eraser mode deletes this line/shape
-    if (ev.button === 0 && primaryActionMode === 'eraser') {
-      onClick(id);
-      console.log(`LINE |click: primaryActionMode=${primaryActionMode}`);
+  const handleErase = (ev: any) => {
+    // Left-click while in eraser mode deletes this shape
+    if (interactive && ev.button === 0 && primaryActionMode === 'eraser') {
+      onErase?.();
     }
   };
+
+  const hoverProps = interactive
+    ? {
+        onMouseEnter: () => setHover(true),
+        onMouseLeave: () => setHover(false),
+        onMouseDown: handleErase,
+      }
+    : {};
 
   if (type === 'circle') {
     if (!points || points.length < 2) return null;
@@ -64,45 +114,39 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
             rx={(maxX - minX) / 2}
             ry={(maxY - minY) / 2}
             fill="none"
-            stroke={hover ? hoverC : c}
+            stroke={strokeColor}
             strokeOpacity={alpha ?? 0.6}
             strokeWidth={size ?? 5}
             strokeLinejoin="miter"   // <-- sharp corners
             strokeLinecap="butt"     // <-- flat line ends
             shapeRendering="crispEdges"
-            onMouseEnter={() => setHover(true)}
-            onMouseLeave={() => setHover(false)}
-            onMouseDown={handleClick}
+            {...hoverProps}
           />
-          <foreignObject x={minX} y={minY} width={maxX - minX} height={maxY - minY}>
-            <div style={{
-              width: '100%',
-              height: '100%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center'
-            }}>
-              <input
-                type='text'
-                value={text}
-                style={{
-                  width: '90%',
-                  height: '90%',
-                  background: 'transparent',
-                  border: 'none',
-                  color: c,
-                  fontSize: '50px',
-                  textAlign: 'center',
-                  outline: 'none'
-                }}
-                onChange={handleTextChange}
-              />
-            </div>
-          </foreignObject>
+          {interactive && (
+            <foreignObject x={minX} y={minY} width={maxX - minX} height={maxY - minY}>
+              <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <input
+                  type="text"
+                  value={text}
+                  style={{
+                    width: '90%',
+                    height: '90%',
+                    background: 'transparent',
+                    border: 'none',
+                    color: c,
+                    fontSize: '50px',
+                    textAlign: 'center',
+                    outline: 'none',
+                  }}
+                  onChange={(ev) => onTextChange?.(ev.target.value)}
+                />
+              </div>
+            </foreignObject>
+          )}
         </g>
       );
     } catch (error) {
-      console.log(`${error}`)
+      console.log(`${error}`);
     }
   }
 
@@ -129,74 +173,50 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
           width={width}
           height={height}
           fill="none"
-          stroke={hover ? hoverC : c}
+          stroke={strokeColor}
           strokeOpacity={alpha ?? 0.6}
           strokeWidth={size ?? 5}
           strokeLinejoin="miter"   // Sharp corners
           strokeLinecap="butt"     // Flat line ends
           shapeRendering="crispEdges"
-          onMouseEnter={() => setHover(true)}
-          onMouseLeave={() => setHover(false)}
-          onMouseDown={handleClick}
+          {...hoverProps}
         />
-        <foreignObject x={minX} y={minY} width={width} height={height}>
-          <div style={{
-            width: '100%',
-            height: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}>
-            <input
-              type='text'
-              value={text}
-              style={{
-                width: '90%',
-                height: '90%',
-                background: 'transparent',
-                border: 'none',
-                color: c,
-                fontSize: '50px',
-                textAlign: 'center',
-                outline: 'none'
-              }}
-              onChange={handleTextChange}
-            />
-          </div>
-        </foreignObject>
+        {interactive && (
+          <foreignObject x={minX} y={minY} width={width} height={height}>
+            <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <input
+                type="text"
+                value={text}
+                style={{
+                  width: '90%',
+                  height: '90%',
+                  background: 'transparent',
+                  border: 'none',
+                  color: c,
+                  fontSize: '50px',
+                  textAlign: 'center',
+                  outline: 'none',
+                }}
+                onChange={(ev) => onTextChange?.(ev.target.value)}
+              />
+            </div>
+          </foreignObject>
+        )}
       </g>
     );
   }
 
-  // --- Render freehand lines with LESS rounding ----------------------------
-  // Use perfect-freehand to build the stroke outline, but:
-  //  - Lower smoothing and streamline to reduce roundness
-  //  - Build a polygonal path (M/L + Z) instead of quadratic curves
-  const strokeOutline = getStroke(points, {
-    size: size,
-    thinning: 0.35,     // a bit less 'brushy'
-    smoothing: 0.2,     // LOWER -> less rounding than your 0.6
-    streamline: 0.12,   // LOWER -> tracks pointer more tightly
-    last: isComplete,
-  });
-
-  const pathData = getSvgPathFromStrokePolygon(strokeOutline);
-
   if (type === 'arrow') {
     if (!points || points.length < 2) return null;
-
-    // Compute bounding box from whatever points we have (robust to closed poly or 2-point form)
     try {
       const x1 = points[0][0];
       const y1 = points[0][1];
       const x2 = points[1][0];
       const y2 = points[1][1];
-
       return (
         <g opacity={alpha}>
           <defs>
             <marker
-              // unique ID for every marker head
               id={`${x1},${y1},${x2},${y2}`}
               orient="auto"
               markerWidth="5"
@@ -205,43 +225,36 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
               refX="5"   // place the tip (10,5) on the vertex
               refY="5"
             >
-              <path d="M0 0 L10 5 L0 10 Z" fill={hover ? hoverC : c} />
+              <path d="M0 0 L10 5 L0 10 Z" fill={strokeColor} />
             </marker>
           </defs>
-
           <path
             className="line"
             d={`M ${x1},${y1}, L ${x2},${y2}`}
-            stroke={hover ? hoverC : c}
+            stroke={strokeColor}
             strokeWidth={size}
-            strokeLinecap='round'
+            strokeLinecap="round"
             markerEnd={`url(#${x1},${y1},${x2},${y2})`}
-            onMouseEnter={() => setHover(true)}
-            onMouseLeave={() => setHover(false)}
-            onMouseDown={handleClick}
+            {...hoverProps}
           />
         </g>
       );
     } catch (e) {
-      console.log("Error rendering arrow:", e);
+      console.log('Error rendering arrow:', e);
     }
   }
 
   if (type === 'doubleArrow') {
     if (!points || points.length < 2) return null;
-
-    // Compute bounding box from whatever points we have (robust to closed poly or 2-point form)
     try {
       const x1 = points[0][0];
       const y1 = points[0][1];
       const x2 = points[1][0];
       const y2 = points[1][1];
-
       return (
         <g opacity={alpha}>
           <defs>
             <marker
-              // unique ID for every marker head
               id={`${x1},${y1},${x2},${y2}`}
               orient="auto-start-reverse"
               markerWidth="5"
@@ -250,53 +263,82 @@ export const Line = memo(function Line({ line, onClick }: LineProps) {
               refX="4"   // place the tip (10,5) on the vertex
               refY="5"
             >
-              <path d="M0 0 L10 5 L0 10 Z" fill={hover ? hoverC : c} />
+              <path d="M0 0 L10 5 L0 10 Z" fill={strokeColor} />
             </marker>
           </defs>
-
           <path
             className="line"
             d={`M ${x1},${y1}, L ${x2},${y2}`}
-            stroke={hover ? hoverC : c}
+            stroke={strokeColor}
             strokeWidth={size}
-            strokeLinecap='round'
+            strokeLinecap="round"
             markerEnd={`url(#${x1},${y1},${x2},${y2})`}
             markerStart={`url(#${x1},${y1},${x2},${y2})`}
-            onMouseEnter={() => setHover(true)}
-            onMouseLeave={() => setHover(false)}
-            onMouseDown={handleClick}
+            {...hoverProps}
           />
         </g>
       );
     } catch (e) {
-      console.log("Error rendering double arrow:", e);
+      console.log('Error rendering double arrow:', e);
     }
   }
 
+  // --- Freehand line -------------------------------------------------------
   return (
     <g>
-      <path
-        className="canvas-line"
-        d={pathData}
-        fill={hover ? hoverC : c}
-        fillOpacity={alpha}
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
-        onMouseDown={handleClick}
-      />
+      <path className="canvas-line" d={pathData} fill={strokeColor} fillOpacity={alpha} {...hoverProps} />
     </g>
   );
 });
 
+export interface LineProps {
+  line: Y.Map<any>;
+  onClick: (id: string) => void;
+}
+
+/**
+ * A finalized annotation shape backed by a Y.Map.  Subscribes to the Yjs
+ * document for its geometry/metadata and renders via the shared ShapeView.
+ */
+export const Line = memo(function Line({ line, onClick }: LineProps) {
+  const { points, color, isComplete, alpha, size, type, text } = useLine(line);
+  const id = line.get('id') as string;
+
+  return (
+    <ShapeView
+      points={points}
+      color={color}
+      isComplete={isComplete}
+      alpha={alpha}
+      size={size}
+      type={type}
+      text={text}
+      interactive={true}
+      onErase={() => onClick(id)}
+      onTextChange={(value) => line.set('text', value)}
+    />
+  );
+});
+
 function getSvgPathFromStrokePolygon(stroke: number[][]) {
-  // Build a polygonal path (no quadratic beziers) for crisper corners
+  // Build a polygonal path (no quadratic beziers) for crisper corners.  Use
+  // RELATIVE line commands ('l'): outline vertices are close together, so the
+  // deltas are tiny compared to absolute board coordinates (which can be 7+
+  // digits on a 3,000,000-unit board), yielding a much shorter `d` string.
+  // Each delta is the difference between consecutive points rounded to 0.1, and
+  // the rounded position is carried forward, so there is no accumulation drift.
   if (!stroke || stroke.length === 0) return '';
-  let d = `M${stroke[0][0].toFixed(1)},${stroke[0][1].toFixed(1)}`;
+  let px = Math.round(stroke[0][0] * 10) / 10;
+  let py = Math.round(stroke[0][1] * 10) / 10;
+  let d = `M${px.toFixed(1)},${py.toFixed(1)}`;
   for (let i = 1; i < stroke.length; i++) {
-    const [x, y] = stroke[i];
-    d += ` L${x.toFixed(1)},${y.toFixed(1)}`;
+    const cx = Math.round(stroke[i][0] * 10) / 10;
+    const cy = Math.round(stroke[i][1] * 10) / 10;
+    d += `l${(cx - px).toFixed(1)},${(cy - py).toFixed(1)}`;
+    px = cx;
+    py = cy;
   }
-  d += ' Z';
+  d += 'z';
   return d;
 }
 
@@ -353,7 +395,7 @@ export function useLine(line: Y.Map<any>) {
 
 /**
  * Converts an array into an array of pairs by grouping consecutive elements.
- * 
+ *
  * @template T - The type of elements in the input array
  * @param arr - The input array to be converted into pairs
  * @returns An array of pairs, where each pair is a two-element array containing consecutive elements from the input array

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -41,8 +41,50 @@ import {
   useYjs,
 } from '@sage3/frontend';
 
-import { Line } from './Line';
+import { Line, ShapeView } from './Line';
 import { useDragAndDropBoard } from '../DragAndDropBoard';
+
+/**
+ * Minimum pointer travel (in screen pixels) between stored samples while a
+ * freehand stroke is in progress.  Larger values yield a smaller/cheaper draft
+ * path at the cost of finer detail; the pointer-up Simplify pass runs regardless.
+ */
+const MIN_DRAFT_SAMPLE_PX = 2;
+
+/**
+ * Freehand simplification tolerance, expressed in SCREEN pixels and converted to
+ * board units at commit time (divided by the current scale).  A fixed board-unit
+ * tolerance would over-simplify strokes drawn while zoomed in (discarding the
+ * detail the draft decimation preserved) and under-simplify strokes drawn while
+ * zoomed out.  0.5px matches the previous hard-coded 0.5 board-unit value at 1x.
+ */
+const SIMPLIFY_TOL_PX = 0.5;
+
+/**
+ * Trailing debounce (ms) for persisting annotations.  Rapid stroke commits are
+ * coalesced into a single save; forced flushes on tab-hide/unload and tool/board
+ * change guarantee durability.  Persisting each stroke immediately would PUT the
+ * entire whiteboardLines array (O(board)) on every stroke.
+ */
+const SAVE_DEBOUNCE_MS = 1500;
+
+/**
+ * Round to 0.1 board units — matching the stroke renderer's own `toFixed(1)`
+ * precision.  Finer than integer rounding so strokes stay smooth when zoomed in
+ * (up to 6x, 0.1 unit ≈ 0.6 screen px), while not exceeding what the SVG path
+ * can represent.  Rendered path size is unaffected (it depends on point count).
+ */
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+/** Metadata for the shape currently being drawn (kept local until finalized). */
+type DraftShape = {
+  id: string;
+  type: string;
+  userColor: string;
+  alpha: number;
+  size: number;
+  userId?: string;
+};
 
 type WhiteboardProps = {
   boardId: string;
@@ -91,8 +133,15 @@ export function Whiteboard(props: WhiteboardProps) {
   const [yDoc, setYdoc] = useState<Y.Doc | null>(null);
   const [yLines, setYlines] = useState<Y.Array<Y.Map<any>> | null>(null);
   const [lines, setLines] = useState<Y.Map<any>[]>([]);
-  const rCurrentLine = useRef<Y.Map<any>>();
   const activeTouchCount = useRef(0);
+
+  // In-progress stroke: held entirely in local state so that pointer moves do
+  // NOT write to the Yjs document.  The shape is committed to Yjs exactly once,
+  // on pointer-up.  rDraftPoints is the authoritative point list (read on
+  // finalize); draftPoints mirrors it into state to drive the live preview.
+  const rDraft = useRef<DraftShape | null>(null);
+  const rDraftPoints = useRef<number[][]>([]);
+  const [draftPoints, setDraftPoints] = useState<number[][]>([]);
 
   // Preview cursor state
   const [cursorPosition, setCursorPosition] = useState<{ x: number; y: number } | null>(null);
@@ -112,23 +161,81 @@ export function Whiteboard(props: WhiteboardProps) {
     }
   }
 
+  // Debounced persistence.  updateBoardLines() serializes and PUTs the whole
+  // whiteboardLines array, so calling it on every stroke is O(board) per stroke.
+  // We coalesce rapid edits into a single trailing save and force a flush on
+  // tab-hide/unload and tool/board change so nothing is lost.
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveDirty = useRef(false);
+  // Latest-ref so the stable save helpers below always call the current closure.
+  const updateBoardLinesRef = useRef(updateBoardLines);
+  useEffect(() => {
+    updateBoardLinesRef.current = updateBoardLines;
+  });
+
+  // Schedule a trailing save — used for high-frequency stroke commits.
+  const scheduleSave = useCallback(() => {
+    saveDirty.current = true;
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      saveTimer.current = null;
+      if (!saveDirty.current) return;
+      saveDirty.current = false;
+      updateBoardLinesRef.current();
+    }, SAVE_DEBOUNCE_MS);
+  }, []);
+
+  // Flush a pending save immediately, if any — used for tab-hide/unload/unmount.
+  const flushSave = useCallback(() => {
+    if (!saveDirty.current) return;
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+    saveDirty.current = false;
+    updateBoardLinesRef.current();
+  }, []);
+
+  // Save immediately — used for infrequent destructive ops (clear/undo/erase).
+  const saveNow = useCallback(() => {
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+    saveDirty.current = false;
+    updateBoardLinesRef.current();
+  }, []);
+
+  // Force a flush when the tab is hidden or the page is unloaded.
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') flushSave();
+    };
+    window.addEventListener('beforeunload', flushSave);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('beforeunload', flushSave);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [flushSave]);
+
+  // Flush pending saves when the drawing tool changes or the component unmounts.
+  useEffect(() => {
+    return () => {
+      flushSave();
+    };
+  }, [primaryActionMode, flushSave]);
+
   /**
-   * Cancel and remove the in-progress stroke (if any).  Called when a second
+   * Cancel and discard the in-progress stroke (if any).  Called when a second
    * touch finger arrives so the initial single-finger touch doesn't leave a
-   * tiny dot behind during a pan/zoom gesture.
+   * tiny dot behind during a pan/zoom gesture.  Since the in-progress stroke
+   * lives only in local state, this never touches the Yjs document.
    */
   function cancelInProgressStroke() {
-    const current = rCurrentLine.current;
-    if (!current || !yLines) {
-      rCurrentLine.current = undefined;
-      return;
-    }
-    // Remove the incomplete shape from the Yjs array
-    const index = yLines.toArray().indexOf(current);
-    if (index >= 0) {
-      yLines.delete(index, 1);
-    }
-    rCurrentLine.current = undefined;
+    rDraft.current = null;
+    rDraftPoints.current = [];
+    setDraftPoints([]);
     setCursorPosition(null);
   }
 
@@ -222,6 +329,8 @@ export function Whiteboard(props: WhiteboardProps) {
       connect(yAnnotations);
     }
     return () => {
+      // Persist any pending edits before tearing down (e.g. board switch).
+      flushSave();
       unsubAnnotations();
     };
   }, [yAnnotations, props.boardId]);
@@ -260,30 +369,11 @@ export function Whiteboard(props: WhiteboardProps) {
       // Capture pointer events
       e.currentTarget.setPointerCapture(e.pointerId);
 
-      // Prepare a shared Yjs array for storing points
-      const pts = new Y.Array<number>();
-      pts.push([x0, y0]);
-      // Circle needs to have at least two points to correctly render
-      // Extra point gets deleted when the pointer moves
-      if (type === 'circle' || type === 'arrow' || type === 'doubleArrow') {
-        pts.push([x0 + .000001, y0 + .000001]);
-      }
-      // Create a Yjs map for this shape
-      const yShape = new Y.Map();
-
-      yDoc.transact(() => {
-        yShape.set('id', id);
-        yShape.set('type', type);
-        yShape.set('points', pts);
-        yShape.set('userColor', color);
-        yShape.set('alpha', markerOpacity);
-        yShape.set('size', markerSize);
-        yShape.set('isComplete', false);
-        yShape.set('userId', user?._id);
-        yShape.set('text', '');
-      });
-      rCurrentLine.current = yShape;
-      yLines.push([yShape]);
+      // Keep the in-progress shape in local state only.  Nothing is written to
+      // Yjs until the stroke is finalized in handlePointerUp.
+      rDraft.current = { id, type, userColor: color, alpha: markerOpacity, size: markerSize, userId: user?._id };
+      rDraftPoints.current = [[x0, y0]];
+      setDraftPoints(rDraftPoints.current);
       setCursorPosition({ x: x0, y: y0 });
     },
     [yLines, yDoc, canAnnotate, boardSynced, primaryActionMode, color, markerOpacity, markerSize, user, getPoint]
@@ -297,7 +387,7 @@ export function Whiteboard(props: WhiteboardProps) {
    */
   const handlePointerMove = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
-      if (!rCurrentLine.current) return;
+      if (!rDraft.current) return;
       // For mouse / pen / touch we require an active pointer capture to avoid stray moves.
       if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
 
@@ -310,29 +400,33 @@ export function Whiteboard(props: WhiteboardProps) {
       const [x, y] = getPoint(e.clientX, e.clientY);
       setCursorPosition(primaryActionMode !== 'eraser' ? { x, y } : null);
 
-      const current = rCurrentLine.current;
-      const type = current.get('type') as string;
-      const pts = current.get('points') as Y.Array<number>;
-      if (!pts) return;
-
+      const type = rDraft.current.type;
       if (type === 'line') {
-        // Append new point for freehand line
-        pts.push([x, y]);
+        // Decimate the freehand draft: only append a sample once the pointer has
+        // travelled at least MIN_DRAFT_SAMPLE_PX (in screen space) from the last
+        // stored point, and round to integer board coords.  This keeps the
+        // in-progress SVG path small and cheap to re-tessellate on each move; the
+        // pointer-up Simplify pass still cleans up the committed stroke.
+        const pts = rDraftPoints.current;
+        const last = pts[pts.length - 1];
+        const minDist = MIN_DRAFT_SAMPLE_PX / scale; // screen px -> board units
+        const dx = x - last[0];
+        const dy = y - last[1];
+        if (dx * dx + dy * dy < minDist * minDist) return; // too close; skip
+        rDraftPoints.current = [...pts, [round1(x), round1(y)]];
+        setDraftPoints(rDraftPoints.current);
       }
-      // use same logic to track circle and rectangle movements 
+      // Rectangle / circle / arrow track start + current drag-end point
       else if (type === 'rectangle' || type === 'circle' || type === 'arrow' || type === 'doubleArrow') {
-        // Replace the last end point (if exists) with the current coordinates
-        // A rectangle stores two points: start and current drag end
-        if (pts.length >= 4) {
-          pts.delete(2, 2);
-        }
-        pts.push([x, y]);
+        const start = rDraftPoints.current[0];
+        rDraftPoints.current = [start, [x, y]];
+        setDraftPoints(rDraftPoints.current);
       }
       else {
         setCursorPosition(null);
       }
     },
-    [primaryActionMode, getPoint, rCurrentLine.current]
+    [primaryActionMode, getPoint, scale]
   );
 
   /**
@@ -342,93 +436,85 @@ export function Whiteboard(props: WhiteboardProps) {
    * including the starting point repeated).  After finalisation, the
    * shape is marked complete and persisted to the annotation store.
    */
+  /**
+   * Commit a finalized shape to the Yjs document in a single transaction.  The
+   * points are stored flat ([x, y, x, y, ...]) to match the persisted format.
+   */
+  function commitShape(draft: DraftShape, finalPairs: number[][]) {
+    if (!yLines || !yDoc) return;
+    const flat: number[] = [];
+    for (const [px, py] of finalPairs) flat.push(px, py);
+    const pts = new Y.Array<number>();
+    pts.push(flat);
+    const yShape = new Y.Map();
+    yDoc.transact(() => {
+      yShape.set('id', draft.id);
+      yShape.set('type', draft.type);
+      yShape.set('points', pts);
+      yShape.set('userColor', draft.userColor);
+      yShape.set('alpha', draft.alpha);
+      yShape.set('size', draft.size);
+      yShape.set('isComplete', true);
+      yShape.set('userId', draft.userId);
+      yShape.set('text', '');
+    });
+    yLines.push([yShape]);
+  }
+
   const handlePointerUp = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
       if (e.pointerType === 'touch' && activeTouchCount.current > 0) {
         activeTouchCount.current -= 1;
       }
       e.currentTarget.releasePointerCapture(e.pointerId);
-      const current = rCurrentLine.current;
-      if (!current) return;
+      const draft = rDraft.current;
+      const points = rDraftPoints.current;
+      // Clear the local draft up front so an early return can't leave it dangling.
+      rDraft.current = null;
+      rDraftPoints.current = [];
+      setDraftPoints([]);
+      if (!draft) return;
 
-      const type = current.get('type') as string;
-      const pts = current.get('points') as Y.Array<number>;
-      if (!pts) {
-        rCurrentLine.current = undefined;
-        return;
-      }
+      const type = draft.type;
+      let committed = false;
 
       if (type === 'line') {
-        // Simplify freehand stroke
-        if (pts.length >= 4) {
-          const xyPoints: { x: number; y: number }[] = [];
-          for (let i = 0; i < pts.length / 2; i++) {
-            xyPoints.push({ x: pts.get(i * 2), y: pts.get(i * 2 + 1) });
-          }
-          // Simplify the stroke; tolerance 0.5, high quality
-          const simpler = Simplify.default(xyPoints, 0.5, true);
-          pts.delete(0, pts.length);
-          for (const p of simpler) {
-            pts.push([Math.round(p.x), Math.round(p.y)]);
-          }
+        // Simplify freehand stroke (tolerance 0.5, high quality)
+        let finalPairs = points;
+        if (points.length >= 2) {
+          const xyPoints = points.map(([x, y]) => ({ x, y }));
+          // Scale-aware tolerance: keep simplification consistent with the
+          // screen-space draft decimation (equals 0.5 board units at 1x zoom).
+          const tolerance = SIMPLIFY_TOL_PX / scale;
+          const simpler = Simplify.default(xyPoints, tolerance, true);
+          finalPairs = simpler.map((p) => [round1(p.x), round1(p.y)]);
         }
-        current.set('isComplete', true);
+        commitShape(draft, finalPairs);
+        committed = true;
       } else if (type === 'rectangle') {
-        // Finalise rectangle: convert two endpoints to a closed rectangle
-        // If the user never moved, remove the shape
-        if (pts.length < 4) {
-          // Remove incomplete rectangle
-          const index = yLines?.toArray().indexOf(current) ?? -1;
-          if (index >= 0 && yLines) {
-            yLines.delete(index, 1);
-          }
-        } else {
-          const x0 = pts.get(0);
-          const y0 = pts.get(1);
-          const x1 = pts.get(2);
-          const y1 = pts.get(3);
-          // Determine top-left corner and dimensions【992428044196702†L130-L147】
+        // Need a start + drag-end point; otherwise the shape never formed.
+        if (points.length >= 2) {
+          const [x0, y0] = points[0];
+          const [x1, y1] = points[1];
           const xMin = Math.min(x0, x1);
           const yMin = Math.min(y0, y1);
           const width = Math.abs(x1 - x0);
           const height = Math.abs(y1 - y0);
-          // Build a closed rectangle path: TL, TR, BR, BL, back to TL
-          const rectPoints = [
-            xMin,
-            yMin,
-            xMin + width,
-            yMin,
-            xMin + width,
-            yMin + height,
-            xMin,
-            yMin + height,
-            xMin,
-            yMin,
+          // Closed rectangle path: TL, TR, BR, BL, back to TL
+          const rectPairs: number[][] = [
+            [xMin, yMin],
+            [xMin + width, yMin],
+            [xMin + width, yMin + height],
+            [xMin, yMin + height],
+            [xMin, yMin],
           ];
-          pts.delete(0, pts.length);
-          for (let i = 0; i < rectPoints.length; i += 2) {
-            pts.push([rectPoints[i], rectPoints[i + 1]]);
-          }
-          current.set('isComplete', true);
+          commitShape(draft, rectPairs);
+          committed = true;
         }
-      }
-      else if (type === 'circle') {
-        if (pts.length < 4) {
-          try {
-            const index = yLines?.toArray().indexOf(current) ?? -1;
-            if (index >= 0 && yLines) {
-              yLines.delete(index, 1);
-            }
-          }
-          catch {
-            console.log(`array not long enough circle points: ${pts}`)
-          }
-        }
-        else {
-          const x0 = pts.get(0);
-          const y0 = pts.get(1);
-          const x1 = pts.get(2);
-          const y1 = pts.get(3);
+      } else if (type === 'circle') {
+        if (points.length >= 2) {
+          const [x0, y0] = points[0];
+          const [x1, y1] = points[1];
           const maxX = Math.max(x0, x1);
           const minX = Math.min(x0, x1);
           const maxY = Math.max(y0, y1);
@@ -441,48 +527,27 @@ export function Whiteboard(props: WhiteboardProps) {
           const vert1y = cy + ry * Math.sin(Math.PI / 2);
           const vert2x = cx + rx * Math.cos((3 * Math.PI) / 2);
           const vert2y = cy + ry * Math.sin((3 * Math.PI) / 2);
-          const circlePoints = [
-            x0,
-            y0,
-            x1,
-            y1,
-            vert1x,
-            vert1y,
-            vert2x,
-            vert2y,
+          const circlePairs: number[][] = [
+            [x0, y0],
+            [x1, y1],
+            [vert1x, vert1y],
+            [vert2x, vert2y],
           ];
-          pts.delete(0, pts.length);
-          for (let i = 0; i < circlePoints.length; i += 2) {
-            pts.push([circlePoints[i], circlePoints[i + 1]]);
-          }
-          current.set('isComplete', true);
+          commitShape(draft, circlePairs);
+          committed = true;
+        }
+      } else if (type === 'arrow' || type === 'doubleArrow') {
+        if (points.length >= 2) {
+          commitShape(draft, [points[0], points[1]]);
+          committed = true;
         }
       }
-      else if (type === 'arrow' || type === 'doubleArrow') {
-        console.log(type)
-        if (pts.length < 4) {
-          const index = yLines?.toArray().indexOf(current) ?? -1;
-          if (index >= 0 && yLines) {
-            yLines.delete(index, 1);
-          }
-        }
-        else {
-          const x0 = pts.get(0);
-          const y0 = pts.get(1);
-          const x1 = pts.get(2);
-          const y1 = pts.get(3);
-          const points = [x0, y0, x1, y1];
-          pts.delete(0, pts.length);
-          for (let i = 0; i < points.length; i += 2) {
-            pts.push([points[i], points[i + 1]]);
-          }
-          current.set('isComplete', true);
-        }
-      }
-      updateBoardLines();
-      rCurrentLine.current = undefined;
+
+      // Persist to the annotation store only when a shape was actually added.
+      // Debounced so a burst of strokes coalesces into a single save.
+      if (committed) scheduleSave();
     },
-    [updateBoardLines, yLines]
+    [scheduleSave, yLines, yDoc, scale]
   );
 
   /**
@@ -492,7 +557,7 @@ export function Whiteboard(props: WhiteboardProps) {
     if (yLines && clearAllMarkers) {
       yLines.delete(0, yLines.length);
       setClearAllMarkers(false);
-      updateBoardLines();
+      saveNow();
     }
   }, [clearAllMarkers]);
 
@@ -507,7 +572,7 @@ export function Whiteboard(props: WhiteboardProps) {
           yLines.delete(index, 1);
         }
       }
-      updateBoardLines();
+      saveNow();
       setClearMarkers(false);
     }
   }, [clearMarkers]);
@@ -524,7 +589,7 @@ export function Whiteboard(props: WhiteboardProps) {
           break;
         }
       }
-      updateBoardLines();
+      saveNow();
       setUndoLastMarker(false);
     }
   }, [undoLastMarker]);
@@ -543,7 +608,7 @@ export function Whiteboard(props: WhiteboardProps) {
         break;
       }
     }
-    if (deleted) updateBoardLines();
+    if (deleted) saveNow();
   };
 
   // Hotkeys: undo last line (Pen only)
@@ -616,6 +681,18 @@ export function Whiteboard(props: WhiteboardProps) {
           {lines.map((line, i) => (
             <Line key={i} line={line} onClick={lineClicked} />
           ))}
+          {/* In-progress (local, non-persisted) draft stroke preview */}
+          {rDraft.current && draftPoints.length > 0 && (
+            <ShapeView
+              points={draftPoints}
+              color={rDraft.current.userColor}
+              isComplete={false}
+              alpha={rDraft.current.alpha}
+              size={rDraft.current.size}
+              type={rDraft.current.type}
+              interactive={false}
+            />
+          )}
           {/* Preview cursor for pen */}
           {cursorPosition && primaryActionMode === 'pen' && (
             <circle

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -21,8 +21,7 @@ Can't select and move lines/shapes
 <--------------------------------------------------------------------------------------------TODO-------------------------------------------------------------------------------------------->
 */
 
-
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as Simplify from 'simplify-js';
 
 // Yjs Imports
@@ -85,6 +84,68 @@ type DraftShape = {
   size: number;
   userId?: string;
 };
+
+/**
+ * Extra viewport margin (fraction of the visible board rect) used when culling
+ * off-screen annotations, so shapes are rendered slightly before they scroll
+ * into view during a pan.
+ */
+const VIEWPORT_CULL_MARGIN = 0.25;
+
+type ShapeBBox = { minX: number; minY: number; maxX: number; maxY: number };
+
+/** An indexed shape: the live Y.Map plus its cached bounding box for culling. */
+type IndexedLine = { line: Y.Map<any>; bbox: ShapeBBox | null };
+
+/**
+ * Compute the (board-space) bounding box of a shape from its stored points,
+ * expanded by half the stroke width so the outline is fully covered.  Reads the
+ * Yjs points array directly — no React subscription — so off-screen shapes can
+ * be culled without mounting a component for each.
+ */
+function computeShapeBBox(line: Y.Map<any>): ShapeBBox | null {
+  const pts = line.get('points') as Y.Array<number> | undefined;
+  if (!pts || pts.length < 2) return null;
+  const arr = pts.toArray();
+  const size = (line.get('size') as number) ?? 5;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (let i = 0; i + 1 < arr.length; i += 2) {
+    const x = arr[i];
+    const y = arr[i + 1];
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+  }
+  const m = size / 2 + 1;
+  return { minX: minX - m, minY: minY - m, maxX: maxX + m, maxY: maxY + m };
+}
+
+/** Reference-equality comparison of two Y.Map arrays (same length, same items). */
+function sameLineArray(a: Y.Map<any>[], b: Y.Map<any>[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/**
+ * The committed (finalized) annotations layer.  Memoized and keyed by stable
+ * shape id so that drawing an in-progress stroke (which re-renders the parent on
+ * every pointer move) does NOT reconcile the potentially-thousands of finalized
+ * shapes.  It only re-renders when the visible set or erase handler changes.
+ */
+const CommittedAnnotations = memo(function CommittedAnnotations(props: {
+  lines: Y.Map<any>[];
+  onErase: (id: string) => void;
+}) {
+  return (
+    <>
+      {props.lines.map((line) => (
+        <Line key={line.get('id')} line={line} onClick={props.onErase} />
+      ))}
+    </>
+  );
+});
 
 type WhiteboardProps = {
   boardId: string;
@@ -226,6 +287,60 @@ export function Whiteboard(props: WhiteboardProps) {
     };
   }, [primaryActionMode, flushSave]);
 
+  // DEV-ONLY: generate N freehand strokes for performance testing at scale.
+  // Pushes generated shapes straight into the Yjs array (same path a real
+  // stroke commit uses), spread over a grid so both zoomed-in (culling) and
+  // zoomed-out (all-visible) regimes can be exercised.  Persists via the normal
+  // debounced save, so a reload cold-loads them.  Call from the browser
+  // console: seedStrokes(3000).  Stripped from production builds.
+  function seedTestStrokes(count: number) {
+    if (!yLines || !yDoc) return;
+    const colors = ['red', 'blue', 'green', 'orange', 'purple', 'teal', 'pink', 'cyan'];
+    const cols = Math.ceil(Math.sqrt(count));
+    const spacing = 400; // board units between strokes
+    const ox = boardWidth / 2 - (cols * spacing) / 2;
+    const oy = boardHeight / 2 - (cols * spacing) / 2;
+    yDoc.transact(() => {
+      for (let i = 0; i < count; i++) {
+        const gx = ox + (i % cols) * spacing;
+        const gy = oy + Math.floor(i / cols) * spacing;
+        const n = 8 + Math.floor(Math.random() * 20); // ~8–28 points per squiggle
+        let x = gx;
+        let y = gy;
+        const flat: number[] = [];
+        for (let p = 0; p < n; p++) {
+          x += (Math.random() - 0.5) * 60;
+          y += (Math.random() - 0.5) * 60;
+          flat.push(Math.round(x * 10) / 10, Math.round(y * 10) / 10);
+        }
+        const pts = new Y.Array<number>();
+        pts.push(flat);
+        const yShape = new Y.Map<any>();
+        yShape.set('id', `seed-${Date.now()}-${i}`);
+        yShape.set('type', 'line');
+        yShape.set('points', pts);
+        yShape.set('userColor', colors[i % colors.length]);
+        yShape.set('alpha', 0.8);
+        yShape.set('size', 15);
+        yShape.set('isComplete', true);
+        yShape.set('userId', user?._id);
+        yShape.set('text', '');
+        yLines.push([yShape]);
+      }
+    });
+    scheduleSave();
+    console.log(`[seedStrokes] generated ${count} freehand strokes`);
+  }
+
+  // Expose the seeder on window in development builds only.
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') return;
+    (window as any).seedStrokes = seedTestStrokes;
+    return () => {
+      delete (window as any).seedStrokes;
+    };
+  }, [yLines, yDoc, boardWidth, boardHeight, user, scheduleSave]);
+
   /**
    * Cancel and discard the in-progress stroke (if any).  Called when a second
    * touch finger arrives so the initial single-finger touch doesn't leave a
@@ -249,7 +364,7 @@ export function Whiteboard(props: WhiteboardProps) {
       const localY = y / scale - boardPosition.y;
       return [localX, localY];
     },
-    [boardPosition.x, boardPosition.y, scale]
+    [boardPosition.x, boardPosition.y, scale],
   );
 
   /**
@@ -358,7 +473,18 @@ export function Whiteboard(props: WhiteboardProps) {
         return;
       }
       // Determine type based on current tool
-      const type = primaryActionMode === 'rectangle' ? 'rectangle' : primaryActionMode === 'pen' ? 'line' : primaryActionMode === 'circle' ? 'circle' : primaryActionMode === 'arrow' ? 'arrow' : primaryActionMode === 'doubleArrow' ? 'doubleArrow' : 'eraser';
+      const type =
+        primaryActionMode === 'rectangle'
+          ? 'rectangle'
+          : primaryActionMode === 'pen'
+            ? 'line'
+            : primaryActionMode === 'circle'
+              ? 'circle'
+              : primaryActionMode === 'arrow'
+                ? 'arrow'
+                : primaryActionMode === 'doubleArrow'
+                  ? 'doubleArrow'
+                  : 'eraser';
       if (type === 'eraser') return;
       if (!yLines || !yDoc || !canAnnotate || !boardSynced) return;
       if (!e.isPrimary || e.button !== 0) return;
@@ -376,7 +502,7 @@ export function Whiteboard(props: WhiteboardProps) {
       setDraftPoints(rDraftPoints.current);
       setCursorPosition({ x: x0, y: y0 });
     },
-    [yLines, yDoc, canAnnotate, boardSynced, primaryActionMode, color, markerOpacity, markerSize, user, getPoint]
+    [yLines, yDoc, canAnnotate, boardSynced, primaryActionMode, color, markerOpacity, markerSize, user, getPoint],
   );
 
   /**
@@ -421,12 +547,11 @@ export function Whiteboard(props: WhiteboardProps) {
         const start = rDraftPoints.current[0];
         rDraftPoints.current = [start, [x, y]];
         setDraftPoints(rDraftPoints.current);
-      }
-      else {
+      } else {
         setCursorPosition(null);
       }
     },
-    [primaryActionMode, getPoint, scale]
+    [primaryActionMode, getPoint, scale],
   );
 
   /**
@@ -547,7 +672,7 @@ export function Whiteboard(props: WhiteboardProps) {
       // Debounced so a burst of strokes coalesces into a single save.
       if (committed) scheduleSave();
     },
-    [scheduleSave, yLines, yDoc, scale]
+    [scheduleSave, yLines, yDoc, scale],
   );
 
   /**
@@ -595,21 +720,60 @@ export function Whiteboard(props: WhiteboardProps) {
   }, [undoLastMarker]);
 
   /**
-   * Remove a shape when clicked on.
+   * Remove a shape when clicked on.  Stable identity (useCallback) so the
+   * memoized committed-annotations layer isn't re-rendered by drawing.
    */
-  const lineClicked = (id: string) => {
-    if (!yLines) return;
-    let deleted = false;
-    for (let index = yLines.length - 1; index >= 0; index--) {
-      const line = yLines.get(index);
-      if (line.get('id') === id) {
-        yLines.delete(index, 1);
-        deleted = true;
-        break;
+  const lineClicked = useCallback(
+    (id: string) => {
+      if (!yLines) return;
+      let deleted = false;
+      for (let index = yLines.length - 1; index >= 0; index--) {
+        const line = yLines.get(index);
+        if (line.get('id') === id) {
+          yLines.delete(index, 1);
+          deleted = true;
+          break;
+        }
+      }
+      if (deleted) saveNow();
+    },
+    [yLines, saveNow]
+  );
+
+  // Bounding-box index over all committed shapes.  Rebuilt only when the set of
+  // shapes changes (commit/delete) — not on pan/zoom or while drawing.
+  const bboxIndex = useMemo<IndexedLine[]>(
+    () => lines.map((line) => ({ line, bbox: computeShapeBBox(line) })),
+    [lines]
+  );
+
+  // Visible subset: shapes whose bbox intersects the (margin-expanded) viewport.
+  // Recomputed on pan/zoom, but returns the SAME array reference when the visible
+  // set is unchanged, so the memoized committed layer doesn't re-render
+  // needlessly (and never re-renders during drawing, when the viewport is fixed).
+  const prevVisible = useRef<Y.Map<any>[]>([]);
+  const visibleLines = useMemo(() => {
+    const winW = typeof window !== 'undefined' ? window.innerWidth : 1920;
+    const winH = typeof window !== 'undefined' ? window.innerHeight : 1080;
+    const viewW = winW / scale;
+    const viewH = winH / scale;
+    const marginX = viewW * VIEWPORT_CULL_MARGIN;
+    const marginY = viewH * VIEWPORT_CULL_MARGIN;
+    const vMinX = -boardPosition.x - marginX;
+    const vMaxX = -boardPosition.x + viewW + marginX;
+    const vMinY = -boardPosition.y - marginY;
+    const vMaxY = -boardPosition.y + viewH + marginY;
+    const next: Y.Map<any>[] = [];
+    for (const { line, bbox } of bboxIndex) {
+      // Shapes with no computable bbox (e.g. degenerate) are always kept.
+      if (!bbox || (bbox.maxX >= vMinX && bbox.minX <= vMaxX && bbox.maxY >= vMinY && bbox.minY <= vMaxY)) {
+        next.push(line);
       }
     }
-    if (deleted) saveNow();
-  };
+    if (sameLineArray(next, prevVisible.current)) return prevVisible.current;
+    prevVisible.current = next;
+    return next;
+  }, [bboxIndex, boardPosition.x, boardPosition.y, scale]);
 
   // Hotkeys: undo last line (Pen only)
   useHotkeys(
@@ -619,7 +783,7 @@ export function Whiteboard(props: WhiteboardProps) {
         setUndoLastMarker(true);
       }
     },
-    { dependencies: [primaryActionMode] }
+    { dependencies: [primaryActionMode] },
   );
   useHotkeys(
     'cmd+z',
@@ -628,19 +792,15 @@ export function Whiteboard(props: WhiteboardProps) {
         setUndoLastMarker(true);
       }
     },
-    { dependencies: [primaryActionMode] }
+    { dependencies: [primaryActionMode] },
   );
 
   return (
     <div
       className="canvas-container"
       style={{
-        pointerEvents: ['pen', 'eraser', 'rectangle', 'circle', 'arrow', 'doubleArrow'].includes(primaryActionMode)
-          ? 'auto'
-          : 'none',
-        touchAction: ['pen', 'eraser', 'rectangle', 'circle', 'arrow', 'doubleArrow'].includes(primaryActionMode)
-          ? 'none'
-          : 'auto',
+        pointerEvents: ['pen', 'eraser', 'rectangle', 'circle', 'arrow', 'doubleArrow'].includes(primaryActionMode) ? 'auto' : 'none',
+        touchAction: ['pen', 'eraser', 'rectangle', 'circle', 'arrow', 'doubleArrow'].includes(primaryActionMode) ? 'none' : 'auto',
       }}
     >
       <svg
@@ -653,8 +813,8 @@ export function Whiteboard(props: WhiteboardProps) {
           left: 0,
           top: 0,
           zIndex: 1000,
-        // Use a consistent crosshair cursor for all annotation tools
-        cursor: 'crosshair',
+          // Use a consistent crosshair cursor for all annotation tools
+          cursor: 'crosshair',
         }}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
@@ -677,10 +837,9 @@ export function Whiteboard(props: WhiteboardProps) {
         {...dragProps}
       >
         <g>
-          {/* Render all shapes */}
-          {lines.map((line, i) => (
-            <Line key={i} line={line} onClick={lineClicked} />
-          ))}
+          {/* Render committed shapes — culled to the viewport and isolated in a
+              memoized subtree so drawing/panning stays cheap at scale. */}
+          <CommittedAnnotations lines={visibleLines} onErase={lineClicked} />
           {/* In-progress (local, non-persisted) draft stroke preview */}
           {rDraft.current && draftPoints.length > 0 && (
             <ShapeView

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -185,6 +185,7 @@ export function Whiteboard(props: WhiteboardProps) {
 
   // Annotations Store
   const updateAnnotation = useAnnotationStore((state) => state.update);
+  const appendLines = useAnnotationStore((state) => state.appendLines);
   const subAnnotations = useAnnotationStore((state) => state.subscribeToBoard);
   const unsubAnnotations = useAnnotationStore((state) => state.unsubscribe);
   const getAnnotations = useAnnotationStore((state) => state.getAnnotations);
@@ -211,9 +212,9 @@ export function Whiteboard(props: WhiteboardProps) {
   const { dragProps, renderContent } = useDragAndDropBoard({ roomId: props.roomId, boardId: props.boardId });
 
   /**
-   * Persist the Yjs lines array to the SAGE annotation store.  Called after
-   * completing a stroke or clearing markers.  Only runs when yLines and
-   * boardId are defined.
+   * Full save: serialize the entire Yjs lines array and PUT it.  O(board).  Used
+   * for destructive ops (clear/undo/erase) and as reconciliation if an
+   * incremental append ever fails.  Only runs when yLines and boardId are set.
    */
   function updateBoardLines() {
     if (yLines && props.boardId) {
@@ -222,16 +223,40 @@ export function Whiteboard(props: WhiteboardProps) {
     }
   }
 
-  // Debounced persistence.  updateBoardLines() serializes and PUTs the whole
-  // whiteboardLines array, so calling it on every stroke is O(board) per stroke.
-  // We coalesce rapid edits into a single trailing save and force a flush on
-  // tab-hide/unload and tool/board change so nothing is lost.
+  // Incremental persistence.  New strokes are queued and appended with a single
+  // O(stroke) request per debounce window; only destructive ops (or a failed
+  // append) fall back to the O(board) full save.  Rapid commits coalesce, and a
+  // flush is forced on tab-hide/unload and tool/board change so nothing is lost.
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveDirty = useRef(false);
+  const pendingAppends = useRef<any[]>([]); // serialized shapes awaiting append
+  const needsFullSave = useRef(false); // a remove/clear (or append failure) occurred
+
+  // Decide append-vs-full and execute.  A pending full save supersedes queued
+  // appends (they are already present in the serialized array).
+  function persist() {
+    if (needsFullSave.current) {
+      needsFullSave.current = false;
+      pendingAppends.current = [];
+      updateBoardLines();
+    } else if (pendingAppends.current.length > 0 && props.boardId) {
+      const batch = pendingAppends.current;
+      pendingAppends.current = [];
+      appendLines(props.boardId, batch).then((ok) => {
+        if (!ok) {
+          // Re-queue as a reconciling full save on the next flush.
+          needsFullSave.current = true;
+          saveDirty.current = true;
+          scheduleSave();
+        }
+      });
+    }
+  }
+
   // Latest-ref so the stable save helpers below always call the current closure.
-  const updateBoardLinesRef = useRef(updateBoardLines);
+  const persistRef = useRef(persist);
   useEffect(() => {
-    updateBoardLinesRef.current = updateBoardLines;
+    persistRef.current = persist;
   });
 
   // Schedule a trailing save — used for high-frequency stroke commits.
@@ -242,7 +267,7 @@ export function Whiteboard(props: WhiteboardProps) {
       saveTimer.current = null;
       if (!saveDirty.current) return;
       saveDirty.current = false;
-      updateBoardLinesRef.current();
+      persistRef.current();
     }, SAVE_DEBOUNCE_MS);
   }, []);
 
@@ -254,7 +279,7 @@ export function Whiteboard(props: WhiteboardProps) {
       saveTimer.current = null;
     }
     saveDirty.current = false;
-    updateBoardLinesRef.current();
+    persistRef.current();
   }, []);
 
   // Save immediately — used for infrequent destructive ops (clear/undo/erase).
@@ -264,8 +289,15 @@ export function Whiteboard(props: WhiteboardProps) {
       saveTimer.current = null;
     }
     saveDirty.current = false;
-    updateBoardLinesRef.current();
+    persistRef.current();
   }, []);
+
+  // Force a full (reconciling) save immediately — for destructive ops that
+  // change existing shapes, where an incremental append cannot express the change.
+  const saveFullNow = useCallback(() => {
+    needsFullSave.current = true;
+    saveNow();
+  }, [saveNow]);
 
   // Force a flush when the tab is hidden or the page is unloaded.
   useEffect(() => {
@@ -328,7 +360,9 @@ export function Whiteboard(props: WhiteboardProps) {
         yLines.push([yShape]);
       }
     });
-    scheduleSave();
+    // Seeded shapes are pushed straight into yLines (not queued as appends), so
+    // persist the whole array once.
+    saveFullNow();
     console.log(`[seedStrokes] generated ${count} freehand strokes`);
   }
 
@@ -584,6 +618,8 @@ export function Whiteboard(props: WhiteboardProps) {
       yShape.set('text', '');
     });
     yLines.push([yShape]);
+    // Queue the plain snapshot for an incremental append (persisted on save).
+    pendingAppends.current.push(yShape.toJSON());
   }
 
   const handlePointerUp = useCallback(
@@ -682,7 +718,7 @@ export function Whiteboard(props: WhiteboardProps) {
     if (yLines && clearAllMarkers) {
       yLines.delete(0, yLines.length);
       setClearAllMarkers(false);
-      saveNow();
+      saveFullNow();
     }
   }, [clearAllMarkers]);
 
@@ -697,7 +733,7 @@ export function Whiteboard(props: WhiteboardProps) {
           yLines.delete(index, 1);
         }
       }
-      saveNow();
+      saveFullNow();
       setClearMarkers(false);
     }
   }, [clearMarkers]);
@@ -714,7 +750,7 @@ export function Whiteboard(props: WhiteboardProps) {
           break;
         }
       }
-      saveNow();
+      saveFullNow();
       setUndoLastMarker(false);
     }
   }, [undoLastMarker]);
@@ -735,9 +771,9 @@ export function Whiteboard(props: WhiteboardProps) {
           break;
         }
       }
-      if (deleted) saveNow();
+      if (deleted) saveFullNow();
     },
-    [yLines, saveNow]
+    [yLines, saveFullNow]
   );
 
   // Bounding-box index over all committed shapes.  Rebuilt only when the set of

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -68,6 +68,18 @@ const SIMPLIFY_TOL_PX = 0.5;
 const SAVE_DEBOUNCE_MS = 1500;
 
 /**
+ * Cold-load hydration tuning.  Persisted annotations are loaded into Yjs in
+ * chunks — each chunk is a SINGLE Yjs transaction plus one batched array push
+ * (vs. a transaction + push per stroke) — and the loop yields to the event loop
+ * between chunks so a very large board (tens of thousands of strokes) renders
+ * progressively instead of freezing the main thread.  To bound the O(n) bbox
+ * re-index, the visible set is refreshed only every RENDER_EVERY_CHUNKS chunks
+ * (plus the first and last).
+ */
+const HYDRATE_CHUNK_SIZE = 2000;
+const RENDER_EVERY_CHUNKS = 4;
+
+/**
  * Round to 0.1 board units — matching the stroke renderer's own `toFixed(1)`
  * precision.  Finer than integer rounding so strokes stay smooth when zoomed in
  * (up to 6x, 0.1 unit ≈ 0.6 screen px), while not exceeding what the SVG path
@@ -128,11 +140,27 @@ function sameLineArray(a: Y.Map<any>[], b: Y.Map<any>[]): boolean {
   return true;
 }
 
+// Stable, guaranteed-unique React key per shape.  Some persisted boards contain
+// duplicate shape ids, so keying by id alone triggers "two children with the
+// same key" warnings and reconciliation bugs.  Keying by the Y.Map's object
+// identity (via a WeakMap counter) is both unique and stable across re-renders.
+let shapeKeyCounter = 0;
+const shapeKeys = new WeakMap<object, string>();
+function shapeKey(line: Y.Map<any>): string {
+  let k = shapeKeys.get(line);
+  if (k === undefined) {
+    k = `s${shapeKeyCounter++}`;
+    shapeKeys.set(line, k);
+  }
+  return k;
+}
+
 /**
  * The committed (finalized) annotations layer.  Memoized and keyed by stable
- * shape id so that drawing an in-progress stroke (which re-renders the parent on
- * every pointer move) does NOT reconcile the potentially-thousands of finalized
- * shapes.  It only re-renders when the visible set or erase handler changes.
+ * per-shape identity so that drawing an in-progress stroke (which re-renders the
+ * parent on every pointer move) does NOT reconcile the potentially-thousands of
+ * finalized shapes.  It only re-renders when the visible set or erase handler
+ * changes.
  */
 const CommittedAnnotations = memo(function CommittedAnnotations(props: {
   lines: Y.Map<any>[];
@@ -141,7 +169,7 @@ const CommittedAnnotations = memo(function CommittedAnnotations(props: {
   return (
     <>
       {props.lines.map((line) => (
-        <Line key={line.get('id')} line={line} onClick={props.onErase} />
+        <Line key={shapeKey(line)} line={line} onClick={props.onErase} />
       ))}
     </>
   );
@@ -196,6 +224,9 @@ export function Whiteboard(props: WhiteboardProps) {
   const [yLines, setYlines] = useState<Y.Array<Y.Map<any>> | null>(null);
   const [lines, setLines] = useState<Y.Map<any>[]>([]);
   const activeTouchCount = useRef(0);
+  // True while the cold-load hydration is populating yLines in chunks; the array
+  // observer defers to the explicit progressive setLines during this window.
+  const hydrating = useRef(false);
 
   // In-progress stroke: held entirely in local state so that pointer moves do
   // NOT write to the Yjs document.  The shape is committed to Yjs exactly once,
@@ -408,6 +439,9 @@ export function Whiteboard(props: WhiteboardProps) {
    */
   useEffect(() => {
     function handleChange() {
+      // During chunked cold-load hydration, setLines is driven explicitly at a
+      // bounded cadence; skip the per-push refresh to avoid O(n^2) re-indexing.
+      if (hydrating.current) return;
       if (yLines) {
         setLines(yLines.toArray());
       }
@@ -430,6 +464,28 @@ export function Whiteboard(props: WhiteboardProps) {
    * into the Yjs doc.
    */
   useEffect(() => {
+    // Set when the effect is torn down (board switch / unmount) so an in-flight
+    // chunked hydration stops instead of writing into a stale doc.
+    let cancelled = false;
+
+    // Build a single Yjs shape map from a persisted line record.
+    function toYLine(line: any): Y.Map<any> {
+      const pts = new Y.Array<number>();
+      // Persisted points are a flat [x, y, x, y, ...] array.
+      pts.push(line.points);
+      const yLine = new Y.Map<any>();
+      yLine.set('id', line.id);
+      yLine.set('type', line.type ?? 'line');
+      yLine.set('points', pts);
+      yLine.set('userColor', line.userColor);
+      yLine.set('alpha', line.alpha);
+      yLine.set('size', line.size);
+      yLine.set('isComplete', true);
+      yLine.set('userId', line.userId);
+      yLine.set('text', line.text);
+      return yLine;
+    }
+
     async function connectYjs(yRoom: YjsRoomConnection) {
       const yLinesArr = yRoom.doc.getArray('lines') as Y.Array<Y.Map<any>>;
       const ydoc = yRoom.doc;
@@ -438,46 +494,64 @@ export function Whiteboard(props: WhiteboardProps) {
       setYlines(yLinesArr);
       setLines(yLinesArr.toArray());
 
-      // If I'm the only user connected, sync lines from the DB
+      // Only the first (solo) connection hydrates from the DB; otherwise state
+      // arrives via Yjs sync from peers.
       const users = yRoom.provider.awareness.getStates();
-      if (users.size === 1) {
-        const dbLines = getAnnotations();
-        if (dbLines && ydoc) {
-          // Clear the Yjs array
-          yLinesArr.delete(0, yLinesArr.length);
-          // Push each persisted line/rectangle into the Yjs array
-          dbLines.data.whiteboardLines.forEach((line: any) => {
-            const pts = new Y.Array<number>();
-            // If the persisted line stores points as nested arrays, push them
-            pts.push(line.points);
-            const yLine = new Y.Map<any>();
-            ydoc.transact(() => {
-              yLine.set('id', line.id);
-              yLine.set('type', line.type ?? 'line');
-              yLine.set('points', pts);
-              yLine.set('userColor', line.userColor);
-              yLine.set('alpha', line.alpha);
-              yLine.set('size', line.size);
-              yLine.set('isComplete', true);
-              yLine.set('userId', line.userId);
-              yLine.set('text', line.text);
-            });
-            yLinesArr.push([yLine]);
-          });
-          // Update local state
+      if (users.size !== 1) return;
+      const dbLines = getAnnotations();
+      if (!dbLines || !ydoc) return;
+
+      const all = dbLines.data.whiteboardLines as any[];
+      const total = all.length;
+      const t0 = performance.now();
+
+      // Clear any existing strokes, then hydrate in chunks: each chunk is ONE
+      // transaction + ONE batched push, and we yield between chunks so the board
+      // renders progressively and the main thread stays responsive.
+      hydrating.current = true;
+      ydoc.transact(() => yLinesArr.delete(0, yLinesArr.length));
+
+      let chunkIndex = 0;
+      for (let start = 0; start < total; start += HYDRATE_CHUNK_SIZE) {
+        if (cancelled) {
+          hydrating.current = false;
+          return;
+        }
+        const chunk = all.slice(start, start + HYDRATE_CHUNK_SIZE);
+        ydoc.transact(() => {
+          yLinesArr.push(chunk.map(toYLine));
+        });
+        chunkIndex += 1;
+        const isLast = start + HYDRATE_CHUNK_SIZE >= total;
+        // Progressive render, but not every chunk (bounds the bbox re-index).
+        if (isLast || chunkIndex === 1 || chunkIndex % RENDER_EVERY_CHUNKS === 0) {
           setLines(yLinesArr.toArray());
         }
+        if (!isLast) {
+          await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+        }
+      }
+
+      hydrating.current = false;
+      if (!cancelled) {
+        setLines(yLinesArr.toArray());
+        console.log(`[annotations] hydrated ${total} strokes in ${Math.round(performance.now() - t0)}ms`);
       }
     }
+
     async function connect(yRoom: YjsRoomConnection) {
       setLines([]);
+      const tGet = performance.now();
       await subAnnotations(props.boardId);
+      console.log(`[annotations] fetched from server in ${Math.round(performance.now() - tGet)}ms`);
+      if (cancelled) return;
       connectYjs(yRoom);
     }
     if (yAnnotations) {
       connect(yAnnotations);
     }
     return () => {
+      cancelled = true;
       // Persist any pending edits before tearing down (e.g. board switch).
       flushSave();
       unsubAnnotations();
@@ -523,7 +597,9 @@ export function Whiteboard(props: WhiteboardProps) {
       if (!yLines || !yDoc || !canAnnotate || !boardSynced) return;
       if (!e.isPrimary || e.button !== 0) return;
 
-      const id = Date.now().toString();
+      // Collision-resistant id: Date.now() alone repeats for strokes committed
+      // in the same millisecond, which produced duplicate ids on existing boards.
+      const id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
       const [x0, y0] = getPoint(e.clientX, e.clientY);
 
       // Capture pointer events

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -140,6 +140,41 @@ function sameLineArray(a: Y.Map<any>[], b: Y.Map<any>[]): boolean {
   return true;
 }
 
+/** Build a single Yjs shape map from a persisted/plain line record. */
+function buildYLineMap(line: any): Y.Map<any> {
+  const pts = new Y.Array<number>();
+  // Persisted points are a flat [x, y, x, y, ...] array.
+  pts.push(line.points);
+  const yLine = new Y.Map<any>();
+  yLine.set('id', line.id);
+  yLine.set('type', line.type ?? 'line');
+  yLine.set('points', pts);
+  yLine.set('userColor', line.userColor);
+  yLine.set('alpha', line.alpha);
+  yLine.set('size', line.size);
+  yLine.set('isComplete', true);
+  yLine.set('userId', line.userId);
+  yLine.set('text', line.text);
+  return yLine;
+}
+
+/**
+ * Content signature of a shape (type + style + text + points) used to detect
+ * duplicate strokes.  Two shapes with the same signature are visually identical,
+ * so keeping one is safe — unlike de-duping by id, this never drops distinct
+ * strokes that merely collided on an old Date.now() id.
+ */
+function shapeSignature(json: any): string {
+  return [
+    json.type ?? 'line',
+    json.userColor,
+    json.size,
+    json.alpha,
+    json.text ?? '',
+    (json.points || []).join(','),
+  ].join('|');
+}
+
 // Stable, guaranteed-unique React key per shape.  Some persisted boards contain
 // duplicate shape ids, so keying by id alone triggers "two children with the
 // same key" warnings and reconciliation bugs.  Keying by the Y.Map's object
@@ -407,6 +442,56 @@ export function Whiteboard(props: WhiteboardProps) {
   }, [yLines, yDoc, boardWidth, boardHeight, user, scheduleSave]);
 
   /**
+   * Remove duplicate strokes from the board and persist the cleaned set.  Fixes
+   * boards created with the old id scheme, where the same stroke was stored many
+   * times.  De-dupes by content signature (type + style + text + points), keeping
+   * the first occurrence, then rebuilds the Yjs array in one batched transaction
+   * and does a full save.  Returns the number of duplicates removed.  Requires
+   * annotate permission.  Callable from the console: dedupAnnotations().
+   */
+  function dedupAnnotations(): number {
+    if (!yLines || !yDoc || !canAnnotate) return 0;
+    const arr = yLines.toArray();
+    const before = arr.length;
+    const seen = new Set<string>();
+    const unique: any[] = [];
+    for (const m of arr) {
+      const json = m.toJSON();
+      const sig = shapeSignature(json);
+      if (!seen.has(sig)) {
+        seen.add(sig);
+        unique.push(json);
+      }
+    }
+    const removed = before - unique.length;
+    if (removed === 0) {
+      console.log('[dedupAnnotations] no duplicates found');
+      return 0;
+    }
+    // Rebuild the array with one copy of each unique shape (batched), suppressing
+    // the observer during the rebuild, then persist the cleaned array.
+    hydrating.current = true;
+    yDoc.transact(() => {
+      yLines.delete(0, yLines.length);
+      yLines.push(unique.map(buildYLineMap));
+    });
+    hydrating.current = false;
+    setLines(yLines.toArray());
+    saveFullNow();
+    console.log(`[dedupAnnotations] ${before} -> ${unique.length} strokes (removed ${removed}); saving…`);
+    return removed;
+  }
+
+  // Expose the cleanup on window (all builds) so a problematic board can be fixed
+  // from the console: dedupAnnotations().  The save itself is permission-gated.
+  useEffect(() => {
+    (window as any).dedupAnnotations = dedupAnnotations;
+    return () => {
+      delete (window as any).dedupAnnotations;
+    };
+  }, [yLines, yDoc, canAnnotate, saveFullNow]);
+
+  /**
    * Cancel and discard the in-progress stroke (if any).  Called when a second
    * touch finger arrives so the initial single-finger touch doesn't leave a
    * tiny dot behind during a pan/zoom gesture.  Since the in-progress stroke
@@ -468,24 +553,6 @@ export function Whiteboard(props: WhiteboardProps) {
     // chunked hydration stops instead of writing into a stale doc.
     let cancelled = false;
 
-    // Build a single Yjs shape map from a persisted line record.
-    function toYLine(line: any): Y.Map<any> {
-      const pts = new Y.Array<number>();
-      // Persisted points are a flat [x, y, x, y, ...] array.
-      pts.push(line.points);
-      const yLine = new Y.Map<any>();
-      yLine.set('id', line.id);
-      yLine.set('type', line.type ?? 'line');
-      yLine.set('points', pts);
-      yLine.set('userColor', line.userColor);
-      yLine.set('alpha', line.alpha);
-      yLine.set('size', line.size);
-      yLine.set('isComplete', true);
-      yLine.set('userId', line.userId);
-      yLine.set('text', line.text);
-      return yLine;
-    }
-
     async function connectYjs(yRoom: YjsRoomConnection) {
       const yLinesArr = yRoom.doc.getArray('lines') as Y.Array<Y.Map<any>>;
       const ydoc = yRoom.doc;
@@ -501,8 +568,23 @@ export function Whiteboard(props: WhiteboardProps) {
       const dbLines = getAnnotations();
       if (!dbLines || !ydoc) return;
 
-      const all = dbLines.data.whiteboardLines as any[];
+      const raw = dbLines.data.whiteboardLines as any[];
+      const rawTotal = raw.length;
+
+      // Auto de-duplicate on load: older boards stored the same stroke many
+      // times.  Keep one copy per content signature so we hydrate the real
+      // strokes, not the redundant copies.  If any were dropped, the cleaned set
+      // is persisted below so the board is fixed for next time.
+      const seen = new Set<string>();
+      const all: any[] = [];
+      for (const line of raw) {
+        const sig = shapeSignature(line);
+        if (seen.has(sig)) continue;
+        seen.add(sig);
+        all.push(line);
+      }
       const total = all.length;
+      const duplicatesRemoved = rawTotal - total;
       const t0 = performance.now();
 
       // Clear any existing strokes, then hydrate in chunks: each chunk is ONE
@@ -519,7 +601,7 @@ export function Whiteboard(props: WhiteboardProps) {
         }
         const chunk = all.slice(start, start + HYDRATE_CHUNK_SIZE);
         ydoc.transact(() => {
-          yLinesArr.push(chunk.map(toYLine));
+          yLinesArr.push(chunk.map(buildYLineMap));
         });
         chunkIndex += 1;
         const isLast = start + HYDRATE_CHUNK_SIZE >= total;
@@ -535,7 +617,12 @@ export function Whiteboard(props: WhiteboardProps) {
       hydrating.current = false;
       if (!cancelled) {
         setLines(yLinesArr.toArray());
-        console.log(`[annotations] hydrated ${total} strokes in ${Math.round(performance.now() - t0)}ms`);
+        console.log(
+          `[annotations] hydrated ${total} strokes in ${Math.round(performance.now() - t0)}ms` +
+            (duplicatesRemoved > 0 ? ` (removed ${duplicatesRemoved} duplicates)` : '')
+        );
+        // Persist the cleaned set so the duplicates don't return on next load.
+        if (duplicatesRemoved > 0) saveFullNow();
       }
     }
 

--- a/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
+++ b/webstack/apps/webapp/src/app/pages/board/layers/background/components/Whiteboard/Whiteboard.tsx
@@ -175,6 +175,22 @@ function shapeSignature(json: any): string {
   ].join('|');
 }
 
+/**
+ * Return one copy of each unique shape (by content signature), preserving order.
+ * Used to clean up boards that stored the same stroke many times.
+ */
+function dedupeLines(raw: any[]): any[] {
+  const seen = new Set<string>();
+  const unique: any[] = [];
+  for (const line of raw) {
+    const sig = shapeSignature(line);
+    if (seen.has(sig)) continue;
+    seen.add(sig);
+    unique.push(line);
+  }
+  return unique;
+}
+
 // Stable, guaranteed-unique React key per shape.  Some persisted boards contain
 // duplicate shape ids, so keying by id alone triggers "two children with the
 // same key" warnings and reconciliation bugs.  Keying by the Y.Map's object
@@ -442,56 +458,6 @@ export function Whiteboard(props: WhiteboardProps) {
   }, [yLines, yDoc, boardWidth, boardHeight, user, scheduleSave]);
 
   /**
-   * Remove duplicate strokes from the board and persist the cleaned set.  Fixes
-   * boards created with the old id scheme, where the same stroke was stored many
-   * times.  De-dupes by content signature (type + style + text + points), keeping
-   * the first occurrence, then rebuilds the Yjs array in one batched transaction
-   * and does a full save.  Returns the number of duplicates removed.  Requires
-   * annotate permission.  Callable from the console: dedupAnnotations().
-   */
-  function dedupAnnotations(): number {
-    if (!yLines || !yDoc || !canAnnotate) return 0;
-    const arr = yLines.toArray();
-    const before = arr.length;
-    const seen = new Set<string>();
-    const unique: any[] = [];
-    for (const m of arr) {
-      const json = m.toJSON();
-      const sig = shapeSignature(json);
-      if (!seen.has(sig)) {
-        seen.add(sig);
-        unique.push(json);
-      }
-    }
-    const removed = before - unique.length;
-    if (removed === 0) {
-      console.log('[dedupAnnotations] no duplicates found');
-      return 0;
-    }
-    // Rebuild the array with one copy of each unique shape (batched), suppressing
-    // the observer during the rebuild, then persist the cleaned array.
-    hydrating.current = true;
-    yDoc.transact(() => {
-      yLines.delete(0, yLines.length);
-      yLines.push(unique.map(buildYLineMap));
-    });
-    hydrating.current = false;
-    setLines(yLines.toArray());
-    saveFullNow();
-    console.log(`[dedupAnnotations] ${before} -> ${unique.length} strokes (removed ${removed}); saving…`);
-    return removed;
-  }
-
-  // Expose the cleanup on window (all builds) so a problematic board can be fixed
-  // from the console: dedupAnnotations().  The save itself is permission-gated.
-  useEffect(() => {
-    (window as any).dedupAnnotations = dedupAnnotations;
-    return () => {
-      delete (window as any).dedupAnnotations;
-    };
-  }, [yLines, yDoc, canAnnotate, saveFullNow]);
-
-  /**
    * Cancel and discard the in-progress stroke (if any).  Called when a second
    * touch finger arrives so the initial single-finger touch doesn't leave a
    * tiny dot behind during a pan/zoom gesture.  Since the in-progress stroke
@@ -575,14 +541,7 @@ export function Whiteboard(props: WhiteboardProps) {
       // times.  Keep one copy per content signature so we hydrate the real
       // strokes, not the redundant copies.  If any were dropped, the cleaned set
       // is persisted below so the board is fixed for next time.
-      const seen = new Set<string>();
-      const all: any[] = [];
-      for (const line of raw) {
-        const sig = shapeSignature(line);
-        if (seen.has(sig)) continue;
-        seen.add(sig);
-        all.push(line);
-      }
+      const all = dedupeLines(raw);
       const total = all.length;
       const duplicatesRemoved = rawTotal - total;
       const t0 = performance.now();
@@ -617,12 +576,15 @@ export function Whiteboard(props: WhiteboardProps) {
       hydrating.current = false;
       if (!cancelled) {
         setLines(yLinesArr.toArray());
-        console.log(
-          `[annotations] hydrated ${total} strokes in ${Math.round(performance.now() - t0)}ms` +
-            (duplicatesRemoved > 0 ? ` (removed ${duplicatesRemoved} duplicates)` : '')
-        );
+        console.log(`[annotations] hydrated ${total} strokes in ${Math.round(performance.now() - t0)}ms`);
         // Persist the cleaned set so the duplicates don't return on next load.
-        if (duplicatesRemoved > 0) saveFullNow();
+        if (duplicatesRemoved > 0) {
+          saveFullNow();
+          console.log(
+            `[annotations] de-duplicated board: removed ${duplicatesRemoved} duplicate strokes ` +
+              `(${rawTotal} → ${total}); persisted cleaned set`
+          );
+        }
       }
     }
 

--- a/webstack/libs/backend/src/lib/generics/SAGECollection.ts
+++ b/webstack/libs/backend/src/lib/generics/SAGECollection.ts
@@ -23,12 +23,18 @@ export class SAGE3Collection<T extends SBJSON> {
   private _collection!: SBCollectionRef<T>;
   private _name: string;
   private _queryableAttributes: Partial<T>;
+  // Whether single-document updates are broadcast to subscribers.  Defaults to
+  // true; a collection whose live sync is handled elsewhere (e.g. ANNOTATIONS,
+  // synced via Yjs) can opt out to avoid re-broadcasting the whole document on
+  // every update.
+  private _publishUpdates: boolean;
 
   private _httpRouter!: Router;
 
-  constructor(name: string, queryableAttributes: Partial<T>) {
+  constructor(name: string, queryableAttributes: Partial<T>, options?: { publishUpdates?: boolean }) {
     this._name = name;
     this._queryableAttributes = queryableAttributes;
+    this._publishUpdates = options?.publishUpdates ?? true;
   }
 
   protected get collection(): SBCollectionRef<T> {
@@ -162,7 +168,7 @@ export class SAGE3Collection<T extends SBJSON> {
    */
   public async update(id: string, by: string, update: SBDocumentUpdate<T>): Promise<SBDocument<T> | undefined> {
     try {
-      const response = await this._collection.docRef(id).update(update, by);
+      const response = await this._collection.docRef(id).update(update, by, this._publishUpdates);
       return response.doc;
     } catch (error) {
       this.printError(error);

--- a/webstack/libs/frontend/src/lib/stores/annotation.ts
+++ b/webstack/libs/frontend/src/lib/stores/annotation.ts
@@ -24,6 +24,7 @@ interface AnnotationState {
   fetched: boolean;
   clearError: () => void;
   update: (id: string, updates: Partial<AnnotationSchema>) => void;
+  appendLines: (id: string, lines: unknown[]) => Promise<boolean>;
   getAnnotations: () => Annotation | undefined;
   subscribeToBoard: (boardId: string) => Promise<void>;
   unsubscribe: () => void;
@@ -47,6 +48,17 @@ const AnnotationStore = create<AnnotationState>()((set, get) => {
       if (!res.success) {
         set({ error: res.message });
       }
+    },
+    // Incremental append: adds strokes without rewriting the whole array.
+    appendLines: async (id: string, lines: unknown[]): Promise<boolean> => {
+      if (!SAGE3Ability.canCurrentUser('update', 'boards')) return false;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const res = await APIHttp.POST(`/annotations/${id}/lines`, { lines } as any);
+      if (!res.success) {
+        set({ error: res.message });
+        return false;
+      }
+      return true;
     },
     unsubscribe: () => {
       // Unsubscribe old subscription

--- a/webstack/libs/sagebase/src/lib/modules/database/SBDocument.ts
+++ b/webstack/libs/sagebase/src/lib/modules/database/SBDocument.ts
@@ -186,6 +186,37 @@ export class SBDocumentRef<Type extends SBJSON> {
     }
   }
 
+  /**
+   * Append one or more values to a JSON array field of this document's data,
+   * without rewriting the whole array (RedisJSON ARRAPPEND).  This makes adding
+   * an element O(appended) instead of O(existing).  When `publish` is false the
+   * full document is not read back, keeping the whole operation independent of
+   * the array's current size.
+   */
+  public async arrayAppend(field: string, values: any[], by: string, publish = true): Promise<SBDocWriteResult<Type>> {
+    if (!values || values.length === 0) return generateWriteResult('update', this._colName, false);
+    const exists = await this._redisClient.exists(`${this.path}`);
+    if (exists === 0) {
+      this.ERRORLOG(`Doc does not exists.`);
+      return generateWriteResult('update', this._colName, false);
+    }
+    try {
+      await this._redisClient.json.arrAppend(`${this.path}`, `.data.${field}`, ...values);
+      // Refresh the updatedAt/updatedBy metadata.
+      await this.refreshUpdate(by);
+      // Only read back and broadcast the full document when asked to publish.
+      if (publish) {
+        const newValue = await this.read();
+        if (newValue) await this.publishUpdateAction(newValue, {});
+        return generateWriteResult<Type>('update', this._colName, true, newValue);
+      }
+      return generateWriteResult<Type>('update', this._colName, true);
+    } catch (error) {
+      this.ERRORLOG(error);
+      return generateWriteResult<Type>('update', this._colName, false);
+    }
+  }
+
   private async refreshUpdate(by?: string): Promise<void> {
     const updatedAt = Date.now();
     const redisRes = await this._redisClient.json.set(`${this.path}`, `._updatedAt`, updatedAt, { XX: true });


### PR DESCRIPTION
## Summary

Focused pass on the generation, rendering, persistence, and loading of whiteboard annotations. Goal: smooth drawing and fast loading whether a board has a handful of strokes or tens of thousands, and stop sending the whole annotation set on every save.

## Changes (by area)

### Per-stroke drawing / rendering
- **No per-move Yjs writes** — in-progress strokes live in local state and commit to Yjs once on pointer-up (was ~100 CRDT mutations + network updates per stroke, plus raw points bloating doc history).
- **Memoized stroke geometry** — a shared `ShapeView` renderer with `useMemo`'d `perfect-freehand` output, so finalized strokes aren't re-tessellated on hover.
- **Draft decimation** — 2px screen-space sampling + 0.1-unit rounding keeps the in-progress path small and crisp at any zoom.
- **Relative (`l`) SVG paths** — roughly halves the path `d` string on a 3,000,000-unit board, no accumulation drift.
- **Scale-aware simplify tolerance** — `SIMPLIFY_TOL_PX / scale`, consistent with the decimation across zoom levels.

### Scale to thousands of shapes
- **Isolated, memoized committed layer** — drawing no longer reconciles all committed shapes every pointer-move.
- **Viewport culling + lazy tessellation** — render/tessellate only shapes intersecting the (margin-expanded) viewport; off-screen shapes are read as plain data for their bbox, so per-shape Yjs observers scale with the visible set, not the total.
- **Robust React keys** — committed shapes are keyed by `Y.Map` object identity, so duplicate ids in stored data no longer trigger duplicate-key warnings or dropped elements.
- **Collision-resistant new-stroke ids** — `Date.now()` alone repeated within a millisecond (a source of duplicate ids); ids now include a random suffix.

### Persistence
- **Debounced saves** — one save per ~1.5s of activity with forced flushes on tab-hide/unload/tool/board change, instead of a PUT per stroke.
- **No echo broadcast** — the ANNOTATIONS collection opts out of per-update broadcasts (live sync is Yjs), so a save no longer re-sends the whole array to every subscriber.
- **Incremental append** — `SBDocument.arrayAppend()` (RedisJSON `ARRAPPEND`) + `POST /annotations/:id/lines`; committing strokes sends only the new shapes (O(stroke)) instead of the whole array (O(board)). Destructive ops (clear/undo/erase) and a failed append fall back to a reconciling full save.

### Large-board loading
- **Batched, chunked cold-load** — the backfill did a Yjs transaction + array push per stroke; now each chunk is a single transaction + one batched push, yielding to the event loop between chunks so the board renders progressively instead of freezing for minutes.
- **Observer suppressed during hydration** (bounded-cadence `setLines`) to keep the bbox re-index O(n), and in-flight hydration is cancelled on board switch / unmount.
- **Timing logs** — `[annotations] fetched … / hydrated …` to separate GET/parse cost from Yjs build.

### De-duplication
- Boards created with the old id scheme stored the same stroke many times (e.g. one test board: 81,087 entries → 2,435 unique). **Auto de-dup on cold-load**: the fetched array is de-duplicated by content signature before hydration; if duplicates were dropped, the cleaned set is persisted (full save) so the board self-heals on first solo open. Logs a distinct success message.

## Notes / limitations
- Initial load (GET) and Yjs initial state sync still transfer all (unique) strokes once — inherent.
- Fully zoomed out with everything on screen isn't reduced by culling — future canvas (Tier 3) work.
- Auto-dedup runs only on solo cold-load (`users.size === 1`); always-multi-user boards won't auto-clean.
- Concurrent full-save (one user clearing) racing another user's in-flight append can briefly drift the DB from Yjs; self-corrects on the next full save, with Yjs as the live source of truth.

## Compatibility
- No data migration; existing annotations load and render unchanged (stored format preserved).
- Rolling deploy is graceful: new frontend + old backend → append route 404s → `APIHttp` returns `{success:false}` → reconciling full save (old PUT still supported); old frontend + new backend → uses full PUT, and `publishUpdates:false` is safe because nothing renders from the annotation store's live UPDATE broadcast.
- `SAGE3Collection` gained an optional `publishUpdates` constructor flag (defaults true; only ANNOTATIONS opts out).

## Testing
- Typechecks clean across `webapp`, `homebase`, and `sagebase`.
- Manual verification on a live board recommended: draw/finalize all shape types, undo/clear/erase, touch pan/zoom mid-stroke, zoom-in fidelity; seed a few thousand strokes and confirm culling, that drawing doesn't re-render the committed layer, that `POST /lines` carries only new strokes while removes fire a full `PUT`, and that a duplicate-heavy board loads fast and self-heals (see the console timing/dedup logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)