### PR TITLE
SSRF protection for user-provided URLs (CodeQL alerts #14, #49)

### DIFF
--- a/seer/app/image.py
+++ b/seer/app/image.py
@@ -14,7 +14,7 @@ import httpx
 
 # Image
 from io import BytesIO
-import base64, requests
+import base64
 from typing import List
 
 # SAGE3 API
@@ -34,6 +34,7 @@ from libs.utils import (
     scaleImage,
     isURL,
     isDataURL,
+    fetch_public_image,
     parse_openai_error,
 )
 
@@ -126,9 +127,12 @@ class ImageAgent:
             # Load an image from a base64 encoded data URL
             imageContent = BytesIO(base64.b64decode(qq.asset.split(",")[1])).getbuffer()
         elif isURL(qq.asset):
-            # Fetch and load an image from a URL
-            response = requests.get(qq.asset)
-            imageContent = BytesIO(response.content).getbuffer()
+            # Fetch and load an image from a URL, refusing private/internal addresses
+            try:
+                imageContent = BytesIO(fetch_public_image(qq.asset)).getbuffer()
+            except ValueError as e:
+                self.logger.error(f"Refused or failed to fetch image URL: {e}")
+                imageContent = None
         else:
             # Retrieve the image content from SAGE3
             imageContent = getImageFile(self.ps3, qq.asset)

--- a/seer/libs/utils.py
+++ b/seer/libs/utils.py
@@ -12,6 +12,8 @@ import json
 from PIL import Image
 from io import BytesIO
 import re, time, os, base64
+import ipaddress, socket, requests
+from urllib.parse import urlparse
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -417,6 +419,93 @@ def isURL(string):
         r"(:\d+)?(/.*)?$"  # Optional port and path
     )
     return bool(url_pattern.match(string))
