### PR TITLE
[SageIdeator] Addition of idea visualization feature

### DIFF
--- a/seer/app/ideator.py
+++ b/seer/app/ideator.py
@@ -259,11 +259,13 @@ class IdeatorAgent:
             if dim_entries
             else ""
         )
+        context_line = f"Additional context: {req.additionalContext}. " if req.additionalContext else ""
         prompt = (
             topic_line
             + f'The idea is titled "{req.title}" — {req.summary} '
             + dim_line
             + f"Visual themes: {', '.join(req.keywords)}. "
+            + context_line
             + "Abstract, minimal, clean design. No text, labels, or words."
         )
         self.logger.info(f"IdeatorAgent.image: prompt length={len(prompt)}, prompt={prompt[:200]}")

--- a/seer/app/ideator.py
+++ b/seer/app/ideator.py
@@ -243,7 +243,7 @@ class IdeatorAgent:
         r = await self._prose_chat(msg, req.model, 0.7)
         return IdeatorSummarizeResponse(r=r)
 
-    async def image(self, req: IdeatorImageRequest) -> IdeatorImageResponse:
+    async def image(self, req: IdeatorImageRequest) -> IdeatorImageResponse: # NEED TO WORK ON
         import base64
         client, _ = self._get_client_and_model(req.model)
         topic_line = (
@@ -269,11 +269,10 @@ class IdeatorAgent:
         self.logger.info(f"IdeatorAgent.image: prompt length={len(prompt)}, prompt={prompt[:200]}")
         try:
             response = await client.images.generate(
-                model="dall-e-3",
+                model="gpt-image-1",
                 prompt=prompt,
                 n=1,
                 size="1024x1024",
-                response_format="b64_json",
             )
             b64 = response.data[0].b64_json
             data_url = f"data:image/png;base64,{b64}"

--- a/seer/libs/localtypes.py
+++ b/seer/libs/localtypes.py
@@ -221,6 +221,7 @@ class IdeatorImageRequest(BaseModel):
     model: str
     brainstormingPrompt: str | None = None
     dimension: IdeatorDimension | None = None
+    additionalContext: str | None = None
 
 
 class IdeatorImageResponse(BaseModel):

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/NodeBlock.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/NodeBlock.tsx
@@ -6,6 +6,7 @@
  * the file LICENSE, distributed as part of this software.
  */
 
+import { useState } from 'react';
 import {
   Box,
   Text,
@@ -24,6 +25,9 @@ import {
   ModalBody,
   ModalCloseButton,
   useDisclosure,
+  useColorModeValue,
+  Textarea,
+  Button,
 } from '@chakra-ui/react';
 
 import { MdAltRoute, MdQuestionAnswer, MdImage, MdRefresh } from 'react-icons/md';
@@ -48,7 +52,8 @@ export interface NodeBlockProps {
   onFocus: () => void;
   onBranch: () => void;
   onSelectQA: () => void;
-  onGenerateImage: () => void;
+  onGenerateImage: (context?: string, count?: number, presetLabel?: string, userContext?: string) => void;
+  onCancelGeneration: () => void;
   isGeneratingImage: boolean;
   onReroll: () => void;
   isRerolling: boolean;
@@ -175,6 +180,7 @@ export function NodeBlock({
   onBranch,
   onSelectQA,
   onGenerateImage,
+  onCancelGeneration,
   isGeneratingImage,
   onReroll,
   isRerolling,
@@ -184,6 +190,138 @@ export function NodeBlock({
 
   const bg = hexToRgba(color, isHovered || node.IsMyFav || isSelectedQA ? 1 : 0.82);
   const ring = isSelectedQA ? '0 0 0 2.5px teal, 0 0 8px rgba(0,128,128,0.4)' : isHovered ? '0 0 0 2.5px rgba(0,0,0,0.75)' : 'none';
+
+  const { isOpen: isContextOpen, onOpen: onContextOpen, onClose: onContextClose } = useDisclosure();
+  const [visualizeContext, setVisualizeContext] = useState('');
+  const [variationCount, setVariationCount] = useState(1);
+  const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+  const textareaColor = useColorModeValue('gray.800', 'whiteAlpha.900');
+  const textareaBg = useColorModeValue('white', 'whiteAlpha.100');
+  const placeholderColor = useColorModeValue('gray.400', 'whiteAlpha.400');
+  const variantBtnActive = useColorModeValue('blue.500', 'blue.300');
+  const variantBtnInactive = useColorModeValue('gray.200', 'whiteAlpha.200');
+  const variantTextActive = useColorModeValue('white', 'gray.900');
+  const variantTextInactive = useColorModeValue('gray.700', 'whiteAlpha.800');
+  const presetActiveBg = useColorModeValue('gray.700', 'whiteAlpha.300');
+  const presetInactiveBg = useColorModeValue('gray.100', 'whiteAlpha.100');
+  const presetActiveColor = useColorModeValue('white', 'whiteAlpha.900');
+  const presetInactiveColor = useColorModeValue('gray.600', 'whiteAlpha.600');
+
+  const PRESETS: { label: string; directive: string; tooltip: string }[] = [
+    {
+      label: 'Realistic',
+      directive: 'photorealistic rendering, natural lighting, detailed textures, true to life',
+      tooltip: 'Grounds the idea in concrete visual reality to help evaluate how it might look in the real world.',
+    },
+    {
+      label: 'Sketch',
+      directive: 'hand-drawn pencil sketch, rough lines, minimal shading, unfinished feel',
+      tooltip: 'Signals that the idea is still in progress and invites teams to build on or critique it freely.',
+    },
+    {
+      label: 'Technical',
+      directive: 'technical schematic, white lines on dark background, flow diagrams, engineering drawing style',
+      tooltip: 'Shifts attention from how the idea looks to how it works, useful for systems and processes.',
+    },
+  ];
+
+  const contextModal = (
+    <Modal isOpen={isContextOpen} onClose={onContextClose} size="sm" isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalCloseButton />
+        <ModalBody py={5}>
+          <VStack spacing={3} align="stretch">
+            <Box>
+              <Text fontSize="sm" fontWeight="700" mb={0.5}>Visualize: {node.Title}</Text>
+              <Text fontSize="xs" color="gray.500">
+                Add more details about visualization in the textbox below if needed, then press Generate.
+              </Text>
+            </Box>
+            <Box>
+              <Text fontSize="xs" fontWeight="600" color="gray.500" mb={1}>Style Preset</Text>
+              <HStack spacing={2}>
+              {PRESETS.map((preset) => {
+                const isActive = selectedPreset === preset.label;
+                return (
+                  <Tooltip key={preset.label} label={preset.tooltip} placement="top" hasArrow openDelay={300} fontSize="xs">
+                    <Box
+                      as="button"
+                      px={3}
+                      py={1}
+                      borderRadius="full"
+                      fontSize="xs"
+                      fontWeight="600"
+                      bg={isActive ? presetActiveBg : presetInactiveBg}
+                      color={isActive ? presetActiveColor : presetInactiveColor}
+                      onClick={() => setSelectedPreset(isActive ? null : preset.label)}
+                      transition="all 0.15s"
+                      _hover={{ opacity: 0.8 }}
+                    >
+                      {preset.label}
+                    </Box>
+                  </Tooltip>
+                );
+              })}
+              </HStack>
+            </Box>
+            <Textarea
+              placeholder="Optional: add more details about style, mood, or focus…"
+              value={visualizeContext}
+              onChange={(e) => setVisualizeContext(e.target.value)}
+              size="sm"
+              rows={3}
+              resize="vertical"
+              color={textareaColor}
+              bg={textareaBg}
+              _placeholder={{ color: placeholderColor }}
+            />
+            <HStack spacing={2} align="center">
+              <Text fontSize="xs" color="gray.500" flexShrink={0}>Variations</Text>
+              <HStack spacing={1}>
+                {[1, 2, 3].map((n) => (
+                  <Box
+                    key={n}
+                    as="button"
+                    w="24px"
+                    h="24px"
+                    borderRadius="md"
+                    fontSize="xs"
+                    fontWeight="600"
+                    bg={variationCount === n ? variantBtnActive : variantBtnInactive}
+                    color={variationCount === n ? variantTextActive : variantTextInactive}
+                    onClick={() => setVariationCount(n)}
+                    transition="all 0.15s"
+                    _hover={{ opacity: 0.85 }}
+                  >
+                    {n}
+                  </Box>
+                ))}
+              </HStack>
+              <Box flex={1} />
+              <Button size="sm" variant="ghost" onClick={onContextClose}>Cancel</Button>
+              <Button
+                size="sm"
+                colorScheme="blue"
+                onClick={() => {
+                  const preset = PRESETS.find((p) => p.label === selectedPreset);
+                  const userText = visualizeContext.trim();
+                  const combined = [preset?.directive, userText].filter(Boolean).join('. ');
+                  onContextClose();
+                  onGenerateImage(combined || undefined, variationCount, selectedPreset || undefined, userText || undefined);
+                  setVisualizeContext('');
+                  setVariationCount(1);
+                  setSelectedPreset(null);
+                }}
+              >
+                Generate
+              </Button>
+            </HStack>
+          </VStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
 
   const onDragStart = (e: React.DragEvent) => {
     e.dataTransfer.clearData();
@@ -291,6 +429,7 @@ export function NodeBlock({
   // ── Level 4: title + summary + steps + attributes ─────────────────
   if (zoom < 10) {
     return (
+      <>
       <Box position="relative" display="inline-block">
         {node.IsMyFav && <FavBadge size={18} offset={-7} />}
         <Box bg={bg} borderRadius="md" w={w(240)} boxShadow={ring || 'lg'} cursor="default" overflow="hidden">
@@ -404,30 +543,36 @@ export function NodeBlock({
                 color={isSelectedQA ? 'teal.500' : 'black'}
               />
             </Tooltip>
-            {/* <Tooltip label={node.imageUrl ? 'Regenerate image' : 'Generate image'} placement="bottom" hasArrow openDelay={300}>
+            <Tooltip label={isGeneratingImage ? 'Cancel visualization' : 'Visualize'} placement="bottom" hasArrow openDelay={300}>
               <IconButton
-                aria-label="Generate image"
+                aria-label={isGeneratingImage ? 'Cancel visualization' : 'Visualize'}
                 size="xs"
                 variant="ghost"
                 icon={isGeneratingImage ? <Spinner size="xs" /> : <MdImage />}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onGenerateImage();
+                  if (isGeneratingImage) {
+                    onCancelGeneration();
+                  } else {
+                    onContextOpen();
+                  }
                 }}
                 h="18px"
                 minW="18px"
-                color={node.imageUrl ? 'blue.500' : 'black'}
-                isDisabled={isGeneratingImage}
+                color={isGeneratingImage ? 'red.400' : node.imageUrl ? 'blue.500' : 'black'}
               />
-            </Tooltip> */}
+            </Tooltip>
           </HStack>
         </Box>
       </Box>
+      {contextModal}
+    </>
     );
   }
 
   // ── Level 5: full prose + attributes ──────────────────────────────
   return (
+    <>
     <Box position="relative" display="inline-block">
       {node.IsMyFav && <FavBadge size={18} offset={-7} />}
       <Box bg={bg} borderRadius="md" w={w(295)} boxShadow={ring || 'xl'} cursor="default" overflow="hidden">
@@ -516,24 +661,29 @@ export function NodeBlock({
               color={isSelectedQA ? 'teal.500' : 'black'}
             />
           </Tooltip>
-          {/* <Tooltip label={node.imageUrl ? 'Regenerate image' : 'Generate image'} placement="bottom" hasArrow openDelay={300}>
+          <Tooltip label={isGeneratingImage ? 'Cancel visualization' : 'Visualize'} placement="bottom" hasArrow openDelay={300}>
             <IconButton
-              aria-label="Generate image"
+              aria-label={isGeneratingImage ? 'Cancel visualization' : 'Visualize'}
               size="xs"
               variant="ghost"
               icon={isGeneratingImage ? <Spinner size="xs" /> : <MdImage />}
               onClick={(e) => {
                 e.stopPropagation();
-                onGenerateImage();
+                if (isGeneratingImage) {
+                  onCancelGeneration();
+                } else {
+                  onContextOpen();
+                }
               }}
               h="20px"
               minW="20px"
-              color={node.imageUrl ? 'blue.500' : 'black'}
-              isDisabled={isGeneratingImage}
+              color={isGeneratingImage ? 'red.400' : node.imageUrl ? 'blue.500' : 'black'}
             />
-          </Tooltip> */}
+          </Tooltip>
         </HStack>
       </Box>
     </Box>
+    {contextModal}
+  </>
   );
 }

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/QAPanel.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/QAPanel.tsx
@@ -6,8 +6,9 @@
  * the file LICENSE, distributed as part of this software.
  */
 
-import { Flex, Box, Text, HStack, VStack, Input, IconButton, Spinner, Center } from '@chakra-ui/react';
-import { MdSend, MdClear } from 'react-icons/md';
+import { useRef, useState, useEffect } from 'react';
+import { Flex, Box, Text, HStack, VStack, Input, IconButton, Spinner, Center, Collapse } from '@chakra-ui/react';
+import { MdSend, MdClear, MdChevronRight, MdExpandMore } from 'react-icons/md';
 
 import { state as AppState } from './index';
 
@@ -41,6 +42,27 @@ export function QAPanel({
 }: QAPanelProps) {
   const s = (px: number) => `${Math.round(px * 1.5)}px`;
 
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const latestEntryRef = useRef<HTMLDivElement>(null);
+
+  // Auto-expand and scroll to the newest entry when it arrives
+  useEffect(() => {
+    if (qaEntries.length === 0) return;
+    const latest = qaEntries[qaEntries.length - 1];
+    setExpandedIds((prev) => new Set(prev).add(latest.id));
+    // Small delay to let Collapse animate open before scrolling
+    setTimeout(() => latestEntryRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 100);
+  }, [qaEntries.length]);
+
+  const toggleExpand = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
   return (
     <Flex direction="column" w="300px" minW="300px" h="100%" bg={panelBgHex} borderLeft="1px solid" borderColor={borderHex} flexShrink={0}>
       {/* Header */}
@@ -59,7 +81,7 @@ export function QAPanel({
         </Center>
       ) : (
         <>
-          {/* Scrollable body: summary + Q&A entries together */}
+          {/* Scrollable body */}
           <Box flex={1} overflowY="auto" px={3} py={2} onWheel={(e) => e.stopPropagation()}>
             {/* Node summary */}
             <Text fontSize={s(13)} fontWeight="500" color={textColor} lineHeight="1.6">
@@ -83,7 +105,6 @@ export function QAPanel({
               </VStack>
             )}
 
-            {/* Divider before Q&A */}
             <Box borderTop="1px solid" borderColor="gray.200" _dark={{ borderColor: 'gray.600' }} my={2} />
 
             {/* Q&A entries */}
@@ -92,22 +113,46 @@ export function QAPanel({
                 No questions yet. Ask one below.
               </Text>
             )}
-            <VStack align="stretch" spacing={3}>
-              {qaEntries.map((e) => (
-                <Box key={e.id}>
-                  <Text fontSize={s(13)} fontWeight="700" color="teal.600" _dark={{ color: 'teal.300' }} mb={1}>
-                    Q: {e.question}
-                  </Text>
-                  <Text fontSize={s(13)} color={textColor} lineHeight="1.6">
-                    {e.answer}
-                  </Text>
-                  <Text fontSize={s(11)} color="gray.400" mt={1}>
-                    {e.userName}
-                  </Text>
-                </Box>
-              ))}
+
+            <VStack align="stretch" spacing={1}>
+              {qaEntries.map((e, idx) => {
+                const isExpanded = expandedIds.has(e.id);
+                const isLatest = idx === qaEntries.length - 1;
+                return (
+                  <Box key={e.id} ref={isLatest ? latestEntryRef : undefined}>
+                    {/* Question row — always visible, click to toggle */}
+                    <HStack
+                      spacing={1}
+                      cursor="pointer"
+                      onClick={() => toggleExpand(e.id)}
+                      py={1}
+                      _hover={{ opacity: 0.8 }}
+                    >
+                      <Box color="teal.500" _dark={{ color: 'teal.300' }} flexShrink={0} mt="1px">
+                        {isExpanded ? <MdExpandMore size={16} /> : <MdChevronRight size={16} />}
+                      </Box>
+                      <Text fontSize={s(13)} fontWeight="700" color="teal.600" _dark={{ color: 'teal.300' }} flex={1}>
+                        {e.question}
+                      </Text>
+                    </HStack>
+
+                    {/* Answer — collapsed by default, expanded when toggled */}
+                    <Collapse in={isExpanded} animateOpacity>
+                      <Box pl={5} pb={2}>
+                        <Text fontSize={s(13)} color={textColor} lineHeight="1.6">
+                          {e.answer}
+                        </Text>
+                        <Text fontSize={s(11)} color="gray.400" mt={1}>
+                          {e.userName}
+                        </Text>
+                      </Box>
+                    </Collapse>
+                  </Box>
+                );
+              })}
+
               {askingNodeId === node.ID && (
-                <HStack spacing={2}>
+                <HStack spacing={2} py={1}>
                   <Spinner size="xs" color="teal.400" />
                   <Text fontSize={s(13)} color="teal.500">
                     Answering…

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
@@ -6,15 +6,14 @@
  * the file LICENSE, distributed as part of this software.
  */
 
-import { useRef, useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
 import { format } from 'date-fns/format';
 
 import { Flex, Box, Button, IconButton, Tooltip, useToast, useColorModeValue } from '@chakra-ui/react';
 import { MdFileDownload, MdChat, MdChevronLeft, MdChevronRight } from 'react-icons/md';
 
-import { useAppStore, useHexColor, useUser, downloadFile, apiUrls, useAssetStore, useLinkStore } from '@sage3/frontend';
-import { genId } from '@sage3/shared';
+import { useAppStore, useHexColor, downloadFile } from '@sage3/frontend';
 
 import { App } from '../../schema';
 import { state as AppState } from './index';
@@ -28,18 +27,6 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.min.mjs';
 const CMAP_URL = './node_modules/pdfjs-dist/cmaps/';
 const FONT_URL = './node_modules/pdfjs-dist/standard_fonts/';
 const CMAP_PACKED = true;
-
-import {
-  generateDimensionsFromPrompt,
-  generateNodeContent,
-  abstractNode,
-  buildRequirements,
-  callProseAPI,
-  generateUserDimension,
-  VISION_MODELS,
-  summarizeFavorites as summarizeFavoritesAPI,
-  generateNodeImage,
-} from './openai';
 
 // ─── PDF text extraction ──────────────────────────────────────────────────────
 const MAX_PDF_CHARS = 5000;
@@ -60,65 +47,20 @@ async function extractPdfText(file: File): Promise<string> {
   }
   return text.slice(0, MAX_PDF_CHARS);
 }
+import { useIdeation } from './useIdeation';
+import { useImageGeneration } from './useImageGeneration';
+import { useStickyImport } from './useStickyImport';
 import { ChatPanel } from './ChatPanel';
-import { VisualizationCanvas, DimBlend } from './VisualizationCanvas';
+import { VisualizationCanvas } from './VisualizationCanvas';
 import { QAPanel } from './QAPanel';
-import { StickyImportDialog, ImportPreview } from './StickyImportDialog';
-
-type SageNode = AppState['nodes'][number];
-
-// ─── Blended requirements builder ────────────────────────────────────────────
-
-function buildBlendedRequirements(
-  dims: AppState['dimensions'],
-  xDimName: string | null,
-  xBlend: DimBlend | null,
-  yDimName: string | null,
-  yBlend: DimBlend | null,
-): { requirements: string; categorical: Record<string, string>; ordinal: Record<string, string> } {
-  let req = '';
-  const categorical: Record<string, string> = {};
-  const ordinal: Record<string, string> = {};
-
-  for (const dim of dims) {
-    const blend = dim.name === xDimName ? xBlend : dim.name === yDimName ? yBlend : null;
-    let assignedValue: string;
-
-    if (blend) {
-      if (blend.secondary === null || blend.primaryWeight === 1) {
-        req += `${dim.name}: ${blend.primary}\n`;
-        assignedValue = blend.primary;
-      } else if (blend.primaryWeight >= 0.65) {
-        req += `${dim.name}: primarily "${blend.primary}" with some "${blend.secondary}" influence\n`;
-        assignedValue = blend.primary;
-      } else {
-        const pct = Math.round(blend.primaryWeight * 100);
-        const sPct = 100 - pct;
-        req += `${dim.name}: blend of "${blend.primary}" (${pct}%) and "${blend.secondary}" (${sPct}%)\n`;
-        assignedValue = blend.primary;
-      }
-    } else {
-      assignedValue = dim.values[Math.floor(Math.random() * dim.values.length)];
-      req += `${dim.name}: ${assignedValue}\n`;
-    }
-
-    if (dim.type === 'categorical') categorical[dim.name] = assignedValue;
-    else ordinal[dim.name] = assignedValue;
-  }
-
-  return { requirements: req, categorical, ordinal };
-}
+import { StickyImportDialog } from './StickyImportDialog';
 
 // ─── AppComponent ─────────────────────────────────────────────────────────────
 
 function AppComponent(props: App): JSX.Element {
   const s = props.data.state as AppState;
-  const { user } = useUser();
   const updateState = useAppStore((state) => state.updateState);
-  const updateApp = useAppStore((state) => state.update);
-  const createApp = useAppStore((state) => state.create);
-  const boardApps = useAppStore((s) => s.apps);
-  const addLink = useLinkStore((s) => s.addLink);
+
   const toast = useToast();
 
   // Theme
@@ -132,157 +74,54 @@ function AppComponent(props: App): JSX.Element {
 
   // Input / UI state
   const [input, setInput] = useState('');
-  const [username, setUsername] = useState('');
-  const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
-  const [askingNodeId, setAskingNodeId] = useState<string | null>(null);
   const [selectedQANodeId, setSelectedQANodeId] = useState<string | null>(null);
   const [qaPanelOpen, setQaPanelOpen] = useState(false);
   const [qaInput, setQaInput] = useState('');
-  const [isAddingDimension, setIsAddingDimension] = useState(false);
-  const [isSummarizing, setIsSummarizing] = useState(false);
-  const [generatingImageNodeId, setGeneratingImageNodeId] = useState<string | null>(null);
-  const [localNodeImages, setLocalNodeImages] = useState<Record<string, string>>({});
-  const [rerollingNodeId, setRerollingNodeId] = useState<string | null>(null);
-  const [isGeneratingAt, setIsGeneratingAt] = useState(false);
-  const [isAddingManualIdea, setIsAddingManualIdea] = useState(false);
   const [chatPanelOpen, setChatPanelOpen] = useState(true);
   const [attachedImage, setAttachedImage] = useState<string | null>(null);
   const [isLoadingPdf, setIsLoadingPdf] = useState(false);
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [localStatusMessage, setLocalStatusMessage] = useState('');
 
-  // Refs shared with VisualizationCanvas
-  const positionsRef = useRef<Map<string, { x: number; y: number }>>(new Map());
-  const hasFitRef = useRef(false);
-  const imageAbortRef = useRef<AbortController | null>(null);
+  const {
+    activeEntryId, localNodes, localDims,
+    isGenerating, localStatusMessage, askingNodeId,
+    isAddingDimension, rerollingNodeId, isGeneratingAt,
+    isAddingManualIdea, isSummarizing,
+    positionsRef, hasFitRef,
+    generate, toggleFav, clearAll, deleteEntry, restoreSnapshot,
+    branchFromNode, askNodeQuestion, addDimension, rerollNode,
+    generateMore, generateAt, addManualIdea, removeDimension,
+    summarizeFavorites, branchFromFavorites,
+  } = useIdeation({
+    s,
+    appId: props._id,
+    input,
+    setInput,
+    attachedImage,
+    setAttachedImage,
+    boardId: props.data.boardId,
+    roomId: props.data.roomId,
+    appPosition: props.data.position,
+    appSize: props.data.size,
+  });
 
-  // Stickie drag-to-import state
-  const [pendingImport, setPendingImport] = useState<{
-    stickieId: string;
-    text: string;
-    originalPosition: { x: number; y: number; z: number };
-    preview: ImportPreview | null;
-    isLoading: boolean;
-    temperature: number;
-  } | null>(null);
-  // Track previous stickie positions to detect entry into ideator bounds on drag-end
-  const prevPositionsRef = useRef<Record<string, { x: number; y: number }>>({});
-  const importingRef = useRef(false);
+  const { pendingImport, handleImportConfirm, handleImportCancel, handleImportRegenerate } = useStickyImport({
+    s,
+    localDims,
+    activeEntryId,
+    appId: props._id,
+    appPosition: props.data.position,
+    appSize: props.data.size,
+  });
 
-  // Per-user local view — derived from the active chatHistory entry
-  const activeEntry = s.chatHistory.find((e) => e.id === activeEntryId) ?? null;
-  const favorites = s.favorites ?? {};
-  const localNodes = (activeEntry?.nodes ?? []).map((n) => ({
-    ...n,
-    IsMyFav: favorites[n.ID] ?? false,
-    imageUrl: localNodeImages[n.ID] ?? n.imageUrl,
-  }));
-  const localDims = activeEntry?.dimensions ?? [];
-
-  useEffect(() => {
-    if (user) setUsername(user.data.name.split(' ')[0]);
-  }, [user]);
-
-  // ── Stickie drag-to-import detection ──
-
-  // Detect when a Stickie's position changes from outside to inside the ideator bounds.
-  // App dragging in SAGE3 is local-only during the drag; the store position only updates
-  // when the drag ends and the server confirms, so position changes == drag-end events.
-  useEffect(() => {
-    const stickies = boardApps.filter((a) => a.data.type === 'Stickie');
-    const ip = props.data.position;
-    const is = props.data.size;
-
-    for (const stickie of stickies) {
-      const prev = prevPositionsRef.current[stickie._id];
-      const curr = stickie.data.position;
-
-      if (prev && !importingRef.current) {
-        const { width: sw, height: sh } = stickie.data.size;
-        const wasInside = prev.x < ip.x + is.width && prev.x + sw > ip.x && prev.y < ip.y + is.height && prev.y + sh > ip.y;
-        const isInside = curr.x < ip.x + is.width && curr.x + sw > ip.x && curr.y < ip.y + is.height && curr.y + sh > ip.y;
-
-        if (!wasInside && isInside) {
-          const originalPosition = { x: prev.x, y: prev.y, z: curr.z };
-          const text = ((stickie.data.state as { text: string }).text ?? '').trim();
-
-          if (!activeEntryId || localDims.length === 0) {
-            toast({ title: 'No idea space yet', description: 'Generate ideas first, then import a Stickie.', status: 'warning', duration: 3000, isClosable: true });
-          } else if (text) {
-            importingRef.current = true;
-            updateApp(stickie._id, { position: { x: ip.x + is.width + 20, y: ip.y, z: curr.z } });
-            setPendingImport({ stickieId: stickie._id, text, originalPosition, preview: null, isLoading: true, temperature: 0 });
-          }
-        }
-      }
-
-      prevPositionsRef.current[stickie._id] = { x: curr.x, y: curr.y };
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [boardApps]);
-
-  // Run abstractNode whenever a new import preview is needed (initial drop or "Try Again")
-  useEffect(() => {
-    if (!pendingImport?.isLoading) return;
-    const { text, stickieId, originalPosition } = pendingImport;
-    let active = true;
-    abstractNode(text, s.apiKey, s.model, pendingImport.temperature)
-      .then((preview) => {
-        if (active) setPendingImport((prev) => (prev ? { ...prev, preview, isLoading: false } : null));
-      })
-      .catch(() => {
-        if (active) {
-          updateApp(stickieId, { position: originalPosition });
-          setPendingImport(null);
-          importingRef.current = false;
-          toast({ title: 'Preview failed', status: 'error', duration: 3000, isClosable: true });
-        }
-      });
-    return () => { active = false; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingImport?.isLoading]);
-
-  const handleImportConfirm = useCallback(() => {
-    if (!pendingImport?.preview || !activeEntryId) return;
-    const { preview, text } = pendingImport;
-    const rawDims = {
-      categorical: Object.fromEntries(localDims.filter((d) => d.type === 'categorical').map((d) => [d.name, d.values])),
-      ordinal: Object.fromEntries(localDims.filter((d) => d.type === 'ordinal').map((d) => [d.name, d.values])),
-    };
-    const { categorical, ordinal } = buildRequirements(rawDims);
-    const newNode: AppState['nodes'][number] = {
-      ID: genId(),
-      Title: preview.Title,
-      Summary: preview.Summary,
-      Keywords: preview.Keywords,
-      Steps: preview.Steps,
-      Result: text,
-      Structure: preview.Structure,
-      Dimension: { categorical, ordinal },
-      IsMyFav: false,
-    };
-    const latest = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-    const cur = latest ?? s;
-    const updatedHistory = cur.chatHistory.map((e) => (e.id === activeEntryId ? { ...e, nodes: [...e.nodes, newNode] } : e));
-    updateState(props._id, { ...cur, chatHistory: updatedHistory });
-    setPendingImport(null);
-    importingRef.current = false;
-  }, [pendingImport, activeEntryId, localDims, s, props._id, updateState]);
-
-  const handleImportCancel = useCallback(() => {
-    if (!pendingImport) return;
-    updateApp(pendingImport.stickieId, { position: pendingImport.originalPosition });
-    setPendingImport(null);
-    importingRef.current = false;
-  }, [pendingImport, updateApp]);
-
-  const handleImportRegenerate = useCallback(() => {
-    if (!pendingImport) return;
-    setPendingImport((prev) => (prev ? { ...prev, preview: null, isLoading: true, temperature: 0.7 } : null));
-  }, [pendingImport]);
-
-  // ── Setup save ──
-
+  const { generateImageForNode, cancelImageGeneration, generatingImageNodeId } = useImageGeneration({
+    s,
+    localNodes,
+    activeEntryId,
+    appId: props._id,
+    boardId: props.data.boardId,
+    roomId: props.data.roomId,
+    appPosition: props.data.position,
+  });
 
   // ── PDF context ──
   const handleAttachPdf = useCallback(
@@ -304,739 +143,6 @@ function AppComponent(props: App): JSX.Element {
   const handleClearPdf = useCallback(() => {
     updateState(props._id, { ...s, pdfContext: undefined });
   }, [s, props._id]);
-
-  // ── Generation ──
-
-  const generate = useCallback(
-    async (branchOpts?: { displayPrompt: string; aiPrompt: string; parentEntryId?: string; parentNodeTitle?: string }) => {
-      if (!user || isGenerating) return;
-
-      const displayPrompt = branchOpts?.displayPrompt ?? input.trim();
-      const aiPrompt = branchOpts?.aiPrompt ?? input.trim();
-      if (!displayPrompt) {
-        toast({ title: 'Enter a prompt', status: 'warning', duration: 2500, isClosable: true });
-        return;
-      }
-
-      // Guard: image attached but model doesn't support vision
-      const image = branchOpts ? undefined : (attachedImage ?? undefined);
-      if (image && !VISION_MODELS.has(s.model)) {
-        toast({
-          title: 'Model does not support images',
-          description: `Switch to a vision-capable model (e.g. gpt-4o-mini) to use image prompts.`,
-          status: 'warning',
-          duration: 4000,
-          isClosable: true,
-        });
-        return;
-      }
-
-      if (!branchOpts) {
-        setInput('');
-        setAttachedImage(null);
-        updateState(props._id, { ...s, pdfContext: undefined });
-      }
-      positionsRef.current.clear();
-      hasFitRef.current = false;
-
-      const chatEntry = {
-        id: genId(),
-        prompt: displayPrompt,
-        userName: username,
-        userId: user._id,
-        timestamp: Date.now(),
-        nodes: [] as AppState['nodes'],
-        dimensions: [] as AppState['dimensions'],
-        parentEntryId: branchOpts?.parentEntryId,
-        parentNodeTitle: branchOpts?.parentNodeTitle,
-        imageUrl: image,
-        pdfFilename: s.pdfContext?.filename,
-      };
-
-      setIsGenerating(true);
-      setLocalStatusMessage('Determining important aspects…');
-      updateState(props._id, {
-        ...s,
-        prompt: aiPrompt,
-        chatHistory: [...s.chatHistory, chatEntry],
-      });
-
-      try {
-        const rawDims = await generateDimensionsFromPrompt(aiPrompt, s.apiKey, s.model, s.numDimensions, image, s.pdfContext?.text);
-
-        const dimensions: AppState['dimensions'] = [
-          ...Object.entries(rawDims.categorical).map(([name, values], i) => ({
-            id: i,
-            name,
-            type: 'categorical' as const,
-            values,
-          })),
-          ...Object.entries(rawDims.ordinal).map(([name, values], i) => ({
-            id: Object.keys(rawDims.categorical).length + i,
-            name,
-            type: 'ordinal' as const,
-            values,
-          })),
-        ];
-
-        setLocalStatusMessage(`Generating ${s.batchSize} responses…`);
-
-        const newNodes: AppState['nodes'] = [];
-
-        const results = await Promise.allSettled(
-          Array.from({ length: s.batchSize }, async () => {
-            const { requirements, categorical, ordinal } = buildRequirements(rawDims);
-            const text = await generateNodeContent(aiPrompt, requirements, s.apiKey, s.model, image, s.pdfContext?.text);
-            const summary = await abstractNode(text, s.apiKey, s.model);
-            return {
-              ID: genId(),
-              Title: summary.Title,
-              Summary: summary.Summary,
-              Keywords: summary.Keywords,
-              Steps: summary.Steps,
-              Result: text,
-              Structure: summary.Structure,
-              Dimension: { categorical, ordinal },
-              IsMyFav: false,
-            };
-          }),
-        );
-        for (const r of results) {
-          if (r.status === 'fulfilled') newNodes.push(r.value);
-        }
-        if (newNodes.length === 0) throw new Error('All idea generations failed');
-
-        const latest = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-        const updatedHistory = (latest?.chatHistory ?? [...s.chatHistory, chatEntry]).map((e) =>
-          e.id === chatEntry.id ? { ...e, nodes: newNodes, dimensions } : e,
-        );
-        setIsGenerating(false);
-        setLocalStatusMessage('');
-        updateState(props._id, {
-          ...(latest ?? s),
-          status: 'ready',
-          prompt: aiPrompt,
-          chatHistory: updatedHistory,
-        });
-
-        setActiveEntryId(chatEntry.id);
-      } catch (err: unknown) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        toast({ title: 'Generation failed', description: errMsg, status: 'error', duration: 5000, isClosable: true });
-        setIsGenerating(false);
-        setLocalStatusMessage('');
-        updateState(props._id, { ...s, status: 'idle' });
-      }
-    },
-    [user, s, input, username, isGenerating, props._id, attachedImage],
-  );
-
-  const toggleFav = (nodeId: string) => {
-    const current = (s.favorites ?? {})[nodeId] ?? false;
-    updateState(props._id, { favorites: { ...(s.favorites ?? {}), [nodeId]: !current } });
-  };
-
-  const clearAll = () => {
-    updateState(props._id, {
-      ...s,
-      status: 'idle',
-      nodes: [],
-      dimensions: [],
-      prompt: '',
-      statusMessage: '',
-      chatHistory: [],
-      qa: [],
-      favorites: {},
-      nodeImages: {},
-    });
-    positionsRef.current.clear();
-    hasFitRef.current = false;
-    setActiveEntryId(null);
-  };
-
-  const deleteEntry = useCallback(
-    (entryId: string) => {
-      const updated = s.chatHistory.filter((e) => e.id !== entryId);
-      updateState(props._id, { ...s, chatHistory: updated });
-      if (activeEntryId === entryId) {
-        // Switch to the previous remaining entry, if any
-        const idx = s.chatHistory.findIndex((e) => e.id === entryId);
-        const next = updated[idx - 1] ?? updated[idx] ?? null;
-        setActiveEntryId(next?.id ?? null);
-      }
-    },
-    [s, props._id, activeEntryId],
-  );
-
-  const restoreSnapshot = useCallback((entry: AppState['chatHistory'][number]) => {
-    if (!(entry.nodes ?? []).length) return;
-    positionsRef.current.clear();
-    hasFitRef.current = false;
-    setActiveEntryId(entry.id);
-  }, []);
-
-  const branchFromNode = useCallback(
-    (node: SageNode) => {
-      const aiPrompt = [
-        s.prompt,
-        `\nNow explore new variations specifically inspired by this idea:`,
-        `Title: "${node.Title}"`,
-        node.Summary,
-        node.Steps?.length ? `Steps: ${node.Steps.join('; ')}` : '',
-      ]
-        .filter(Boolean)
-        .join('\n');
-      generate({
-        displayPrompt: node.Title,
-        aiPrompt,
-        parentEntryId: activeEntryId ?? undefined,
-        parentNodeTitle: node.Title,
-      });
-    },
-    [s.prompt, activeEntryId, generate],
-  );
-
-  const askNodeQuestion = useCallback(
-    async (node: SageNode, question: string) => {
-      if (!user || askingNodeId) return;
-      setAskingNodeId(node.ID);
-      try {
-        const context = [
-          `Idea: "${node.Title}"`,
-          node.Summary,
-          node.Steps?.length ? `Steps: ${node.Steps.join('; ')}` : '',
-          node.Result ? `Details: ${node.Result}` : '',
-        ]
-          .filter(Boolean)
-          .join('\n');
-        const answer = await callProseAPI(`${context}\n\nQuestion: ${question}`, s.apiKey, s.model);
-        const qaEntry = {
-          id: genId(),
-          nodeId: node.ID,
-          nodeTitle: node.Title,
-          question,
-          answer,
-          userId: user._id,
-          userName: username,
-          timestamp: Date.now(),
-        };
-        const latest = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-        updateState(props._id, { ...(latest ?? s), qa: [...(latest?.qa ?? s.qa ?? []), qaEntry] });
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        toast({ title: 'Question failed', description: msg, status: 'error', duration: 4000, isClosable: true });
-      } finally {
-        setAskingNodeId(null);
-      }
-    },
-    [user, s, username, askingNodeId, props._id],
-  );
-
-  // ── Dimension management ──
-
-  const addDimension = useCallback(
-    async (dimName: string) => {
-      if (isAddingDimension || localNodes.length === 0 || !activeEntryId) return;
-      setIsAddingDimension(true);
-      try {
-        const nodeStubs = localNodes.map((n) => ({ ID: n.ID, Title: n.Title, Summary: n.Summary }));
-        const { type, values, assignments } = await generateUserDimension(dimName, s.prompt, nodeStubs, s.apiKey, s.model);
-        const newDim = { id: localDims.length, name: dimName, type, values };
-        const updatedNodes = localNodes.map((n) => ({
-          ...n,
-          Dimension: {
-            categorical:
-              type === 'categorical' ? { ...n.Dimension.categorical, [dimName]: assignments[n.ID] ?? values[0] } : n.Dimension.categorical,
-            ordinal: type === 'ordinal' ? { ...n.Dimension.ordinal, [dimName]: assignments[n.ID] ?? values[0] } : n.Dimension.ordinal,
-          },
-        }));
-        const latest = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-        const cur = latest ?? s;
-        const updatedHistory = cur.chatHistory.map((e) =>
-          e.id === activeEntryId ? { ...e, nodes: updatedNodes, dimensions: [...(e.dimensions ?? []), newDim] } : e,
-        );
-        updateState(props._id, { ...cur, chatHistory: updatedHistory });
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        toast({ title: 'Failed to add dimension', description: msg, status: 'error', duration: 4000, isClosable: true });
-      } finally {
-        setIsAddingDimension(false);
-      }
-    },
-    [s, localNodes, localDims, activeEntryId, isAddingDimension, props._id],
-  );
-
-  const rerollNode = useCallback(
-    async (nodeId: string) => {
-      if (rerollingNodeId || !activeEntryId) return;
-      setRerollingNodeId(nodeId);
-      try {
-        const latest = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-        const cur = latest ?? s;
-        const curEntry = cur.chatHistory.find((e) => e.id === activeEntryId);
-        if (!curEntry) return;
-        const rawDims = {
-          categorical: Object.fromEntries(curEntry.dimensions.filter((d) => d.type === 'categorical').map((d) => [d.name, d.values])),
-          ordinal: Object.fromEntries(curEntry.dimensions.filter((d) => d.type === 'ordinal').map((d) => [d.name, d.values])),
-        };
-        const { requirements, categorical, ordinal } = buildRequirements(rawDims);
-        const text = await generateNodeContent(curEntry.prompt, requirements, s.apiKey, s.model, undefined, s.pdfContext?.text);
-        const summary = await abstractNode(text, s.apiKey, s.model);
-        const afterGen = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-        const afterEntry = (afterGen ?? cur).chatHistory.find((e) => e.id === activeEntryId);
-        if (!afterEntry) return;
-        const updatedNodes = afterEntry.nodes.map((n) =>
-          n.ID === nodeId
-            ? {
-                ...n,
-                Title: summary.Title,
-                Summary: summary.Summary,
-                Keywords: summary.Keywords,
-                Steps: summary.Steps,
-                Result: text,
-                Structure: summary.Structure,
-                Dimension: { categorical, ordinal },
-                IsMyFav: false,
-                imageUrl: undefined,
-              }
-            : n,
-        );
-        const updatedHistory = (afterGen ?? cur).chatHistory.map((e) => (e.id === activeEntryId ? { ...e, nodes: updatedNodes } : e));
-        updateState(props._id, { ...(afterGen ?? cur), chatHistory: updatedHistory });
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        toast({ title: 'Re-roll failed', description: msg, status: 'error', duration: 4000, isClosable: true });
-      } finally {
-        setRerollingNodeId(null);
-      }
-    },
-    [s, localNodes, activeEntryId, rerollingNodeId, props._id],
-  );
-
-  const generateMore = useCallback(
-    async (entry: AppState['chatHistory'][number]) => {
-      const entryDims = entry.dimensions ?? [];
-      if (!user || isGenerating || entryDims.length === 0) return;
-      // Restore the entry's snapshot first so the canvas shows the right nodes
-      restoreSnapshot(entry);
-      const rawDims = {
-        categorical: Object.fromEntries(entryDims.filter((d) => d.type === 'categorical').map((d) => [d.name, d.values])),
-        ordinal: Object.fromEntries(entryDims.filter((d) => d.type === 'ordinal').map((d) => [d.name, d.values])),
-      };
-      setIsGenerating(true);
-      setLocalStatusMessage(`Generating ${s.batchSize} more ideas…`);
-      const latest = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-      updateState(props._id, { ...(latest ?? s) });
-      try {
-        const newNodes: AppState['nodes'] = [];
-        const moreResults = await Promise.allSettled(
-          Array.from({ length: s.batchSize }, async () => {
-            const { requirements, categorical, ordinal } = buildRequirements(rawDims);
-            const text = await generateNodeContent(entry.prompt, requirements, s.apiKey, s.model, undefined, s.pdfContext?.text);
-            const summary = await abstractNode(text, s.apiKey, s.model);
-            return {
-              ID: genId(),
-              Title: summary.Title,
-              Summary: summary.Summary,
-              Keywords: summary.Keywords,
-              Steps: summary.Steps,
-              Result: text,
-              Structure: summary.Structure,
-              Dimension: { categorical, ordinal },
-              IsMyFav: false,
-            };
-          }),
-        );
-        for (const r of moreResults) {
-          if (r.status === 'fulfilled') newNodes.push(r.value);
-        }
-        if (newNodes.length === 0) throw new Error('All idea generations failed');
-        const afterGen = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-        const cur = afterGen ?? s;
-        const existingEntry = cur.chatHistory.find((e) => e.id === entry.id);
-        const combinedNodes = [...(existingEntry?.nodes ?? entry.nodes), ...newNodes];
-        const updatedHistory = cur.chatHistory.map((e) => (e.id === entry.id ? { ...e, nodes: combinedNodes } : e));
-        setIsGenerating(false);
-        setLocalStatusMessage('');
-        updateState(props._id, { ...cur, status: 'ready', chatHistory: updatedHistory });
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        toast({ title: 'Generation failed', description: msg, status: 'error', duration: 5000, isClosable: true });
-        setIsGenerating(false);
-        setLocalStatusMessage('');
-        const afterFail = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-        updateState(props._id, { ...(afterFail ?? s), status: 'ready' });
-      }
-    },
-    [user, s, isGenerating, props._id, restoreSnapshot],
-  );
-
-  const generateImageForNode = useCallback(
-    async (nodeId: string, context?: string, count = 1, presetLabel?: string, userContext?: string) => {
-      if (generatingImageNodeId || !activeEntryId) return;
-      const node = localNodes.find((n) => n.ID === nodeId);
-      if (!node) return;
-      const controller = new AbortController();
-      imageAbortRef.current = controller;
-      setGeneratingImageNodeId(nodeId);
-      try {
-        // ── 1. Find or create anchor Stickie ─────────────────────────────
-        const liveApps = useAppStore.getState().apps;
-        const existingStickieId = s.nodeStickies?.[nodeId];
-        let stickieApp = existingStickieId
-          ? liveApps.find((a) => a._id === existingStickieId) ?? null
-          : null;
-
-        if (!stickieApp) {
-          stickieApp = liveApps.find(
-            (a) =>
-              a.data.type === 'Stickie' &&
-              a.data.boardId === props.data.boardId &&
-              (a.data.state as { text?: string }).text?.startsWith(node.Title)
-          ) ?? null;
-        }
-
-        let stickieId: string;
-        let stickiePosition: { x: number; y: number; z: number };
-        let stickieSize: { width: number; height: number; depth: number };
-
-        if (stickieApp) {
-          stickieId = stickieApp._id;
-          stickiePosition = stickieApp.data.position;
-          stickieSize = stickieApp.data.size;
-        } else {
-          const stickieResult = await createApp({
-            title: node.Title,
-            roomId: props.data.roomId,
-            boardId: props.data.boardId,
-            position: { x: props.data.position.x, y: props.data.position.y - 260, z: 0 },
-            size: { width: 320, height: 200, depth: 0 },
-            rotation: { x: 0, y: 0, z: 0 },
-            type: 'Stickie',
-            state: {
-              text: `${node.Title}\n\n${node.Summary}`,
-              fontSize: 18,
-              color: 'purple',
-              lock: false,
-              sources: [props._id],
-              executeInfo: { executeFunc: '', params: {} },
-            },
-            raised: true,
-            dragging: false,
-            pinned: false,
-          });
-          stickieId = stickieResult?.data?._id ?? '';
-          stickiePosition = { x: props.data.position.x, y: props.data.position.y - 260, z: 0 };
-          stickieSize = { width: 320, height: 200, depth: 0 };
-        }
-
-        // ── 2. Count existing visualizations to offset placement ──────────
-        const existingVizCount = liveApps.filter(
-          (a) =>
-            a.data.type === 'ImageViewer' &&
-            a.data.boardId === props.data.boardId &&
-            a.data.title.startsWith(node.Title)
-        ).length;
-
-        // ── 3. Generate all variations in parallel ────────────────────────
-        const safeTitle = node.Title.replace(/[^a-zA-Z0-9\s-]/g, '').trim().slice(0, 40);
-        const safePrompt = s.prompt.replace(/[^a-zA-Z0-9\s-]/g, '').trim().slice(0, 40);
-        const imgSize = 512;
-        const gap = 20;
-
-        const results = await Promise.allSettled(
-          Array.from({ length: count }, () =>
-            generateNodeImage(node.Title, node.Summary, node.Keywords, s.apiKey, s.prompt, node.Dimension, controller.signal, context)
-          )
-        );
-
-        // ── 4. Upload and place each successful result ────────────────────
-        let placedCount = 0;
-        let lastAssetId: string | null = null;
-
-        for (const result of results) {
-          if (result.status === 'rejected') {
-            const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
-            if (msg !== 'Cancelled') {
-              toast({ title: 'One variation failed', description: msg, status: 'warning', duration: 3000, isClosable: true });
-            }
-            continue;
-          }
-
-          const iteration = existingVizCount + placedCount + 1;
-          const blob = await fetch(result.value).then((r) => r.blob());
-          const variantSuffix = ` v${iteration}`;
-          const imgFile = new File([blob], `${safeTitle}${variantSuffix} - ${safePrompt}.png`, { type: 'image/png' });
-          const fd = new FormData();
-          fd.append('files', imgFile);
-          fd.append('room', props.data.roomId);
-          const uploadRes = await fetch(apiUrls.assets.upload, { method: 'POST', body: fd, credentials: 'include' });
-          if (!uploadRes.ok) {
-            toast({ title: 'Upload failed', status: 'warning', duration: 3000, isClosable: true });
-            continue;
-          }
-          const uploadedIds = await uploadRes.json() as string[];
-          const assetDbId = uploadedIds[0];
-          if (!assetDbId) continue;
-          lastAssetId = assetDbId;
-
-          // Build ImageViewer title
-          const titleParts = [`${node.Title} v${iteration}`];
-          if (presetLabel) titleParts.push(presetLabel);
-          if (userContext) titleParts.push(`"${userContext.slice(0, 30)}"`);
-          const imageTitle = `${titleParts.join(' · ')} — ${s.prompt}`.slice(0, 100);
-
-          const imageResult = await createApp({
-            title: imageTitle,
-            roomId: props.data.roomId,
-            boardId: props.data.boardId,
-            position: {
-              x: stickiePosition.x + stickieSize.width + gap + (existingVizCount + placedCount) * (imgSize + gap),
-              y: stickiePosition.y,
-              z: 0,
-            },
-            size: { width: imgSize, height: imgSize, depth: 0 },
-            rotation: { x: 0, y: 0, z: 0 },
-            type: 'ImageViewer',
-            state: { assetid: assetDbId },
-            raised: true,
-            dragging: false,
-            pinned: false,
-          });
-
-          const imageViewerId = imageResult?.data?._id;
-
-          // ── Create info Stickie and link ──
-          const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-          const provenanceLines = [`Iteration: v${iteration}`, `Prompt: ${s.prompt}`];
-          if (presetLabel) provenanceLines.push(`Style: ${presetLabel}`);
-          if (userContext) provenanceLines.push(`Context: "${userContext}"`);
-          provenanceLines.push(`Generated: ${time}`);
-
-          const imgX = stickiePosition.x + stickieSize.width + gap + (existingVizCount + placedCount) * (imgSize + gap);
-          const provenanceResult = await createApp({
-            title: `${node.Title} v${iteration} — provenance`,
-            roomId: props.data.roomId,
-            boardId: props.data.boardId,
-            position: { x: imgX, y: stickiePosition.y + imgSize + gap, z: 0 },
-            size: { width: imgSize, height: 160, depth: 0 },
-            rotation: { x: 0, y: 0, z: 0 },
-            type: 'Stickie',
-            state: {
-              text: provenanceLines.join('\n'),
-              fontSize: 16,
-              color: 'yellow',
-              lock: false,
-              sources: [],
-              executeInfo: { executeFunc: '', params: {} },
-            },
-            raised: true,
-            dragging: false,
-            pinned: false,
-          });
-
-          const provenanceId = provenanceResult?.data?._id;
-          if (stickieId && provenanceId) {
-            addLink(stickieId, provenanceId, props.data.boardId, 'provenance');
-          }
-          if (provenanceId && imageViewerId) {
-            addLink(provenanceId, imageViewerId, props.data.boardId, 'provenance');
-          }
-
-          placedCount++;
-        }
-
-        // ── 5. Persist stickie + most recent asset ID in state ────────────
-        if (placedCount > 0 && lastAssetId) {
-          updateState(props._id, {
-            nodeImages: { ...(s.nodeImages ?? {}), [nodeId]: lastAssetId },
-            nodeStickies: { ...(s.nodeStickies ?? {}), [nodeId]: stickieId },
-          });
-        }
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg !== 'Cancelled') {
-          toast({ title: 'Visualization failed', description: msg, status: 'error', duration: 4000, isClosable: true });
-        }
-      } finally {
-        imageAbortRef.current = null;
-        setGeneratingImageNodeId(null);
-      }
-    },
-    [s, localNodes, activeEntryId, generatingImageNodeId, props._id, props.data, boardApps, createApp, addLink],
-  );
-
-  const cancelImageGeneration = useCallback(() => {
-    imageAbortRef.current?.abort();
-    imageAbortRef.current = null;
-    setGeneratingImageNodeId(null);
-  }, []);
-
-  const summarizeFavorites = useCallback(async () => {
-    const favNodes = localNodes.filter((n) => n.IsMyFav);
-    if (favNodes.length === 0 || isSummarizing) return;
-    setIsSummarizing(true);
-    try {
-      const summary = await summarizeFavoritesAPI(
-        favNodes.map((n) => ({ Title: n.Title, Summary: n.Summary, Keywords: n.Keywords })),
-        s.prompt,
-        s.apiKey,
-        s.model,
-      );
-      const header = `★ Favorites Summary\nTopic: ${s.prompt}\n\n`;
-      const footer = `\n\nFavorites: ${favNodes.map((n) => n.Title).join(', ')}`;
-      await createApp({
-        title: 'Favorites Summary',
-        roomId: props.data.roomId,
-        boardId: props.data.boardId,
-        position: { x: props.data.position.x + props.data.size.width + 20, y: props.data.position.y, z: 0 },
-        size: { width: 420, height: 520, depth: 0 },
-        rotation: { x: 0, y: 0, z: 0 },
-        type: 'Stickie',
-        state: {
-          text: header + summary + footer,
-          fontSize: 18,
-          color: 'yellow',
-          lock: false,
-          sources: [props._id],
-          executeInfo: { executeFunc: '', params: {} },
-        },
-        raised: true,
-        dragging: false,
-        pinned: false,
-      });
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      toast({ title: 'Summary failed', description: msg, status: 'error', duration: 4000, isClosable: true });
-    } finally {
-      setIsSummarizing(false);
-    }
-  }, [localNodes, s.prompt, s.apiKey, s.model, isSummarizing, props._id, props.data, createApp]);
-
-  const branchFromFavorites = useCallback(() => {
-    const favNodes = localNodes.filter((n) => n.IsMyFav);
-    if (favNodes.length === 0) return;
-    const ideasList = favNodes.map((n, i) => `${i + 1}. "${n.Title}": ${n.Summary}`).join('\n');
-    const aiPrompt = [
-      s.prompt ? `Original topic: ${s.prompt}` : '',
-      `\nThe following ideas were favorited from the previous exploration:\n${ideasList}`,
-      `\nNow generate new ideas that build on, combine, or extend the themes from these favorites. Explore adjacent variations that share their strengths.`,
-    ]
-      .filter(Boolean)
-      .join('\n');
-    const displayPrompt = `Branch from ${favNodes.length} favorite${favNodes.length > 1 ? 's' : ''}: ${favNodes.map((n) => n.Title).join(', ')}`;
-    generate({
-      displayPrompt,
-      aiPrompt,
-      parentEntryId: activeEntryId ?? undefined,
-    });
-  }, [localNodes, s.prompt, activeEntryId, generate]);
-
-  const generateAt = useCallback(
-    async ({
-      worldX,
-      worldY,
-      xDimName,
-      xBlend,
-      yDimName,
-      yBlend,
-    }: {
-      worldX: number;
-      worldY: number;
-      xDimName: string | null;
-      xBlend: DimBlend | null;
-      yDimName: string | null;
-      yBlend: DimBlend | null;
-    }) => {
-      if (!activeEntryId || localDims.length === 0) return;
-      setIsGeneratingAt(true);
-      try {
-        const { requirements, categorical, ordinal } = buildBlendedRequirements(localDims, xDimName, xBlend, yDimName, yBlend);
-        const text = await generateNodeContent(s.prompt, requirements, s.apiKey, s.model);
-        const summary = await abstractNode(text, s.apiKey, s.model);
-        const newNode: AppState['nodes'][number] = {
-          ID: genId(),
-          Title: summary.Title,
-          Summary: summary.Summary,
-          Keywords: summary.Keywords,
-          Steps: summary.Steps,
-          Result: text,
-          Structure: summary.Structure,
-          Dimension: { categorical, ordinal },
-          IsMyFav: false,
-        };
-        // Seed the position near where the user clicked so the simulation starts there
-        positionsRef.current.set(newNode.ID, { x: worldX, y: worldY });
-        const latest = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-        const cur = latest ?? s;
-        const updatedHistory = cur.chatHistory.map((e) => (e.id === activeEntryId ? { ...e, nodes: [...e.nodes, newNode] } : e));
-        updateState(props._id, { ...cur, chatHistory: updatedHistory });
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        toast({ title: 'Generation failed', description: msg, status: 'error', duration: 4000, isClosable: true });
-      } finally {
-        setIsGeneratingAt(false);
-      }
-    },
-    [s, localDims, activeEntryId, props._id, positionsRef],
-  );
-
-  const addManualIdea = useCallback(
-    async (text: string) => {
-      if (!activeEntryId) return;
-      setIsAddingManualIdea(true);
-      try {
-        const summary = await abstractNode(text, s.apiKey, s.model);
-        const rawDims = {
-          categorical: Object.fromEntries(localDims.filter((d) => d.type === 'categorical').map((d) => [d.name, d.values])),
-          ordinal: Object.fromEntries(localDims.filter((d) => d.type === 'ordinal').map((d) => [d.name, d.values])),
-        };
-        const { categorical, ordinal } = buildRequirements(rawDims);
-        const newNode: AppState['nodes'][number] = {
-          ID: genId(),
-          Title: summary.Title,
-          Summary: summary.Summary,
-          Keywords: summary.Keywords,
-          Steps: summary.Steps,
-          Result: text,
-          Structure: summary.Structure,
-          Dimension: { categorical, ordinal },
-          IsMyFav: false,
-        };
-        const latest = useAppStore.getState().apps.find((a) => a._id === props._id)?.data.state as AppState | undefined;
-        const cur = latest ?? s;
-        const updatedHistory = cur.chatHistory.map((e) => (e.id === activeEntryId ? { ...e, nodes: [...e.nodes, newNode] } : e));
-        updateState(props._id, { ...cur, chatHistory: updatedHistory });
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        toast({ title: 'Failed to add idea', description: msg, status: 'error', duration: 4000, isClosable: true });
-      } finally {
-        setIsAddingManualIdea(false);
-      }
-    },
-    [s, localDims, activeEntryId, props._id],
-  );
-
-  const removeDimension = useCallback(
-    (dimName: string) => {
-      if (!activeEntryId) return;
-      const updatedDims = localDims.filter((d) => d.name !== dimName);
-      const updatedNodes = localNodes.map((n) => {
-        const categorical = { ...n.Dimension.categorical };
-        const ordinal = { ...n.Dimension.ordinal };
-        delete categorical[dimName];
-        delete ordinal[dimName];
-        return { ...n, Dimension: { categorical, ordinal } };
-      });
-      const updatedHistory = s.chatHistory.map((e) =>
-        e.id === activeEntryId ? { ...e, nodes: updatedNodes, dimensions: updatedDims } : e,
-      );
-      updateState(props._id, { ...s, chatHistory: updatedHistory });
-    },
-    [s, localNodes, localDims, activeEntryId, props._id],
-  );
-
-  // ── Setup screen ──
 
   // ── Q&A helpers ──
 

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
@@ -141,8 +141,8 @@ function AppComponent(props: App): JSX.Element {
   );
 
   const handleClearPdf = useCallback(() => {
-    updateState(props._id, { ...s, pdfContext: undefined });
-  }, [s, props._id]);
+    updateState(props._id, { pdfContext: null as any });
+  }, [props._id, updateState]);
 
   // ── Q&A helpers ──
 

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
@@ -13,7 +13,7 @@ import { format } from 'date-fns/format';
 import { Flex, Box, Button, IconButton, Tooltip, useToast, useColorModeValue } from '@chakra-ui/react';
 import { MdFileDownload, MdChat, MdChevronLeft, MdChevronRight } from 'react-icons/md';
 
-import { useAppStore, useHexColor, useUser, downloadFile, apiUrls, useAssetStore } from '@sage3/frontend';
+import { useAppStore, useHexColor, useUser, downloadFile, apiUrls, useAssetStore, useLinkStore } from '@sage3/frontend';
 import { genId } from '@sage3/shared';
 
 import { App } from '../../schema';
@@ -118,6 +118,7 @@ function AppComponent(props: App): JSX.Element {
   const updateApp = useAppStore((state) => state.update);
   const createApp = useAppStore((state) => state.create);
   const boardApps = useAppStore((s) => s.apps);
+  const addLink = useLinkStore((s) => s.addLink);
   const toast = useToast();
 
   // Theme
@@ -153,6 +154,7 @@ function AppComponent(props: App): JSX.Element {
   // Refs shared with VisualizationCanvas
   const positionsRef = useRef<Map<string, { x: number; y: number }>>(new Map());
   const hasFitRef = useRef(false);
+  const imageAbortRef = useRef<AbortController | null>(null);
 
   // Stickie drag-to-import state
   const [pendingImport, setPendingImport] = useState<{
@@ -670,51 +672,162 @@ function AppComponent(props: App): JSX.Element {
   );
 
   const generateImageForNode = useCallback(
-    async (nodeId: string) => {
+    async (nodeId: string, context?: string, count = 1) => {
       if (generatingImageNodeId || !activeEntryId) return;
       const node = localNodes.find((n) => n.ID === nodeId);
       if (!node) return;
+      const controller = new AbortController();
+      imageAbortRef.current = controller;
       setGeneratingImageNodeId(nodeId);
       try {
-        const dataUrl = await generateNodeImage(node.Title, node.Summary, node.Keywords, s.apiKey, s.prompt, node.Dimension);
-        const blob = await fetch(dataUrl).then((r) => r.blob());
-        // Filename encodes idea title + problem space so it's identifiable in the Assets panel
+        // ── 1. Find or create anchor Stickie ─────────────────────────────
+        const liveApps = useAppStore.getState().apps;
+        const existingStickieId = s.nodeStickies?.[nodeId];
+        let stickieApp = existingStickieId
+          ? liveApps.find((a) => a._id === existingStickieId) ?? null
+          : null;
+
+        if (!stickieApp) {
+          stickieApp = liveApps.find(
+            (a) =>
+              a.data.type === 'Stickie' &&
+              a.data.boardId === props.data.boardId &&
+              (a.data.state as { text?: string }).text?.startsWith(node.Title)
+          ) ?? null;
+        }
+
+        let stickieId: string;
+        let stickiePosition: { x: number; y: number; z: number };
+        let stickieSize: { width: number; height: number; depth: number };
+
+        if (stickieApp) {
+          stickieId = stickieApp._id;
+          stickiePosition = stickieApp.data.position;
+          stickieSize = stickieApp.data.size;
+        } else {
+          const stickieResult = await createApp({
+            title: node.Title,
+            roomId: props.data.roomId,
+            boardId: props.data.boardId,
+            position: { x: props.data.position.x, y: props.data.position.y - 260, z: 0 },
+            size: { width: 320, height: 200, depth: 0 },
+            rotation: { x: 0, y: 0, z: 0 },
+            type: 'Stickie',
+            state: {
+              text: `${node.Title}\n\n${node.Summary}`,
+              fontSize: 18,
+              color: 'purple',
+              lock: false,
+              sources: [props._id],
+              executeInfo: { executeFunc: '', params: {} },
+            },
+            raised: true,
+            dragging: false,
+            pinned: false,
+          });
+          stickieId = stickieResult?.data?._id ?? '';
+          stickiePosition = { x: props.data.position.x, y: props.data.position.y - 260, z: 0 };
+          stickieSize = { width: 320, height: 200, depth: 0 };
+        }
+
+        // ── 2. Count existing visualizations to offset placement ──────────
+        const existingVizCount = liveApps.filter(
+          (a) =>
+            a.data.type === 'ImageViewer' &&
+            a.data.boardId === props.data.boardId &&
+            a.data.title.startsWith(node.Title)
+        ).length;
+
+        // ── 3. Generate all variations in parallel ────────────────────────
         const safeTitle = node.Title.replace(/[^a-zA-Z0-9\s-]/g, '').trim().slice(0, 40);
         const safePrompt = s.prompt.replace(/[^a-zA-Z0-9\s-]/g, '').trim().slice(0, 40);
-        const imgFile = new File([blob], `${safeTitle} - ${safePrompt}.png`, { type: 'image/png' });
-        const fd = new FormData();
-        fd.append('files', imgFile);
-        fd.append('room', props.data.roomId);
-        const uploadRes = await fetch(apiUrls.assets.upload, { method: 'POST', body: fd, credentials: 'include' });
-        if (!uploadRes.ok) throw new Error('Asset upload failed');
-        const uploadedIds = await uploadRes.json() as string[];
-        const assetDbId = uploadedIds[0];
-        if (!assetDbId) throw new Error('No asset ID returned from upload');
-        // Store the DB id — localNodes resolves it to a URL via useAssetStore
-        updateState(props._id, { nodeImages: { ...(s.nodeImages ?? {}), [nodeId]: assetDbId } });
-        // Open the image as an ImageViewer app on the board, labelled with idea + problem space
-        await createApp({
-          title: `${node.Title} — ${s.prompt}`.slice(0, 100),
-          roomId: props.data.roomId,
-          boardId: props.data.boardId,
-          position: { x: props.data.position.x + props.data.size.width + 20, y: props.data.position.y, z: 0 },
-          size: { width: 512, height: 512, depth: 0 },
-          rotation: { x: 0, y: 0, z: 0 },
-          type: 'ImageViewer',
-          state: { assetid: assetDbId },
-          raised: true,
-          dragging: false,
-          pinned: false,
-        });
+        const imgSize = 512;
+        const gap = 20;
+
+        const results = await Promise.allSettled(
+          Array.from({ length: count }, () =>
+            generateNodeImage(node.Title, node.Summary, node.Keywords, s.apiKey, s.prompt, node.Dimension, controller.signal, context)
+          )
+        );
+
+        // ── 4. Upload and place each successful result ────────────────────
+        let placedCount = 0;
+        let lastAssetId: string | null = null;
+        for (const result of results) {
+          if (result.status === 'rejected') {
+            const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
+            if (msg !== 'Cancelled') {
+              toast({ title: 'One variation failed', description: msg, status: 'warning', duration: 3000, isClosable: true });
+            }
+            continue;
+          }
+
+          const blob = await fetch(result.value).then((r) => r.blob());
+          const variantSuffix = count > 1 ? ` v${existingVizCount + placedCount + 1}` : '';
+          const imgFile = new File([blob], `${safeTitle} - ${safePrompt}${variantSuffix}.png`, { type: 'image/png' });
+          const fd = new FormData();
+          fd.append('files', imgFile);
+          fd.append('room', props.data.roomId);
+          const uploadRes = await fetch(apiUrls.assets.upload, { method: 'POST', body: fd, credentials: 'include' });
+          if (!uploadRes.ok) {
+            toast({ title: 'Upload failed', status: 'warning', duration: 3000, isClosable: true });
+            continue;
+          }
+          const uploadedIds = await uploadRes.json() as string[];
+          const assetDbId = uploadedIds[0];
+          if (!assetDbId) continue;
+          lastAssetId = assetDbId;
+
+          const imageResult = await createApp({
+            title: `${node.Title}${variantSuffix} — ${s.prompt}`.slice(0, 100),
+            roomId: props.data.roomId,
+            boardId: props.data.boardId,
+            position: {
+              x: stickiePosition.x + stickieSize.width + gap + (existingVizCount + placedCount) * (imgSize + gap),
+              y: stickiePosition.y,
+              z: 0,
+            },
+            size: { width: imgSize, height: imgSize, depth: 0 },
+            rotation: { x: 0, y: 0, z: 0 },
+            type: 'ImageViewer',
+            state: { assetid: assetDbId },
+            raised: true,
+            dragging: false,
+            pinned: false,
+          });
+
+          const imageViewerId = imageResult?.data?._id;
+          if (stickieId && imageViewerId) {
+            addLink(stickieId, imageViewerId, props.data.boardId, 'provenance');
+          }
+          placedCount++;
+        }
+
+        // ── 5. Persist stickie + most recent asset ID in state ────────────
+        if (placedCount > 0 && lastAssetId) {
+          updateState(props._id, {
+            nodeImages: { ...(s.nodeImages ?? {}), [nodeId]: lastAssetId },
+            nodeStickies: { ...(s.nodeStickies ?? {}), [nodeId]: stickieId },
+          });
+        }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        toast({ title: 'Image generation failed', description: msg, status: 'error', duration: 4000, isClosable: true });
+        if (msg !== 'Cancelled') {
+          toast({ title: 'Visualization failed', description: msg, status: 'error', duration: 4000, isClosable: true });
+        }
       } finally {
+        imageAbortRef.current = null;
         setGeneratingImageNodeId(null);
       }
     },
-    [s, localNodes, activeEntryId, generatingImageNodeId, props._id, props.data.roomId, props.data.boardId, props.data.position, props.data.size, createApp],
+    [s, localNodes, activeEntryId, generatingImageNodeId, props._id, props.data, boardApps, createApp, addLink],
   );
+
+  const cancelImageGeneration = useCallback(() => {
+    imageAbortRef.current?.abort();
+    imageAbortRef.current = null;
+    setGeneratingImageNodeId(null);
+  }, []);
 
   const summarizeFavorites = useCallback(async () => {
     const favNodes = localNodes.filter((n) => n.IsMyFav);
@@ -983,6 +1096,7 @@ function AppComponent(props: App): JSX.Element {
           onSummarizeFavorites={summarizeFavorites}
           isSummarizing={isSummarizing}
           onGenerateImage={generateImageForNode}
+          onCancelImageGeneration={cancelImageGeneration}
           generatingImageNodeId={generatingImageNodeId}
           onReroll={rerollNode}
           rerollingNodeId={rerollingNodeId}

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
@@ -672,7 +672,7 @@ function AppComponent(props: App): JSX.Element {
   );
 
   const generateImageForNode = useCallback(
-    async (nodeId: string, context?: string, count = 1) => {
+    async (nodeId: string, context?: string, count = 1, presetLabel?: string, userContext?: string) => {
       if (generatingImageNodeId || !activeEntryId) return;
       const node = localNodes.find((n) => n.ID === nodeId);
       if (!node) return;
@@ -753,6 +753,7 @@ function AppComponent(props: App): JSX.Element {
         // ── 4. Upload and place each successful result ────────────────────
         let placedCount = 0;
         let lastAssetId: string | null = null;
+
         for (const result of results) {
           if (result.status === 'rejected') {
             const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
@@ -762,9 +763,10 @@ function AppComponent(props: App): JSX.Element {
             continue;
           }
 
+          const iteration = existingVizCount + placedCount + 1;
           const blob = await fetch(result.value).then((r) => r.blob());
-          const variantSuffix = count > 1 ? ` v${existingVizCount + placedCount + 1}` : '';
-          const imgFile = new File([blob], `${safeTitle} - ${safePrompt}${variantSuffix}.png`, { type: 'image/png' });
+          const variantSuffix = ` v${iteration}`;
+          const imgFile = new File([blob], `${safeTitle}${variantSuffix} - ${safePrompt}.png`, { type: 'image/png' });
           const fd = new FormData();
           fd.append('files', imgFile);
           fd.append('room', props.data.roomId);
@@ -778,8 +780,14 @@ function AppComponent(props: App): JSX.Element {
           if (!assetDbId) continue;
           lastAssetId = assetDbId;
 
+          // Build ImageViewer title
+          const titleParts = [`${node.Title} v${iteration}`];
+          if (presetLabel) titleParts.push(presetLabel);
+          if (userContext) titleParts.push(`"${userContext.slice(0, 30)}"`);
+          const imageTitle = `${titleParts.join(' · ')} — ${s.prompt}`.slice(0, 100);
+
           const imageResult = await createApp({
-            title: `${node.Title}${variantSuffix} — ${s.prompt}`.slice(0, 100),
+            title: imageTitle,
             roomId: props.data.roomId,
             boardId: props.data.boardId,
             position: {
@@ -797,9 +805,44 @@ function AppComponent(props: App): JSX.Element {
           });
 
           const imageViewerId = imageResult?.data?._id;
-          if (stickieId && imageViewerId) {
-            addLink(stickieId, imageViewerId, props.data.boardId, 'provenance');
+
+          // ── Create info Stickie and link ──
+          const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+          const provenanceLines = [`Iteration: v${iteration}`, `Prompt: ${s.prompt}`];
+          if (presetLabel) provenanceLines.push(`Style: ${presetLabel}`);
+          if (userContext) provenanceLines.push(`Context: "${userContext}"`);
+          provenanceLines.push(`Generated: ${time}`);
+
+          const imgX = stickiePosition.x + stickieSize.width + gap + (existingVizCount + placedCount) * (imgSize + gap);
+          const provenanceResult = await createApp({
+            title: `${node.Title} v${iteration} — provenance`,
+            roomId: props.data.roomId,
+            boardId: props.data.boardId,
+            position: { x: imgX, y: stickiePosition.y + imgSize + gap, z: 0 },
+            size: { width: imgSize, height: 160, depth: 0 },
+            rotation: { x: 0, y: 0, z: 0 },
+            type: 'Stickie',
+            state: {
+              text: provenanceLines.join('\n'),
+              fontSize: 16,
+              color: 'yellow',
+              lock: false,
+              sources: [],
+              executeInfo: { executeFunc: '', params: {} },
+            },
+            raised: true,
+            dragging: false,
+            pinned: false,
+          });
+
+          const provenanceId = provenanceResult?.data?._id;
+          if (stickieId && provenanceId) {
+            addLink(stickieId, provenanceId, props.data.boardId, 'provenance');
           }
+          if (provenanceId && imageViewerId) {
+            addLink(provenanceId, imageViewerId, props.data.boardId, 'provenance');
+          }
+
           placedCount++;
         }
 

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/SageIdeator.tsx
@@ -677,9 +677,11 @@ function AppComponent(props: App): JSX.Element {
       setGeneratingImageNodeId(nodeId);
       try {
         const dataUrl = await generateNodeImage(node.Title, node.Summary, node.Keywords, s.apiKey, s.prompt, node.Dimension);
-        // Upload to SAGE3 assets to avoid storing a ~1MB base64 string in app state
         const blob = await fetch(dataUrl).then((r) => r.blob());
-        const imgFile = new File([blob], `idea-${nodeId}.png`, { type: 'image/png' });
+        // Filename encodes idea title + problem space so it's identifiable in the Assets panel
+        const safeTitle = node.Title.replace(/[^a-zA-Z0-9\s-]/g, '').trim().slice(0, 40);
+        const safePrompt = s.prompt.replace(/[^a-zA-Z0-9\s-]/g, '').trim().slice(0, 40);
+        const imgFile = new File([blob], `${safeTitle} - ${safePrompt}.png`, { type: 'image/png' });
         const fd = new FormData();
         fd.append('files', imgFile);
         fd.append('room', props.data.roomId);
@@ -690,6 +692,20 @@ function AppComponent(props: App): JSX.Element {
         if (!assetDbId) throw new Error('No asset ID returned from upload');
         // Store the DB id — localNodes resolves it to a URL via useAssetStore
         updateState(props._id, { nodeImages: { ...(s.nodeImages ?? {}), [nodeId]: assetDbId } });
+        // Open the image as an ImageViewer app on the board, labelled with idea + problem space
+        await createApp({
+          title: `${node.Title} — ${s.prompt}`.slice(0, 100),
+          roomId: props.data.roomId,
+          boardId: props.data.boardId,
+          position: { x: props.data.position.x + props.data.size.width + 20, y: props.data.position.y, z: 0 },
+          size: { width: 512, height: 512, depth: 0 },
+          rotation: { x: 0, y: 0, z: 0 },
+          type: 'ImageViewer',
+          state: { assetid: assetDbId },
+          raised: true,
+          dragging: false,
+          pinned: false,
+        });
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         toast({ title: 'Image generation failed', description: msg, status: 'error', duration: 4000, isClosable: true });
@@ -697,7 +713,7 @@ function AppComponent(props: App): JSX.Element {
         setGeneratingImageNodeId(null);
       }
     },
-    [s, localNodes, activeEntryId, generatingImageNodeId, props._id, props.data.roomId],
+    [s, localNodes, activeEntryId, generatingImageNodeId, props._id, props.data.roomId, props.data.boardId, props.data.position, props.data.size, createApp],
   );
 
   const summarizeFavorites = useCallback(async () => {

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/StickyImportDialog.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/StickyImportDialog.tsx
@@ -15,6 +15,8 @@ import {
   ModalBody,
   ModalCloseButton,
   Button,
+  IconButton,
+  Tooltip,
   Text,
   VStack,
   HStack,
@@ -26,6 +28,7 @@ import {
   Divider,
   useColorModeValue,
 } from '@chakra-ui/react';
+import { MdRefresh } from 'react-icons/md';
 
 export type ImportPreview = {
   Title: string;
@@ -122,9 +125,16 @@ export function StickyImportDialog({ isOpen, isLoading, originalText, preview, o
           <Button size="sm" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
-          <Button size="sm" variant="outline" onClick={onRegenerate} isDisabled={isLoading}>
-            Try Again
-          </Button>
+          <Tooltip label="Reroll" placement="top" hasArrow openDelay={300}>
+            <IconButton
+              aria-label="Reroll"
+              icon={<MdRefresh />}
+              size="sm"
+              variant="outline"
+              onClick={onRegenerate}
+              isDisabled={isLoading}
+            />
+          </Tooltip>
           <Button size="sm" colorScheme="teal" onClick={onConfirm} isDisabled={isLoading || !preview}>
             Add Idea
           </Button>

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/VisualizationCanvas.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/VisualizationCanvas.tsx
@@ -107,7 +107,7 @@ interface VisualizationCanvasProps {
   onBranchFavorites: () => void;
   onSummarizeFavorites: () => void;
   isSummarizing: boolean;
-  onGenerateImage: (nodeId: string, context?: string, count?: number) => void;
+  onGenerateImage: (nodeId: string, context?: string, count?: number, presetLabel?: string, userContext?: string) => void;
   onCancelImageGeneration: () => void;
   generatingImageNodeId: string | null;
   onReroll: (nodeId: string) => void;
@@ -713,7 +713,7 @@ export function VisualizationCanvas({
                   }}
                   onBranch={() => onBranch(node)}
                   onSelectQA={() => onSelectQA(node.ID)}
-                  onGenerateImage={(context, count) => onGenerateImage(node.ID, context, count)}
+                  onGenerateImage={(context, count, presetLabel, userContext) => onGenerateImage(node.ID, context, count, presetLabel, userContext)}
                   onCancelGeneration={onCancelImageGeneration}
                   isGeneratingImage={generatingImageNodeId === node.ID}
                   onReroll={() => onReroll(node.ID)}

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/VisualizationCanvas.tsx
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/VisualizationCanvas.tsx
@@ -107,7 +107,8 @@ interface VisualizationCanvasProps {
   onBranchFavorites: () => void;
   onSummarizeFavorites: () => void;
   isSummarizing: boolean;
-  onGenerateImage: (nodeId: string) => void;
+  onGenerateImage: (nodeId: string, context?: string, count?: number) => void;
+  onCancelImageGeneration: () => void;
   generatingImageNodeId: string | null;
   onReroll: (nodeId: string) => void;
   rerollingNodeId: string | null;
@@ -166,6 +167,7 @@ export function VisualizationCanvas({
   onSummarizeFavorites,
   isSummarizing,
   onGenerateImage,
+  onCancelImageGeneration,
   generatingImageNodeId,
   onReroll,
   rerollingNodeId,
@@ -711,7 +713,8 @@ export function VisualizationCanvas({
                   }}
                   onBranch={() => onBranch(node)}
                   onSelectQA={() => onSelectQA(node.ID)}
-                  onGenerateImage={() => onGenerateImage(node.ID)}
+                  onGenerateImage={(context, count) => onGenerateImage(node.ID, context, count)}
+                  onCancelGeneration={onCancelImageGeneration}
                   isGeneratingImage={generatingImageNodeId === node.ID}
                   onReroll={() => onReroll(node.ID)}
                   isRerolling={rerollingNodeId === node.ID}

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/index.ts
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/index.ts
@@ -62,6 +62,7 @@ export const schema = z.object({
   pdfContext: z.object({ filename: z.string(), text: z.string() }).optional(),
   favorites: z.record(z.string(), z.boolean()).default({}),
   nodeImages: z.record(z.string(), z.string()).default({}),
+  nodeStickies: z.record(z.string(), z.string()).default({}),
   chatHistory: z.array(
     z.object({
       id: z.string(),
@@ -98,6 +99,7 @@ export const init: Partial<state> = {
   qa: [],
   favorites: {},
   nodeImages: {},
+  nodeStickies: {},
   chatHistory: [],
 };
 

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/openai.ts
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/openai.ts
@@ -89,8 +89,10 @@ export async function generateNodeImage(
   _apiKey: string,
   brainstormingPrompt?: string,
   dimension?: { categorical: Record<string, string>; ordinal: Record<string, string> },
+  signal?: AbortSignal,
+  additionalContext?: string,
 ): Promise<string> {
-  const result = await seerIdeator.image({ title, summary, keywords, model: 'openai', brainstormingPrompt, dimension });
+  const result = await seerIdeator.image({ title, summary, keywords, model: 'openai', brainstormingPrompt, dimension, additionalContext }, signal);
   if (isSError(result)) throw new Error(result.message);
   return result.imageUrl;
 }

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/openai.ts
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/openai.ts
@@ -10,6 +10,8 @@
 
 import { seerIdeator } from '@sage3/frontend';
 import { SError } from '@sage3/shared';
+import { state as AppState } from './index';
+import { DimBlend } from './VisualizationCanvas';
 
 function isSError(r: unknown): r is SError {
   return typeof r === 'object' && r !== null && 'message' in r;
@@ -105,6 +107,42 @@ export async function callProseAPI(
   const result = await seerIdeator.prose({ userPrompt, model });
   if (isSError(result)) throw new Error(result.message);
   return result.r;
+}
+
+export function buildBlendedRequirements(
+  dims: AppState['dimensions'],
+  xDimName: string | null,
+  xBlend: DimBlend | null,
+  yDimName: string | null,
+  yBlend: DimBlend | null,
+): { requirements: string; categorical: Record<string, string>; ordinal: Record<string, string> } {
+  let req = '';
+  const categorical: Record<string, string> = {};
+  const ordinal: Record<string, string> = {};
+  for (const dim of dims) {
+    const blend = dim.name === xDimName ? xBlend : dim.name === yDimName ? yBlend : null;
+    let assignedValue: string;
+    if (blend) {
+      if (blend.secondary === null || blend.primaryWeight === 1) {
+        req += `${dim.name}: ${blend.primary}\n`;
+        assignedValue = blend.primary;
+      } else if (blend.primaryWeight >= 0.65) {
+        req += `${dim.name}: primarily "${blend.primary}" with some "${blend.secondary}" influence\n`;
+        assignedValue = blend.primary;
+      } else {
+        const pct = Math.round(blend.primaryWeight * 100);
+        const sPct = 100 - pct;
+        req += `${dim.name}: blend of "${blend.primary}" (${pct}%) and "${blend.secondary}" (${sPct}%)\n`;
+        assignedValue = blend.primary;
+      }
+    } else {
+      assignedValue = dim.values[Math.floor(Math.random() * dim.values.length)];
+      req += `${dim.name}: ${assignedValue}\n`;
+    }
+    if (dim.type === 'categorical') categorical[dim.name] = assignedValue;
+    else ordinal[dim.name] = assignedValue;
+  }
+  return { requirements: req, categorical, ordinal };
 }
 
 export function buildRequirements(dims: {

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/useIdeation.ts
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/useIdeation.ts
@@ -96,7 +96,6 @@ export function useIdeation({ s, appId, input, setInput, attachedImage, setAttac
       if (!branchOpts) {
         setInput('');
         setAttachedImage(null);
-        updateState(appId, { ...s, pdfContext: undefined });
       }
       positionsRef.current.clear();
       hasFitRef.current = false;
@@ -117,7 +116,12 @@ export function useIdeation({ s, appId, input, setInput, attachedImage, setAttac
 
       setIsGenerating(true);
       setLocalStatusMessage('Determining important aspects…');
-      updateState(appId, { ...s, prompt: aiPrompt, chatHistory: [...s.chatHistory, chatEntry] });
+      updateState(appId, {
+        ...s,
+        prompt: aiPrompt,
+        chatHistory: [...s.chatHistory, chatEntry],
+        ...(!branchOpts && { pdfContext: null as any }),
+      });
 
       try {
         const rawDims = await generateDimensionsFromPrompt(aiPrompt, s.apiKey, s.model, s.numDimensions, image, s.pdfContext?.text);
@@ -250,7 +254,7 @@ export function useIdeation({ s, appId, input, setInput, attachedImage, setAttac
         ]
           .filter(Boolean)
           .join('\n');
-        const answer = await callProseAPI(`${context}\n\nQuestion: ${question}`, s.apiKey, s.model);
+        const answer = await callProseAPI(`Answer in 80 words or fewer.\n\n${context}\n\nQuestion: ${question}`, s.apiKey, s.model);
         const qaEntry = {
           id: genId(),
           nodeId: node.ID,
@@ -313,11 +317,14 @@ export function useIdeation({ s, appId, input, setInput, attachedImage, setAttac
         const cur = latest ?? s;
         const curEntry = cur.chatHistory.find((e) => e.id === activeEntryId);
         if (!curEntry) return;
-        const rawDims = {
-          categorical: Object.fromEntries(curEntry.dimensions.filter((d) => d.type === 'categorical').map((d) => [d.name, d.values])),
-          ordinal: Object.fromEntries(curEntry.dimensions.filter((d) => d.type === 'ordinal').map((d) => [d.name, d.values])),
-        };
-        const { requirements, categorical, ordinal } = buildRequirements(rawDims);
+        const originalNode = curEntry.nodes.find((n) => n.ID === nodeId);
+        if (!originalNode) return;
+        // Preserve the original node's dimension assignments so it stays in the same design-space position
+        const { categorical, ordinal } = originalNode.Dimension;
+        const requirements = [
+          ...Object.entries(categorical).map(([name, value]) => `${name}: ${value}`),
+          ...Object.entries(ordinal).map(([name, value]) => `${name}: ${value}`),
+        ].join('\n');
         const text = await generateNodeContent(curEntry.prompt, requirements, s.apiKey, s.model, undefined, s.pdfContext?.text);
         const summary = await abstractNode(text, s.apiKey, s.model);
         const afterGen = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/useIdeation.ts
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/useIdeation.ts
@@ -1,0 +1,584 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+import { useRef, useState, useCallback } from 'react';
+import { useToast } from '@chakra-ui/react';
+import { useAppStore, useUser } from '@sage3/frontend';
+import { genId } from '@sage3/shared';
+
+import { state as AppState } from './index';
+import { DimBlend } from './VisualizationCanvas';
+import {
+  generateDimensionsFromPrompt,
+  generateNodeContent,
+  abstractNode,
+  buildRequirements,
+  buildBlendedRequirements,
+  generateUserDimension,
+  callProseAPI,
+  summarizeFavorites as summarizeFavoritesAPI,
+  VISION_MODELS,
+} from './openai';
+
+type SageNode = AppState['nodes'][number];
+type SageDimension = AppState['dimensions'][number];
+
+interface UseIdeationProps {
+  s: AppState;
+  appId: string;
+  input: string;
+  setInput: (v: string) => void;
+  attachedImage: string | null;
+  setAttachedImage: (v: string | null) => void;
+  boardId: string;
+  roomId: string;
+  appPosition: { x: number; y: number; z: number };
+  appSize: { width: number; height: number; depth: number };
+}
+
+export function useIdeation({ s, appId, input, setInput, attachedImage, setAttachedImage, boardId, roomId, appPosition, appSize }: UseIdeationProps) {
+  const { user } = useUser();
+  const username = user?.data.name.split(' ')[0] ?? '';
+
+  const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [localStatusMessage, setLocalStatusMessage] = useState('');
+  const [askingNodeId, setAskingNodeId] = useState<string | null>(null);
+  const [isAddingDimension, setIsAddingDimension] = useState(false);
+  const [rerollingNodeId, setRerollingNodeId] = useState<string | null>(null);
+  const [isGeneratingAt, setIsGeneratingAt] = useState(false);
+  const [isAddingManualIdea, setIsAddingManualIdea] = useState(false);
+  const [isSummarizing, setIsSummarizing] = useState(false);
+
+  const positionsRef = useRef<Map<string, { x: number; y: number }>>(new Map());
+  const hasFitRef = useRef(false);
+
+  const updateState = useAppStore((state) => state.updateState);
+  const createApp = useAppStore((state) => state.create);
+  const toast = useToast();
+
+  // Derived from active entry
+  const activeEntry = s.chatHistory.find((e) => e.id === activeEntryId) ?? null;
+  const localNodes: SageNode[] = (activeEntry?.nodes ?? []).map((n) => ({
+    ...n,
+    IsMyFav: (s.favorites ?? {})[n.ID] ?? false,
+  }));
+  const localDims: SageDimension[] = activeEntry?.dimensions ?? [];
+
+  const generate = useCallback(
+    async (branchOpts?: { displayPrompt: string; aiPrompt: string; parentEntryId?: string; parentNodeTitle?: string }) => {
+      if (!user || isGenerating) return;
+
+      const displayPrompt = branchOpts?.displayPrompt ?? input.trim();
+      const aiPrompt = branchOpts?.aiPrompt ?? input.trim();
+      if (!displayPrompt) {
+        toast({ title: 'Enter a prompt', status: 'warning', duration: 2500, isClosable: true });
+        return;
+      }
+
+      const image = branchOpts ? undefined : (attachedImage ?? undefined);
+      if (image && !VISION_MODELS.has(s.model)) {
+        toast({
+          title: 'Model does not support images',
+          description: `Switch to a vision-capable model (e.g. gpt-4o-mini) to use image prompts.`,
+          status: 'warning',
+          duration: 4000,
+          isClosable: true,
+        });
+        return;
+      }
+
+      if (!branchOpts) {
+        setInput('');
+        setAttachedImage(null);
+        updateState(appId, { ...s, pdfContext: undefined });
+      }
+      positionsRef.current.clear();
+      hasFitRef.current = false;
+
+      const chatEntry = {
+        id: genId(),
+        prompt: displayPrompt,
+        userName: username,
+        userId: user._id,
+        timestamp: Date.now(),
+        nodes: [] as AppState['nodes'],
+        dimensions: [] as AppState['dimensions'],
+        parentEntryId: branchOpts?.parentEntryId,
+        parentNodeTitle: branchOpts?.parentNodeTitle,
+        imageUrl: image,
+        pdfFilename: s.pdfContext?.filename,
+      };
+
+      setIsGenerating(true);
+      setLocalStatusMessage('Determining important aspects…');
+      updateState(appId, { ...s, prompt: aiPrompt, chatHistory: [...s.chatHistory, chatEntry] });
+
+      try {
+        const rawDims = await generateDimensionsFromPrompt(aiPrompt, s.apiKey, s.model, s.numDimensions, image, s.pdfContext?.text);
+        const dimensions: AppState['dimensions'] = [
+          ...Object.entries(rawDims.categorical).map(([name, values], i) => ({ id: i, name, type: 'categorical' as const, values })),
+          ...Object.entries(rawDims.ordinal).map(([name, values], i) => ({
+            id: Object.keys(rawDims.categorical).length + i,
+            name,
+            type: 'ordinal' as const,
+            values,
+          })),
+        ];
+
+        setLocalStatusMessage(`Generating ${s.batchSize} responses…`);
+        const newNodes: AppState['nodes'] = [];
+        const results = await Promise.allSettled(
+          Array.from({ length: s.batchSize }, async () => {
+            const { requirements, categorical, ordinal } = buildRequirements(rawDims);
+            const text = await generateNodeContent(aiPrompt, requirements, s.apiKey, s.model, image, s.pdfContext?.text);
+            const summary = await abstractNode(text, s.apiKey, s.model);
+            return {
+              ID: genId(),
+              Title: summary.Title,
+              Summary: summary.Summary,
+              Keywords: summary.Keywords,
+              Steps: summary.Steps,
+              Result: text,
+              Structure: summary.Structure,
+              Dimension: { categorical, ordinal },
+              IsMyFav: false,
+            };
+          }),
+        );
+        for (const r of results) {
+          if (r.status === 'fulfilled') newNodes.push(r.value);
+        }
+        if (newNodes.length === 0) throw new Error('All idea generations failed');
+
+        const latest = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+        const updatedHistory = (latest?.chatHistory ?? [...s.chatHistory, chatEntry]).map((e) =>
+          e.id === chatEntry.id ? { ...e, nodes: newNodes, dimensions } : e,
+        );
+        setIsGenerating(false);
+        setLocalStatusMessage('');
+        updateState(appId, { ...(latest ?? s), status: 'ready', prompt: aiPrompt, chatHistory: updatedHistory });
+        setActiveEntryId(chatEntry.id);
+      } catch (err: unknown) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        toast({ title: 'Generation failed', description: errMsg, status: 'error', duration: 5000, isClosable: true });
+        setIsGenerating(false);
+        setLocalStatusMessage('');
+        updateState(appId, { ...s, status: 'idle' });
+      }
+    },
+    [user, s, input, username, isGenerating, appId, attachedImage, setInput, setAttachedImage, updateState, toast],
+  );
+
+  const toggleFav = useCallback(
+    (nodeId: string) => {
+      const current = (s.favorites ?? {})[nodeId] ?? false;
+      updateState(appId, { favorites: { ...(s.favorites ?? {}), [nodeId]: !current } });
+    },
+    [s, appId, updateState],
+  );
+
+  const clearAll = useCallback(() => {
+    updateState(appId, {
+      ...s,
+      status: 'idle',
+      nodes: [],
+      dimensions: [],
+      prompt: '',
+      statusMessage: '',
+      chatHistory: [],
+      qa: [],
+      favorites: {},
+      nodeImages: {},
+    });
+    positionsRef.current.clear();
+    hasFitRef.current = false;
+    setActiveEntryId(null);
+  }, [s, appId, updateState]);
+
+  const deleteEntry = useCallback(
+    (entryId: string) => {
+      const updated = s.chatHistory.filter((e) => e.id !== entryId);
+      updateState(appId, { ...s, chatHistory: updated });
+      if (activeEntryId === entryId) {
+        const idx = s.chatHistory.findIndex((e) => e.id === entryId);
+        const next = updated[idx - 1] ?? updated[idx] ?? null;
+        setActiveEntryId(next?.id ?? null);
+      }
+    },
+    [s, appId, activeEntryId, updateState],
+  );
+
+  const restoreSnapshot = useCallback((entry: AppState['chatHistory'][number]) => {
+    if (!(entry.nodes ?? []).length) return;
+    positionsRef.current.clear();
+    hasFitRef.current = false;
+    setActiveEntryId(entry.id);
+  }, []);
+
+  const branchFromNode = useCallback(
+    (node: SageNode) => {
+      const aiPrompt = [
+        s.prompt,
+        `\nNow explore new variations specifically inspired by this idea:`,
+        `Title: "${node.Title}"`,
+        node.Summary,
+        node.Steps?.length ? `Steps: ${node.Steps.join('; ')}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n');
+      generate({ displayPrompt: node.Title, aiPrompt, parentEntryId: activeEntryId ?? undefined, parentNodeTitle: node.Title });
+    },
+    [s.prompt, activeEntryId, generate],
+  );
+
+  const askNodeQuestion = useCallback(
+    async (node: SageNode, question: string) => {
+      if (!user || askingNodeId) return;
+      setAskingNodeId(node.ID);
+      try {
+        const context = [
+          `Idea: "${node.Title}"`,
+          node.Summary,
+          node.Steps?.length ? `Steps: ${node.Steps.join('; ')}` : '',
+          node.Result ? `Details: ${node.Result}` : '',
+        ]
+          .filter(Boolean)
+          .join('\n');
+        const answer = await callProseAPI(`${context}\n\nQuestion: ${question}`, s.apiKey, s.model);
+        const qaEntry = {
+          id: genId(),
+          nodeId: node.ID,
+          nodeTitle: node.Title,
+          question,
+          answer,
+          userId: user._id,
+          userName: username,
+          timestamp: Date.now(),
+        };
+        const latest = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+        updateState(appId, { ...(latest ?? s), qa: [...(latest?.qa ?? s.qa ?? []), qaEntry] });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        toast({ title: 'Question failed', description: msg, status: 'error', duration: 4000, isClosable: true });
+      } finally {
+        setAskingNodeId(null);
+      }
+    },
+    [user, s, username, askingNodeId, appId, updateState, toast],
+  );
+
+  const addDimension = useCallback(
+    async (dimName: string) => {
+      if (isAddingDimension || localNodes.length === 0 || !activeEntryId) return;
+      setIsAddingDimension(true);
+      try {
+        const nodeStubs = localNodes.map((n) => ({ ID: n.ID, Title: n.Title, Summary: n.Summary }));
+        const { type, values, assignments } = await generateUserDimension(dimName, s.prompt, nodeStubs, s.apiKey, s.model);
+        const newDim = { id: localDims.length, name: dimName, type, values };
+        const updatedNodes = localNodes.map((n) => ({
+          ...n,
+          Dimension: {
+            categorical: type === 'categorical' ? { ...n.Dimension.categorical, [dimName]: assignments[n.ID] ?? values[0] } : n.Dimension.categorical,
+            ordinal: type === 'ordinal' ? { ...n.Dimension.ordinal, [dimName]: assignments[n.ID] ?? values[0] } : n.Dimension.ordinal,
+          },
+        }));
+        const latest = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+        const cur = latest ?? s;
+        const updatedHistory = cur.chatHistory.map((e) =>
+          e.id === activeEntryId ? { ...e, nodes: updatedNodes, dimensions: [...(e.dimensions ?? []), newDim] } : e,
+        );
+        updateState(appId, { ...cur, chatHistory: updatedHistory });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        toast({ title: 'Failed to add dimension', description: msg, status: 'error', duration: 4000, isClosable: true });
+      } finally {
+        setIsAddingDimension(false);
+      }
+    },
+    [s, localNodes, localDims, activeEntryId, isAddingDimension, appId, updateState, toast],
+  );
+
+  const rerollNode = useCallback(
+    async (nodeId: string) => {
+      if (rerollingNodeId || !activeEntryId) return;
+      setRerollingNodeId(nodeId);
+      try {
+        const latest = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+        const cur = latest ?? s;
+        const curEntry = cur.chatHistory.find((e) => e.id === activeEntryId);
+        if (!curEntry) return;
+        const rawDims = {
+          categorical: Object.fromEntries(curEntry.dimensions.filter((d) => d.type === 'categorical').map((d) => [d.name, d.values])),
+          ordinal: Object.fromEntries(curEntry.dimensions.filter((d) => d.type === 'ordinal').map((d) => [d.name, d.values])),
+        };
+        const { requirements, categorical, ordinal } = buildRequirements(rawDims);
+        const text = await generateNodeContent(curEntry.prompt, requirements, s.apiKey, s.model, undefined, s.pdfContext?.text);
+        const summary = await abstractNode(text, s.apiKey, s.model);
+        const afterGen = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+        const afterEntry = (afterGen ?? cur).chatHistory.find((e) => e.id === activeEntryId);
+        if (!afterEntry) return;
+        const updatedNodes = afterEntry.nodes.map((n) =>
+          n.ID === nodeId
+            ? { ...n, Title: summary.Title, Summary: summary.Summary, Keywords: summary.Keywords, Steps: summary.Steps, Result: text, Structure: summary.Structure, Dimension: { categorical, ordinal }, IsMyFav: false, imageUrl: undefined }
+            : n,
+        );
+        const updatedHistory = (afterGen ?? cur).chatHistory.map((e) => (e.id === activeEntryId ? { ...e, nodes: updatedNodes } : e));
+        updateState(appId, { ...(afterGen ?? cur), chatHistory: updatedHistory });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        toast({ title: 'Re-roll failed', description: msg, status: 'error', duration: 4000, isClosable: true });
+      } finally {
+        setRerollingNodeId(null);
+      }
+    },
+    [s, activeEntryId, rerollingNodeId, appId, updateState, toast],
+  );
+
+  const generateMore = useCallback(
+    async (entry: AppState['chatHistory'][number]) => {
+      const entryDims = entry.dimensions ?? [];
+      if (!user || isGenerating || entryDims.length === 0) return;
+      restoreSnapshot(entry);
+      const rawDims = {
+        categorical: Object.fromEntries(entryDims.filter((d) => d.type === 'categorical').map((d) => [d.name, d.values])),
+        ordinal: Object.fromEntries(entryDims.filter((d) => d.type === 'ordinal').map((d) => [d.name, d.values])),
+      };
+      setIsGenerating(true);
+      setLocalStatusMessage(`Generating ${s.batchSize} more ideas…`);
+      const latest = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+      updateState(appId, { ...(latest ?? s) });
+      try {
+        const newNodes: AppState['nodes'] = [];
+        const moreResults = await Promise.allSettled(
+          Array.from({ length: s.batchSize }, async () => {
+            const { requirements, categorical, ordinal } = buildRequirements(rawDims);
+            const text = await generateNodeContent(entry.prompt, requirements, s.apiKey, s.model, undefined, s.pdfContext?.text);
+            const summary = await abstractNode(text, s.apiKey, s.model);
+            return {
+              ID: genId(),
+              Title: summary.Title,
+              Summary: summary.Summary,
+              Keywords: summary.Keywords,
+              Steps: summary.Steps,
+              Result: text,
+              Structure: summary.Structure,
+              Dimension: { categorical, ordinal },
+              IsMyFav: false,
+            };
+          }),
+        );
+        for (const r of moreResults) {
+          if (r.status === 'fulfilled') newNodes.push(r.value);
+        }
+        if (newNodes.length === 0) throw new Error('All idea generations failed');
+        const afterGen = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+        const cur = afterGen ?? s;
+        const existingEntry = cur.chatHistory.find((e) => e.id === entry.id);
+        const combinedNodes = [...(existingEntry?.nodes ?? entry.nodes), ...newNodes];
+        const updatedHistory = cur.chatHistory.map((e) => (e.id === entry.id ? { ...e, nodes: combinedNodes } : e));
+        setIsGenerating(false);
+        setLocalStatusMessage('');
+        updateState(appId, { ...cur, status: 'ready', chatHistory: updatedHistory });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        toast({ title: 'Generation failed', description: msg, status: 'error', duration: 5000, isClosable: true });
+        setIsGenerating(false);
+        setLocalStatusMessage('');
+        const afterFail = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+        updateState(appId, { ...(afterFail ?? s), status: 'ready' });
+      }
+    },
+    [user, s, isGenerating, appId, restoreSnapshot, updateState, toast],
+  );
+
+  const generateAt = useCallback(
+    async ({ worldX, worldY, xDimName, xBlend, yDimName, yBlend }: {
+      worldX: number; worldY: number;
+      xDimName: string | null; xBlend: DimBlend | null;
+      yDimName: string | null; yBlend: DimBlend | null;
+    }) => {
+      if (!activeEntryId || localDims.length === 0) return;
+      setIsGeneratingAt(true);
+      try {
+        const { requirements, categorical, ordinal } = buildBlendedRequirements(localDims, xDimName, xBlend, yDimName, yBlend);
+        const text = await generateNodeContent(s.prompt, requirements, s.apiKey, s.model);
+        const summary = await abstractNode(text, s.apiKey, s.model);
+        const newNode: AppState['nodes'][number] = {
+          ID: genId(),
+          Title: summary.Title,
+          Summary: summary.Summary,
+          Keywords: summary.Keywords,
+          Steps: summary.Steps,
+          Result: text,
+          Structure: summary.Structure,
+          Dimension: { categorical, ordinal },
+          IsMyFav: false,
+        };
+        positionsRef.current.set(newNode.ID, { x: worldX, y: worldY });
+        const latest = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+        const cur = latest ?? s;
+        const updatedHistory = cur.chatHistory.map((e) => (e.id === activeEntryId ? { ...e, nodes: [...e.nodes, newNode] } : e));
+        updateState(appId, { ...cur, chatHistory: updatedHistory });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        toast({ title: 'Generation failed', description: msg, status: 'error', duration: 4000, isClosable: true });
+      } finally {
+        setIsGeneratingAt(false);
+      }
+    },
+    [s, localDims, activeEntryId, appId, updateState, toast],
+  );
+
+  const addManualIdea = useCallback(
+    async (text: string) => {
+      if (!activeEntryId) return;
+      setIsAddingManualIdea(true);
+      try {
+        const summary = await abstractNode(text, s.apiKey, s.model);
+        const rawDims = {
+          categorical: Object.fromEntries(localDims.filter((d) => d.type === 'categorical').map((d) => [d.name, d.values])),
+          ordinal: Object.fromEntries(localDims.filter((d) => d.type === 'ordinal').map((d) => [d.name, d.values])),
+        };
+        const { categorical, ordinal } = buildRequirements(rawDims);
+        const newNode: AppState['nodes'][number] = {
+          ID: genId(),
+          Title: summary.Title,
+          Summary: summary.Summary,
+          Keywords: summary.Keywords,
+          Steps: summary.Steps,
+          Result: text,
+          Structure: summary.Structure,
+          Dimension: { categorical, ordinal },
+          IsMyFav: false,
+        };
+        const latest = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+        const cur = latest ?? s;
+        const updatedHistory = cur.chatHistory.map((e) => (e.id === activeEntryId ? { ...e, nodes: [...e.nodes, newNode] } : e));
+        updateState(appId, { ...cur, chatHistory: updatedHistory });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        toast({ title: 'Failed to add idea', description: msg, status: 'error', duration: 4000, isClosable: true });
+      } finally {
+        setIsAddingManualIdea(false);
+      }
+    },
+    [s, localDims, activeEntryId, appId, updateState, toast],
+  );
+
+  const removeDimension = useCallback(
+    (dimName: string) => {
+      if (!activeEntryId) return;
+      const updatedDims = localDims.filter((d) => d.name !== dimName);
+      const updatedNodes = localNodes.map((n) => {
+        const categorical = { ...n.Dimension.categorical };
+        const ordinal = { ...n.Dimension.ordinal };
+        delete categorical[dimName];
+        delete ordinal[dimName];
+        return { ...n, Dimension: { categorical, ordinal } };
+      });
+      const updatedHistory = s.chatHistory.map((e) =>
+        e.id === activeEntryId ? { ...e, nodes: updatedNodes, dimensions: updatedDims } : e,
+      );
+      updateState(appId, { ...s, chatHistory: updatedHistory });
+    },
+    [s, localNodes, localDims, activeEntryId, appId, updateState],
+  );
+
+  const summarizeFavorites = useCallback(async () => {
+    const favNodes = localNodes.filter((n) => n.IsMyFav);
+    if (favNodes.length === 0 || isSummarizing) return;
+    setIsSummarizing(true);
+    try {
+      const summary = await summarizeFavoritesAPI(
+        favNodes.map((n) => ({ Title: n.Title, Summary: n.Summary, Keywords: n.Keywords })),
+        s.prompt,
+        s.apiKey,
+        s.model,
+      );
+      const header = `★ Favorites Summary\nTopic: ${s.prompt}\n\n`;
+      const footer = `\n\nFavorites: ${favNodes.map((n) => n.Title).join(', ')}`;
+      await createApp({
+        title: 'Favorites Summary',
+        roomId,
+        boardId,
+        position: { x: appPosition.x + appSize.width + 20, y: appPosition.y, z: 0 },
+        size: { width: 420, height: 520, depth: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        type: 'Stickie',
+        state: {
+          text: header + summary + footer,
+          fontSize: 18,
+          color: 'yellow',
+          lock: false,
+          sources: [appId],
+          executeInfo: { executeFunc: '', params: {} },
+        },
+        raised: true,
+        dragging: false,
+        pinned: false,
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast({ title: 'Summary failed', description: msg, status: 'error', duration: 4000, isClosable: true });
+    } finally {
+      setIsSummarizing(false);
+    }
+  }, [localNodes, s, isSummarizing, appId, boardId, roomId, appPosition, appSize, createApp, updateState, toast]);
+
+  const branchFromFavorites = useCallback(() => {
+    const favNodes = localNodes.filter((n) => n.IsMyFav);
+    if (favNodes.length === 0) return;
+    const ideasList = favNodes.map((n, i) => `${i + 1}. "${n.Title}": ${n.Summary}`).join('\n');
+    const aiPrompt = [
+      s.prompt ? `Original topic: ${s.prompt}` : '',
+      `\nThe following ideas were favorited from the previous exploration:\n${ideasList}`,
+      `\nNow generate new ideas that build on, combine, or extend the themes from these favorites. Explore adjacent variations that share their strengths.`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+    const displayPrompt = `Branch from ${favNodes.length} favorite${favNodes.length > 1 ? 's' : ''}: ${favNodes.map((n) => n.Title).join(', ')}`;
+    generate({ displayPrompt, aiPrompt, parentEntryId: activeEntryId ?? undefined });
+  }, [localNodes, s.prompt, activeEntryId, generate]);
+
+  return {
+    // Derived state
+    activeEntryId,
+    activeEntry,
+    localNodes,
+    localDims,
+    // Loading flags
+    isGenerating,
+    localStatusMessage,
+    askingNodeId,
+    isAddingDimension,
+    rerollingNodeId,
+    isGeneratingAt,
+    isAddingManualIdea,
+    isSummarizing,
+    // Refs for canvas
+    positionsRef,
+    hasFitRef,
+    // Actions
+    generate,
+    toggleFav,
+    clearAll,
+    deleteEntry,
+    restoreSnapshot,
+    branchFromNode,
+    askNodeQuestion,
+    addDimension,
+    rerollNode,
+    generateMore,
+    generateAt,
+    addManualIdea,
+    removeDimension,
+    summarizeFavorites,
+    branchFromFavorites,
+  };
+}

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/useImageGeneration.ts
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/useImageGeneration.ts
@@ -1,0 +1,233 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+import { useRef, useState, useCallback } from 'react';
+import { useToast } from '@chakra-ui/react';
+import { useAppStore, useLinkStore, apiUrls } from '@sage3/frontend';
+
+import { state as AppState } from './index';
+import { generateNodeImage } from './openai';
+
+type SageNode = AppState['nodes'][number];
+
+interface UseImageGenerationProps {
+  s: AppState;
+  localNodes: SageNode[];
+  activeEntryId: string | null;
+  appId: string;
+  boardId: string;
+  roomId: string;
+  appPosition: { x: number; y: number; z: number };
+}
+
+export function useImageGeneration({ s, localNodes, activeEntryId, appId, boardId, roomId, appPosition }: UseImageGenerationProps) {
+  const [generatingImageNodeId, setGeneratingImageNodeId] = useState<string | null>(null);
+  const imageAbortRef = useRef<AbortController | null>(null);
+
+  const updateState = useAppStore((state) => state.updateState);
+  const createApp = useAppStore((state) => state.create);
+  const addLink = useLinkStore((st) => st.addLink);
+  const toast = useToast();
+
+  const generateImageForNode = useCallback(
+    async (nodeId: string, context?: string, count = 1, presetLabel?: string, userContext?: string) => {
+      if (generatingImageNodeId || !activeEntryId) return;
+      const node = localNodes.find((n) => n.ID === nodeId);
+      if (!node) return;
+
+      const controller = new AbortController();
+      imageAbortRef.current = controller;
+      setGeneratingImageNodeId(nodeId);
+
+      try {
+        // ── 1. Find or create anchor Stickie ─────────────────────────────
+        const liveApps = useAppStore.getState().apps;
+        const existingStickieId = s.nodeStickies?.[nodeId];
+        let stickieApp = existingStickieId
+          ? liveApps.find((a) => a._id === existingStickieId) ?? null
+          : null;
+
+        if (!stickieApp) {
+          stickieApp = liveApps.find(
+            (a) =>
+              a.data.type === 'Stickie' &&
+              a.data.boardId === boardId &&
+              (a.data.state as { text?: string }).text?.startsWith(node.Title)
+          ) ?? null;
+        }
+
+        let stickieId: string;
+        let stickiePosition: { x: number; y: number; z: number };
+        let stickieSize: { width: number; height: number; depth: number };
+
+        if (stickieApp) {
+          stickieId = stickieApp._id;
+          stickiePosition = stickieApp.data.position;
+          stickieSize = stickieApp.data.size;
+        } else {
+          const stickieResult = await createApp({
+            title: node.Title,
+            roomId,
+            boardId,
+            position: { x: appPosition.x, y: appPosition.y - 260, z: 0 },
+            size: { width: 320, height: 200, depth: 0 },
+            rotation: { x: 0, y: 0, z: 0 },
+            type: 'Stickie',
+            state: {
+              text: `${node.Title}\n\n${node.Summary}`,
+              fontSize: 18,
+              color: 'purple',
+              lock: false,
+              sources: [appId],
+              executeInfo: { executeFunc: '', params: {} },
+            },
+            raised: true,
+            dragging: false,
+            pinned: false,
+          });
+          stickieId = stickieResult?.data?._id ?? '';
+          stickiePosition = { x: appPosition.x, y: appPosition.y - 260, z: 0 };
+          stickieSize = { width: 320, height: 200, depth: 0 };
+        }
+
+        // ── 2. Count existing visualizations to offset placement ──────────
+        const existingVizCount = liveApps.filter(
+          (a) =>
+            a.data.type === 'ImageViewer' &&
+            a.data.boardId === boardId &&
+            a.data.title.startsWith(node.Title)
+        ).length;
+
+        // ── 3. Generate all variations ────────────────────────
+        const safeTitle = node.Title.replace(/[^a-zA-Z0-9\s-]/g, '').trim().slice(0, 40);
+        const safePrompt = s.prompt.replace(/[^a-zA-Z0-9\s-]/g, '').trim().slice(0, 40);
+        const imgSize = 512;
+        const gap = 20;
+
+        const results = await Promise.allSettled(
+          Array.from({ length: count }, () =>
+            generateNodeImage(node.Title, node.Summary, node.Keywords, s.apiKey, s.prompt, node.Dimension, controller.signal, context)
+          )
+        );
+
+        // ── 4. Upload and place each successful result ────────────────────
+        let placedCount = 0;
+        let lastAssetId: string | null = null;
+
+        for (const result of results) {
+          if (result.status === 'rejected') {
+            const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
+            if (msg !== 'Cancelled') {
+              toast({ title: 'One variation failed', description: msg, status: 'warning', duration: 3000, isClosable: true });
+            }
+            continue;
+          }
+
+          const iteration = existingVizCount + placedCount + 1;
+          const blob = await fetch(result.value).then((r) => r.blob());
+          const imgFile = new File([blob], `${safeTitle} v${iteration} - ${safePrompt}.png`, { type: 'image/png' });
+          const fd = new FormData();
+          fd.append('files', imgFile);
+          fd.append('room', roomId);
+          const uploadRes = await fetch(apiUrls.assets.upload, { method: 'POST', body: fd, credentials: 'include' });
+          if (!uploadRes.ok) {
+            toast({ title: 'Upload failed', status: 'warning', duration: 3000, isClosable: true });
+            continue;
+          }
+          const uploadedIds = await uploadRes.json() as string[];
+          const assetDbId = uploadedIds[0];
+          if (!assetDbId) continue;
+          lastAssetId = assetDbId;
+
+          // Build ImageViewer title
+          const titleParts = [`${node.Title} v${iteration}`];
+          if (presetLabel) titleParts.push(presetLabel);
+          if (userContext) titleParts.push(`"${userContext.slice(0, 30)}"`);
+          const imageTitle = `${titleParts.join(' · ')} — ${s.prompt}`.slice(0, 100);
+
+          const imgX = stickiePosition.x + stickieSize.width + gap + (existingVizCount + placedCount) * (imgSize + gap);
+
+          const imageResult = await createApp({
+            title: imageTitle,
+            roomId,
+            boardId,
+            position: { x: imgX, y: stickiePosition.y, z: 0 },
+            size: { width: imgSize, height: imgSize, depth: 0 },
+            rotation: { x: 0, y: 0, z: 0 },
+            type: 'ImageViewer',
+            state: { assetid: assetDbId },
+            raised: true,
+            dragging: false,
+            pinned: false,
+          });
+
+          const imageViewerId = imageResult?.data?._id;
+
+          // ── Create  Stickie and link ──
+          const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+          const provenanceLines = [`Iteration: v${iteration}`, `Prompt: ${s.prompt}`];
+          if (presetLabel) provenanceLines.push(`Style: ${presetLabel}`);
+          if (userContext) provenanceLines.push(`Context: "${userContext}"`);
+          provenanceLines.push(`Generated: ${time}`);
+
+          const provenanceResult = await createApp({
+            title: `${node.Title} v${iteration} — provenance`,
+            roomId,
+            boardId,
+            position: { x: imgX, y: stickiePosition.y + imgSize + gap, z: 0 },
+            size: { width: imgSize, height: 160, depth: 0 },
+            rotation: { x: 0, y: 0, z: 0 },
+            type: 'Stickie',
+            state: {
+              text: provenanceLines.join('\n'),
+              fontSize: 16,
+              color: 'yellow',
+              lock: false,
+              sources: [],
+              executeInfo: { executeFunc: '', params: {} },
+            },
+            raised: true,
+            dragging: false,
+            pinned: false,
+          });
+
+          const provenanceId = provenanceResult?.data?._id;
+          if (stickieId && provenanceId) addLink(stickieId, provenanceId, boardId, 'provenance');
+          if (provenanceId && imageViewerId) addLink(provenanceId, imageViewerId, boardId, 'provenance');
+
+          placedCount++;
+        }
+
+        // ── 5. Persist stickie + most recent asset ID in state ────────────
+        if (placedCount > 0 && lastAssetId) {
+          updateState(appId, {
+            nodeImages: { ...(s.nodeImages ?? {}), [nodeId]: lastAssetId },
+            nodeStickies: { ...(s.nodeStickies ?? {}), [nodeId]: stickieId },
+          });
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg !== 'Cancelled') {
+          toast({ title: 'Visualization failed', description: msg, status: 'error', duration: 4000, isClosable: true });
+        }
+      } finally {
+        imageAbortRef.current = null;
+        setGeneratingImageNodeId(null);
+      }
+    },
+    [s, localNodes, activeEntryId, generatingImageNodeId, appId, boardId, roomId, appPosition, createApp, addLink, updateState, toast]
+  );
+
+  const cancelImageGeneration = useCallback(() => {
+    imageAbortRef.current?.abort();
+    imageAbortRef.current = null;
+    setGeneratingImageNodeId(null);
+  }, []);
+
+  return { generateImageForNode, cancelImageGeneration, generatingImageNodeId };
+}

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/useStickyImport.ts
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/useStickyImport.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+import { useRef, useState, useEffect, useCallback } from 'react';
+import { useToast } from '@chakra-ui/react';
+import { useAppStore } from '@sage3/frontend';
+import { genId } from '@sage3/shared';
+
+import { state as AppState } from './index';
+import { abstractNode, buildRequirements } from './openai';
+import { ImportPreview } from './StickyImportDialog';
+
+type SageDimension = AppState['dimensions'][number];
+
+export interface PendingImport {
+  stickieId: string;
+  text: string;
+  originalPosition: { x: number; y: number; z: number };
+  preview: ImportPreview | null;
+  isLoading: boolean;
+  temperature: number;
+}
+
+interface UseStickyImportProps {
+  s: AppState;
+  localDims: SageDimension[];
+  activeEntryId: string | null;
+  appId: string;
+  appPosition: { x: number; y: number; z: number };
+  appSize: { width: number; height: number; depth: number };
+}
+
+export function useStickyImport({ s, localDims, activeEntryId, appId, appPosition, appSize }: UseStickyImportProps) {
+  const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
+  const prevPositionsRef = useRef<Record<string, { x: number; y: number }>>({});
+  const importingRef = useRef(false);
+
+  const boardApps = useAppStore((st) => st.apps);
+  const updateApp = useAppStore((st) => st.update);
+  const updateState = useAppStore((st) => st.updateState);
+  const toast = useToast();
+
+  // Detect when a Stickie's position changes from outside to inside the ideator bounds.
+  // App dragging in SAGE3 is local-only during the drag; the store position only updates
+  // when the drag ends and the server confirms, so position changes == drag-end events.
+  useEffect(() => {
+    const stickies = boardApps.filter((a) => a.data.type === 'Stickie');
+
+    for (const stickie of stickies) {
+      const prev = prevPositionsRef.current[stickie._id];
+      const curr = stickie.data.position;
+
+      if (prev && !importingRef.current) {
+        const { width: sw, height: sh } = stickie.data.size;
+        const wasInside =
+          prev.x < appPosition.x + appSize.width &&
+          prev.x + sw > appPosition.x &&
+          prev.y < appPosition.y + appSize.height &&
+          prev.y + sh > appPosition.y;
+        const isInside =
+          curr.x < appPosition.x + appSize.width &&
+          curr.x + sw > appPosition.x &&
+          curr.y < appPosition.y + appSize.height &&
+          curr.y + sh > appPosition.y;
+
+        if (!wasInside && isInside) {
+          const originalPosition = { x: prev.x, y: prev.y, z: curr.z };
+          const text = ((stickie.data.state as { text: string }).text ?? '').trim();
+
+          if (!activeEntryId || localDims.length === 0) {
+            toast({ title: 'No idea space yet', description: 'Generate ideas first, then import a Stickie.', status: 'warning', duration: 3000, isClosable: true });
+          } else if (text) {
+            importingRef.current = true;
+            updateApp(stickie._id, { position: { x: appPosition.x + appSize.width + 20, y: appPosition.y, z: curr.z } });
+            setPendingImport({ stickieId: stickie._id, text, originalPosition, preview: null, isLoading: true, temperature: 0 });
+          }
+        }
+      }
+
+      prevPositionsRef.current[stickie._id] = { x: curr.x, y: curr.y };
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardApps]);
+
+  // Run abstractNode whenever a new import preview is needed (initial drop or "Try Again")
+  useEffect(() => {
+    if (!pendingImport?.isLoading) return;
+    const { text, stickieId, originalPosition } = pendingImport;
+    let active = true;
+    abstractNode(text, s.apiKey, s.model, pendingImport.temperature)
+      .then((preview) => {
+        if (active) setPendingImport((prev) => (prev ? { ...prev, preview, isLoading: false } : null));
+      })
+      .catch(() => {
+        if (active) {
+          updateApp(stickieId, { position: originalPosition });
+          setPendingImport(null);
+          importingRef.current = false;
+          toast({ title: 'Preview failed', status: 'error', duration: 3000, isClosable: true });
+        }
+      });
+    return () => { active = false; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingImport?.isLoading]);
+
+  const handleImportConfirm = useCallback(() => {
+    if (!pendingImport?.preview || !activeEntryId) return;
+    const { preview, text } = pendingImport;
+    const rawDims = {
+      categorical: Object.fromEntries(localDims.filter((d) => d.type === 'categorical').map((d) => [d.name, d.values])),
+      ordinal: Object.fromEntries(localDims.filter((d) => d.type === 'ordinal').map((d) => [d.name, d.values])),
+    };
+    const { categorical, ordinal } = buildRequirements(rawDims);
+    const newNode: AppState['nodes'][number] = {
+      ID: genId(),
+      Title: preview.Title,
+      Summary: preview.Summary,
+      Keywords: preview.Keywords,
+      Steps: preview.Steps,
+      Result: text,
+      Structure: preview.Structure,
+      Dimension: { categorical, ordinal },
+      IsMyFav: false,
+    };
+    const latest = useAppStore.getState().apps.find((a) => a._id === appId)?.data.state as AppState | undefined;
+    const cur = latest ?? s;
+    const updatedHistory = cur.chatHistory.map((e) => (e.id === activeEntryId ? { ...e, nodes: [...e.nodes, newNode] } : e));
+    updateState(appId, { ...cur, chatHistory: updatedHistory });
+    setPendingImport(null);
+    importingRef.current = false;
+  }, [pendingImport, activeEntryId, localDims, s, appId, updateState]);
+
+  const handleImportCancel = useCallback(() => {
+    if (!pendingImport) return;
+    updateApp(pendingImport.stickieId, { position: pendingImport.originalPosition });
+    setPendingImport(null);
+    importingRef.current = false;
+  }, [pendingImport, updateApp]);
+
+  const handleImportRegenerate = useCallback(() => {
+    if (!pendingImport) return;
+    setPendingImport((prev) => (prev ? { ...prev, preview: null, isLoading: true, temperature: 0.7 } : null));
+  }, [pendingImport]);
+
+  return { pendingImport, handleImportConfirm, handleImportCancel, handleImportRegenerate };
+}

--- a/webstack/libs/frontend/src/lib/api/seer.ts
+++ b/webstack/libs/frontend/src/lib/api/seer.ts
@@ -45,10 +45,13 @@ import {
 const AGENT_TIMEOUT_MS = 120 * 1000;
 const IDEATOR_TIMEOUT_MS = 60 * 1000;
 
-async function agentPost<T>(path: string, data: object, timeoutMs = AGENT_TIMEOUT_MS): Promise<T | SError> {
+async function agentPost<T>(path: string, data: object, timeoutMs = AGENT_TIMEOUT_MS, signal?: AbortSignal): Promise<T | SError> {
   try {
-    return await ky.post<T>(path, { json: data, timeout: timeoutMs }).json();
+    return await ky.post<T>(path, { json: data, timeout: timeoutMs, signal }).json();
   } catch (e) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      return { message: 'Cancelled' };
+    }
     const error = e as HTTPError<Response>;
     if (error.name === 'HTTPError') {
       const err: SError = await error.response.json();
@@ -125,11 +128,12 @@ export const seerIdeator = {
       data,
       IDEATOR_TIMEOUT_MS
     ),
-  image: (data: IdeatorImageRequest) =>
+  image: (data: IdeatorImageRequest, signal?: AbortSignal) =>
     agentPost<IdeatorImageResponse>(
       `${apiUrls.ai.ideator.base}${IdeatorRoutes.image}`,
       data,
-      IDEATOR_TIMEOUT_MS
+      IDEATOR_TIMEOUT_MS,
+      signal,
     ),
   prose: (data: IdeatorProseRequest) =>
     agentPost<IdeatorProseResponse>(

--- a/webstack/libs/shared/src/lib/ai/ideator-api.ts
+++ b/webstack/libs/shared/src/lib/ai/ideator-api.ts
@@ -81,6 +81,7 @@ export type IdeatorImageRequest = {
   model: string;
   brainstormingPrompt?: string;
   dimension?: { categorical: Record<string, string>; ordinal: Record<string, string> };
+  additionalContext?: string;
 };
 
 export type IdeatorImageResponse = {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

No relevant issues

### What is in this change?

- `useImageGeneration.ts` contains the logic for the visualization feature within the Ideator application. gpt-image is the model chosen to perform image generation, and the ImageViewer app is used to show generated images. Visualizations are accompanied by a Sticky including details of the visualization.
- `useIdeation.ts` and `useStickyImport.ts` have been extracted from the `SageIdeator.tsx` component as part of a refactor to make the code more readable. `useIdeation.ts`, `useStickyImports.ts` and `useImageGeneration.ts` have distinct concerns, and made sense to me to pull out.
- When pdfs were added as context to a prompt, a pill is created containing the title of the document. Clicking Generate failed to clear it. The corresponding state update function was fixed.


### Additional Information

I made some minor changes to the UI and added a word count cap to Q&A answers to prevent very long text outputs

### Developer Validations

- [x] I have tested my code functionality
- [x] I removed console.log and print statements