+
+
+# Limits for fetching user-provided image URLs
+FETCH_TIMEOUT = 10  # seconds
+FETCH_MAX_BYTES = 20 * 1024 * 1024  # 20 MB
+FETCH_MAX_REDIRECTS = 3
+
+
+def assertPublicHost(url):
+    """
+    Raise ValueError unless every address the URL's hostname resolves to is public.
+
+    Blocks loopback, private (RFC 1918), link-local, multicast, and reserved
+    ranges so a user-provided URL cannot reach internal services (SSRF).
+
+    Args:
+      url (str): The URL to check.
+
+    Returns:
+      The parsed URL (urllib.parse.ParseResult).
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Unsupported URL scheme: {parsed.scheme}")
+    if not parsed.hostname:
+        raise ValueError("URL has no hostname")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        infos = socket.getaddrinfo(parsed.hostname, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise ValueError(f"Cannot resolve host: {parsed.hostname}")
+    # Every resolved address must be public, not just the first one
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global or ip.is_multicast:
+            raise ValueError(f"URL resolves to a non-public address: {ip}")
+    return parsed
+
+
+def fetch_public_image(url):
+    """
+    Fetch an image from a user-provided URL, refusing non-public destinations.
+
+    Redirects are followed manually and each hop is re-validated with
+    assertPublicHost. The download is bounded by FETCH_TIMEOUT and
+    FETCH_MAX_BYTES, and the response must be an image.
+
+    Note: the address check happens before the request (resolve-then-fetch),
+    so a hostile DNS server flipping records between the two lookups is a
+    residual risk; network egress rules are the backstop for that.
+
+    Args:
+      url (str): The http(s) URL of the image.
+
+    Returns:
+      bytes: The raw image content.
+
+    Raises:
+      ValueError: If the URL is unsafe, unreachable, redirects too many
+        times, is too large, or does not contain an image.
+    """
+    for _ in range(FETCH_MAX_REDIRECTS + 1):
+        assertPublicHost(url)
+        try:
+            response = requests.get(
+                url, timeout=FETCH_TIMEOUT, allow_redirects=False, stream=True
+            )
+        except requests.RequestException as e:
+            raise ValueError(f"Failed to fetch URL: {e}")
+        if response.is_redirect or response.is_permanent_redirect:
+            location = response.headers.get("Location")
+            if not location:
+                raise ValueError("Redirect without a Location header")
+            url = requests.compat.urljoin(url, location)
+            continue
+        if response.status_code != 200:
+            raise ValueError(f"Fetch failed with status {response.status_code}")
+        content_type = response.headers.get("Content-Type", "").split(";")[0].strip()
+        if not (content_type.startswith("image/") or content_type == "application/octet-stream"):
+            raise ValueError(f"Not an image: {content_type}")
+        data = BytesIO()
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            data.write(chunk)
+            if data.tell() > FETCH_MAX_BYTES:
+                raise ValueError("Image too large")
+        return data.getvalue()
+    raise ValueError("Too many redirects")
 
 
 def getImageFile(ps3, assetid):

--- a/webstack/apps/homebase-files/src/api/fetch-public.ts
+++ b/webstack/apps/homebase-files/src/api/fetch-public.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2025. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+/**
+ * Fetch user-provided URLs while refusing non-public destinations (SSRF protection).
+ * @file Safe fetch of user-provided URLs
+ * @version 1.0.0
+ */
+
+// Node modules
+import * as dns from 'node:dns/promises';
+import * as net from 'node:net';
+
+// Limits for fetching user-provided URLs
+const FETCH_TIMEOUT = 10 * 1000; // ms, time to response headers, per redirect hop
+const MAX_REDIRECTS = 3;
+
+// Address ranges a user-provided URL must never reach
+const blockedRanges = new net.BlockList();
+// IPv4: "this network", private (RFC 1918), CGNAT, loopback, link-local, benchmarking, multicast and reserved
+blockedRanges.addSubnet('0.0.0.0', 8);
+blockedRanges.addSubnet('10.0.0.0', 8);
+blockedRanges.addSubnet('100.64.0.0', 10);
+blockedRanges.addSubnet('127.0.0.0', 8);
+blockedRanges.addSubnet('169.254.0.0', 16);
+blockedRanges.addSubnet('172.16.0.0', 12);
+blockedRanges.addSubnet('192.168.0.0', 16);
+blockedRanges.addSubnet('198.18.0.0', 15);
+blockedRanges.addSubnet('224.0.0.0', 3);
+// IPv6: unspecified + loopback, unique-local, link-local, multicast
+blockedRanges.addSubnet('::', 127, 'ipv6');
+blockedRanges.addSubnet('fc00::', 7, 'ipv6');
+blockedRanges.addSubnet('fe80::', 10, 'ipv6');
+blockedRanges.addSubnet('ff00::', 8, 'ipv6');
+
+function isBlockedAddress(address: string, family: number): boolean {
+  if (family === 6) {
+    // An IPv4-mapped IPv6 address reaches the embedded IPv4 target — check that instead
+    const mapped = address.toLowerCase().match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped) return blockedRanges.check(mapped[1], 'ipv4');
+    return blockedRanges.check(address, 'ipv6');
+  }
+  return blockedRanges.check(address, 'ipv4');
+}
+
+/**
+ * Throw unless every address the URL's hostname resolves to is public.
+ *
+ * Blocks loopback, private, link-local, multicast, and reserved ranges so a
+ * user-provided URL cannot reach internal services.
+ *
+ * @param {string} url the URL to check
+ * @returns {Promise<URL>} the parsed URL
+ */
+export async function assertPublicHost(url: string): Promise<URL> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Malformed URL: ${url}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Unsupported URL scheme: ${parsed.protocol}`);
+  }
+  // The hostname of an IPv6 literal is bracketed in WHATWG URLs
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+  let addresses;
+  try {
+    addresses = await dns.lookup(hostname, { all: true });
+  } catch {
+    throw new Error(`Cannot resolve host: ${hostname}`);
+  }
+  if (addresses.length === 0) throw new Error(`Cannot resolve host: ${hostname}`);
+  // Every resolved address must be public, not just the first one
+  for (const { address, family } of addresses) {
+    if (isBlockedAddress(address, family)) {
+      throw new Error(`URL resolves to a non-public address: ${address}`);
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Fetch a user-provided URL, refusing non-public destinations.
+ *
+ * Redirects are followed manually and each hop is re-validated with
+ * assertPublicHost. Each hop must return response headers within
+ * FETCH_TIMEOUT; the body stream itself is not time-bounded.
+ *
+ * Note: the address check happens before the request (resolve-then-fetch),
+ * so a hostile DNS server flipping records between the two lookups is a
+ * residual risk; network egress rules are the backstop for that.
+ *
+ * @param {string} url the http(s) URL to fetch
+ * @returns {Promise<Response>} the (non-redirect) fetch response
+ */
+export async function fetchPublicURL(url: string): Promise<Response> {
+  let current = url;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    await assertPublicHost(current);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+    let response: Response;
+    try {
+      response = await fetch(current, { redirect: 'manual', signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) throw new Error('Redirect without a Location header');
+      await response.body?.cancel();
+      current = new URL(location, current).toString();
+      continue;
+    }
+    return response;
+  }
+  throw new Error('Too many redirects');
+}

--- a/webstack/apps/homebase-files/src/api/files.ts
+++ b/webstack/apps/homebase-files/src/api/files.ts
@@ -24,6 +24,8 @@ import { Readable } from 'node:stream';
 import { config } from '../config';
 // Asset model
 import { AssetsCollection } from './assetsCollection';
+// SSRF-safe fetch of user-provided URLs
+import { fetchPublicURL } from './fetch-public';
 
 /**
  * App route/api express middleware.
@@ -38,7 +40,8 @@ export function FilesRouter(): express.Router {
     const fileUrl = params.url as string;
     if (!fileUrl) return res.status(400).send('Missing URL');
     try {
-      const response = await fetch(fileUrl);
+      // Fetch the URL, refusing private/internal addresses
+      const response = await fetchPublicURL(fileUrl);
       if (!response.ok) throw new Error(`Fetch failed: ${response.status}`);
       const body = response.body;
       if (!body) return res.status(500).send('No content returned');
@@ -48,7 +51,8 @@ export function FilesRouter(): express.Router {
       res.setHeader('Content-Type', response.headers.get('content-type') || 'application/octet-stream');
       // set the content disposition to attachment to prompt download with the original filename
       // or 'download' if the filename cannot be determined from the URL
-      res.setHeader('Content-Disposition', `attachment; filename="${decodeURIComponent(fileUrl.split('/').pop() || 'download')}"`);
+      const filename = decodeURIComponent(fileUrl.split('/').pop() || 'download').replace(/["\\\r\n]/g, '');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename || 'download'}"`);
 
       // Convert from Web stream -> Node stream
       const nodeStream = Readable.fromWeb(body as any);


### PR DESCRIPTION
## Summary

Fixes the two critical CodeQL alerts by hardening the two places that fetch user-provided URLs server-side:

- **Alert #14** (`py/full-ssrf`) — `seer/app/image.py`: the image agent fetched `qq.asset` with a bare `requests.get()`. The `isURL()` check only validated the string's shape, not the destination, so any user could make seer reach internal services (redis, cloud metadata at 169.254.169.254, other containers).
- **Alert #49** (`js/request-forgery`) — `apps/homebase-files/src/api/files.ts`: the `/api/files/download/:url` proxy fetched any client-supplied URL, same exposure.

## Changes

- New `fetch_public_image()` + `assertPublicHost()` in `seer/libs/utils.py`: resolves the hostname and refuses any non-public address (loopback, RFC 1918, link-local, multicast, reserved), follows redirects manually re-validating each hop, 10 s timeout, 20 MB cap, image content type required. A refused fetch falls into the existing "Failed to get image." path instead of crashing the handler.
- New `fetchPublicURL()` + `assertPublicHost()` in `apps/homebase-files/src/api/fetch-public.ts`: same address policy (via `net.BlockList`, including IPv4-mapped IPv6), manual redirect re-validation, 10 s time-to-headers per hop. No content-type/size restriction since the proxy streams arbitrary files to the client.
- The download proxy's `Content-Disposition` filename is now sanitized (`"`, `\`, CR/LF stripped) so a crafted URL can't break out of the quoted header value.

External URL fetching stays functional — it is a real feature (ImageViewer accepts raw URLs as `assetid`), so the fix is validation, not removal.

Residual risk, documented in both helpers: the address check is resolve-then-fetch, so DNS rebinding between the two lookups remains theoretically possible; network egress rules are the backstop.

## Testing

- Both helpers exercised live: blocked `127.0.0.1`, `localhost`, `169.254.169.254`, `10.x`, `172.20.x`, `192.168.x`, `[::1]`, `[::ffff:127.0.0.1]`, `0.0.0.0`, `ftp://`, malformed URLs; fetched a real public PNG; and a public URL 302-redirecting to `http://127.0.0.1/secret` was blocked mid-chain.
- `tsc --noEmit -p apps/homebase-files/tsconfig.app.json` passes.
- `py_compile` passes on `seer/libs/utils.py`.

Note: CodeQL may not recognize the custom validators as sanitizers, so the alerts might stay open after merge — if so, dismiss them with a pointer to these helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)