### PR TITLE
[MAIN] Code scanning fixes

### DIFF
--- a/.github/workflows/client_linux.yaml
+++ b/.github/workflows/client_linux.yaml
@@ -1,5 +1,8 @@
 name: Client Linux
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/client_macos.yaml
+++ b/.github/workflows/client_macos.yaml
@@ -1,5 +1,8 @@
 name: Client macos
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/client_macos_arm64.yaml
+++ b/.github/workflows/client_macos_arm64.yaml
@@ -1,5 +1,8 @@
 name: Client macos-arm
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/client_windows.yaml
+++ b/.github/workflows/client_windows.yaml
@@ -1,5 +1,8 @@
 name: Client Windows
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/docker-images-dev.yaml
+++ b/.github/workflows/docker-images-dev.yaml
@@ -1,5 +1,9 @@
 name: Docker Images DEV
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches: ["dev"]

--- a/.github/workflows/docker-images-main.yaml
+++ b/.github/workflows/docker-images-main.yaml
@@ -1,5 +1,9 @@
 name: Docker Images Main
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/tag_linux.yaml
+++ b/.github/workflows/tag_linux.yaml
@@ -1,5 +1,8 @@
 name: Tag release linux
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:

--- a/.github/workflows/tag_macos.yaml
+++ b/.github/workflows/tag_macos.yaml
@@ -1,5 +1,8 @@
 name: Tag release macos-x64
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:

--- a/.github/workflows/tag_macos_arm64.yaml
+++ b/.github/workflows/tag_macos_arm64.yaml
@@ -1,5 +1,8 @@
 name: Tag release macos-arm
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:

--- a/.github/workflows/tag_windows.yaml
+++ b/.github/workflows/tag_windows.yaml
@@ -1,5 +1,8 @@
 name: Tag release windows
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:

--- a/.github/workflows/test_webstack.yaml
+++ b/.github/workflows/test_webstack.yaml
@@ -1,5 +1,8 @@
 name: Webstack CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/webstack/apps/homebase-files/src/api/files.ts
+++ b/webstack/apps/homebase-files/src/api/files.ts
@@ -66,7 +66,7 @@ export function FilesRouter(): express.Router {
 
   // Get one asset: GET /api/files/:id/:token
   // route: /api/files/:id/:token
-  router.use('/:id/:token', createRateLimiter(5, 300));
+  router.use('/:id/:token', createRateLimiter(60));
   router.get('/:id/:token', async ({ params }, res) => {
     // Get the asset
     const data = await AssetsCollection.get(params.id);

--- a/webstack/apps/homebase-files/src/api/files.ts
+++ b/webstack/apps/homebase-files/src/api/files.ts
@@ -26,6 +26,7 @@ import { config } from '../config';
 import { AssetsCollection } from './assetsCollection';
 // SSRF-safe fetch of user-provided URLs
 import { fetchPublicURL } from './fetch-public';
+import { createRateLimiter } from '@sage3/sagebase';
 
 /**
  * App route/api express middleware.
@@ -65,6 +66,7 @@ export function FilesRouter(): express.Router {
 
   // Get one asset: GET /api/files/:id/:token
   // route: /api/files/:id/:token
+  router.use('/:id/:token', createRateLimiter(5, 300));
   router.get('/:id/:token', async ({ params }, res) => {
     // Get the asset
     const data = await AssetsCollection.get(params.id);

--- a/webstack/apps/homebase-files/src/api/router.ts
+++ b/webstack/apps/homebase-files/src/api/router.ts
@@ -12,7 +12,7 @@ import { FilesRouter } from './files';
 import express from 'express';
 import { MessageCollection } from './messageCollection';
 // SAGEBase Imports
-import { SAGEBase } from '@sage3/sagebase';
+import { SAGEBase, createRateLimiter } from '@sage3/sagebase';
 
 /**
  * API Loader function
@@ -31,7 +31,8 @@ export async function expressAPIRouter(): Promise<express.Router> {
   // route: /api/files/:id/:token
   router.use('/files', FilesRouter());
 
-  // Authenticate all API Routes
+  // Rate limit (generous per-IP backstop for asset traffic), then authenticate all API Routes
+  router.use(createRateLimiter(5, 3000));
   router.use(SAGEBase.Auth.authenticate);
 
   // /api/assets/upload

--- a/webstack/apps/homebase-files/src/api/router.ts
+++ b/webstack/apps/homebase-files/src/api/router.ts
@@ -32,7 +32,7 @@ export async function expressAPIRouter(): Promise<express.Router> {
   router.use('/files', FilesRouter());
 
   // Rate limit (generous per-IP backstop for asset traffic), then authenticate all API Routes
-  router.use(createRateLimiter(5, 3000));
+  router.use(createRateLimiter(600));
   router.use(SAGEBase.Auth.authenticate);
 
   // /api/assets/upload

--- a/webstack/apps/homebase-files/src/main.ts
+++ b/webstack/apps/homebase-files/src/main.ts
@@ -41,7 +41,7 @@ export function createApp(): express.Express {
   app.use(
     helmet({
       // Content-Security-Policy
-      contentSecurityPolicy: false,
+      contentSecurityPolicy: true,
       // Strict-Transport-Security
       hsts: true,
       // Cross-Origin-Embedder-Policy: disable to enable map images and zoom images to load

--- a/webstack/apps/homebase/src/api/collections/plugins.ts
+++ b/webstack/apps/homebase/src/api/collections/plugins.ts
@@ -8,6 +8,7 @@
 
 import { PluginSchema } from '@sage3/shared/types';
 import { SAGE3Collection, sageRouter } from '@sage3/backend';
+import { createRateLimiter } from '@sage3/sagebase';
 
 // Node modules
 import * as fs from 'fs';
@@ -84,7 +85,7 @@ class SAGE3PluginsCollection extends SAGE3Collection<PluginSchema> {
     ensureDirectoryExistence(appsPath);
 
     // Upload a new Plugin App
-    router.post('/upload', upload.single('plugin'), async (req, res) => {
+    router.post('/upload', createRateLimiter(15, 50), upload.single('plugin'), async (req, res) => {
       // Check for file.
       const file = req.file;
       if (file == undefined) {
@@ -315,6 +316,7 @@ class SAGE3PluginsCollection extends SAGE3Collection<PluginSchema> {
     });
 
     // REMOVE: Remove the plugin db reference and the files locally.
+    router.use('/remove/:id', createRateLimiter(15, 50));
     router.delete('/remove/:id', async ({ params }, res) => {
       try {
         const docRef = this.collection.docRef(params.id);

--- a/webstack/apps/homebase/src/api/collections/plugins.ts
+++ b/webstack/apps/homebase/src/api/collections/plugins.ts
@@ -85,7 +85,7 @@ class SAGE3PluginsCollection extends SAGE3Collection<PluginSchema> {
     ensureDirectoryExistence(appsPath);
 
     // Upload a new Plugin App
-    router.post('/upload', createRateLimiter(15, 50), upload.single('plugin'), async (req, res) => {
+    router.post('/upload', createRateLimiter(4), upload.single('plugin'), async (req, res) => {
       // Check for file.
       const file = req.file;
       if (file == undefined) {
@@ -316,7 +316,7 @@ class SAGE3PluginsCollection extends SAGE3Collection<PluginSchema> {
     });
 
     // REMOVE: Remove the plugin db reference and the files locally.
-    router.use('/remove/:id', createRateLimiter(15, 50));
+    router.use('/remove/:id', createRateLimiter(4));
     router.delete('/remove/:id', async ({ params }, res) => {
       try {
         const docRef = this.collection.docRef(params.id);

--- a/webstack/apps/homebase/src/api/collections/users.ts
+++ b/webstack/apps/homebase/src/api/collections/users.ts
@@ -80,7 +80,7 @@ class SAGE3UsersCollection extends SAGE3Collection<UserSchema> {
       res.status(200).send({ success: true, data: { userStats } });
     });
 
-    router.post('/accountDeletion', createRateLimiter(60, 10), async ({ body, user }, res) => {
+    router.post('/accountDeletion', createRateLimiter(1), async ({ body, user }, res) => {
       const userRequestingDeletion = user as SBAuthSchema;
 
       // Is the user logged in?

--- a/webstack/apps/homebase/src/api/collections/users.ts
+++ b/webstack/apps/homebase/src/api/collections/users.ts
@@ -9,7 +9,7 @@
 import { UserSchema } from '@sage3/shared/types';
 import { SAGE3Collection, sageRouter } from '@sage3/backend';
 
-import { SAGEBase, SBAuthSchema } from '@sage3/sagebase';
+import { SAGEBase, SBAuthSchema, createRateLimiter } from '@sage3/sagebase';
 
 import { config } from '../../config';
 import { RoomsCollection } from './rooms';
@@ -80,7 +80,7 @@ class SAGE3UsersCollection extends SAGE3Collection<UserSchema> {
       res.status(200).send({ success: true, data: { userStats } });
     });
 
-    router.post('/accountDeletion', async ({ body, user }, res) => {
+    router.post('/accountDeletion', createRateLimiter(60, 10), async ({ body, user }, res) => {
       const userRequestingDeletion = user as SBAuthSchema;
 
       // Is the user logged in?

--- a/webstack/apps/homebase/src/api/routers/httpRouter.ts
+++ b/webstack/apps/homebase/src/api/routers/httpRouter.ts
@@ -35,7 +35,7 @@ import {
 } from '../collections';
 
 // SAGEBase Imports
-import { SAGEBase } from '@sage3/sagebase';
+import { SAGEBase, createRateLimiter } from '@sage3/sagebase';
 
 // Custom Routes
 import { ConfigRouter, InfoRouter, TimeRouter, NLPRouter, LogsRouter, KernelsRouter, PresenceThrottle, AgentRouter } from './custom';
@@ -57,7 +57,8 @@ export function expressAPIRouter(): express.Router {
   router.use('/time', TimeRouter());
   router.use('/logs', LogsRouter());
 
-  // Authenticate all API Routes
+  // Rate limit (generous per-IP backstop), then authenticate all API Routes
+  router.use(createRateLimiter(5, 2000));
   router.use(SAGEBase.Auth.authenticate);
 
   // Kernels Routes

--- a/webstack/apps/homebase/src/api/routers/httpRouter.ts
+++ b/webstack/apps/homebase/src/api/routers/httpRouter.ts
@@ -58,7 +58,7 @@ export function expressAPIRouter(): express.Router {
   router.use('/logs', LogsRouter());
 
   // Rate limit (generous per-IP backstop), then authenticate all API Routes
-  router.use(createRateLimiter(5, 2000));
+  router.use(createRateLimiter(400));
   router.use(SAGEBase.Auth.authenticate);
 
   // Kernels Routes

--- a/webstack/apps/homebase/src/main.ts
+++ b/webstack/apps/homebase/src/main.ts
@@ -40,7 +40,7 @@ import { loadConfig } from './config';
 // import { AssetService } from './services';
 import { expressAPIRouter, wsAPIRouter } from './api/routers';
 import { AppsCollection, loadCollections, PresenceCollection } from './api/collections';
-import { SAGEBase, SAGEBaseConfig } from '@sage3/sagebase';
+import { SAGEBase, SAGEBaseConfig, createRateLimiter } from '@sage3/sagebase';
 
 import { APIClientWSMessage, ServerConfiguration } from '@sage3/shared/types';
 import { SBAuthDB, JWTPayload } from '@sage3/sagebase';
@@ -115,7 +115,7 @@ async function startServer() {
   // Twilio Setup
   const screenShareTimeLimit = 3600 * 6 * 1000; // 6 hours
   const twilio = new SAGETwilio(config.services.twilio, AppsCollection, PresenceCollection, 10000, screenShareTimeLimit);
-  app.get('/twilio/token', SAGEBase.Auth.authenticate, (req, res) => {
+  app.get('/twilio/token', createRateLimiter(5, 30), SAGEBase.Auth.authenticate, (req, res) => {
     const authId = req.user.id;
     if (authId === undefined) {
       res.status(403).send();

--- a/webstack/apps/homebase/src/main.ts
+++ b/webstack/apps/homebase/src/main.ts
@@ -115,7 +115,7 @@ async function startServer() {
   // Twilio Setup
   const screenShareTimeLimit = 3600 * 6 * 1000; // 6 hours
   const twilio = new SAGETwilio(config.services.twilio, AppsCollection, PresenceCollection, 10000, screenShareTimeLimit);
-  app.get('/twilio/token', createRateLimiter(5, 30), SAGEBase.Auth.authenticate, (req, res) => {
+  app.get('/twilio/token', createRateLimiter(6), SAGEBase.Auth.authenticate, (req, res) => {
     const authId = req.user.id;
     if (authId === undefined) {
       res.status(403).send();

--- a/webstack/apps/homebase/src/web/http-server.ts
+++ b/webstack/apps/homebase/src/web/http-server.ts
@@ -78,7 +78,7 @@ export function createApp(assetPath: string, config: ServerConfiguration): expre
   app.use(
     helmet({
       // Content-Security-Policy
-      contentSecurityPolicy: false,
+      contentSecurityPolicy: true,
       // Strict-Transport-Security
       hsts: true,
       // Cross-Origin-Embedder-Policy: disable to enable map images and zoom images to load

--- a/webstack/apps/webapp/src/app/pages/login/Login.tsx
+++ b/webstack/apps/webapp/src/app/pages/login/Login.tsx
@@ -221,7 +221,7 @@ export function LoginPage() {
       }
 
       // Log to console for debugging (always visible)
-      console.error(`OAuth Authentication Error [${error}]:`, {
+      console.error(`OAuth Authentication Error:`, {
         title,
         description,
         details: details ? decodeURIComponent(details) : 'No additional details',

--- a/webstack/clients/electron/html/landing.html
+++ b/webstack/clients/electron/html/landing.html
@@ -89,9 +89,19 @@
       });
     }
 
-    // Change the user's page to the given url
+    // Change the user's page to the given url (http/https only — a javascript:
+    // URL assigned to window.location would execute in this page)
     async function changePage(url) {
-      window.location = url;
+      try {
+        const u = new URL(url);
+        if (u.protocol === 'https:' || u.protocol === 'http:') {
+          window.location = u.href;
+          return;
+        }
+      } catch {
+        // invalid URL: fall through to the notification
+      }
+      showNotification('Invalid hub URL', true);
     }
 
     // Function to show a notification at the bottom of the screen; removes it after 3 seconds
@@ -173,6 +183,14 @@
     // Add a new hub to the list
     function addNewHub(form) {
       const url = form.serverurl.value;
+      // Only web URLs may become hub bookmarks
+      try {
+        const u = new URL(url);
+        if (u.protocol !== 'https:' && u.protocol !== 'http:') throw new Error();
+      } catch {
+        showNotification('Invalid hub URL', true);
+        return;
+      }
       // Get server Info
       fetchServerInfo(url).then((info) => {
         if (info) {

--- a/webstack/libs/applications/src/lib/apps/Webview/Webview.tsx
+++ b/webstack/libs/applications/src/lib/apps/Webview/Webview.tsx
@@ -70,6 +70,43 @@ export const useStore = create<WebviewStore>()((set) => ({
   setLocalURL: (id: string, url: string) => set((state) => ({ localURL: { ...state.localURL, ...{ [id]: url } } })),
 }));
 
+// Shared cookie/session partitions per service, so users stay logged in across
+// app instances. Matched against the URL hostname (exact or subdomain), never
+// substrings — a lookalike host must not join an authenticated partition.
+// Ordered most-specific first: colab would otherwise be shadowed by google.com.
+const SHARED_PARTITIONS: { partition: string; domains: string[] }[] = [
+  { partition: 'persist:colab', domains: ['colab.research.google.com'] },
+  { partition: 'persist:office', domains: ['sharepoint.com', 'live.com', 'office.com'] },
+  { partition: 'persist:whereby', domains: ['appear.in', 'whereby.com'] },
+  { partition: 'persist:youtube', domains: ['youtube.com'] },
+  { partition: 'persist:github', domains: ['github.com'] },
+  { partition: 'persist:google', domains: ['google.com'] },
+];
+
+/**
+ * Pick the session partition for a URL: a shared per-service partition for
+ * known hosts, or a unique isolated one. Unparseable and non-http(s) URLs
+ * are isolated.
+ */
+function partitionForURL(raw: string, appId: string): string {
+  const isolated = 'partition_' + appId;
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return isolated;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return isolated;
+  const host = u.hostname.toLowerCase();
+  const matches = (d: string) => host === d || host.endsWith('.' + d);
+  for (const { partition, domains } of SHARED_PARTITIONS) {
+    if (domains.some(matches)) return partition;
+  }
+  if (u.pathname.toLowerCase().endsWith('.pdf')) return 'persist:pdf';
+  if (host === window.location.hostname) return 'persist:jupyter';
+  return isolated;
+}
+
 /* App component for Webview */
 
 function AppComponent(props: App): JSX.Element {
@@ -125,26 +162,7 @@ function AppComponent(props: App): JSX.Element {
 
       // Set partition to persist login info and settings per service
       // This allows users to stay logged in across app instances
-      if (url.indexOf('sharepoint.com') >= 0 || url.indexOf('live.com') >= 0 || url.indexOf('office.com') >= 0) {
-        webview.partition = 'persist:office';
-      } else if (url.indexOf('appear.in') >= 0 || url.indexOf('whereby.com') >= 0) {
-        webview.partition = 'persist:whereby';
-      } else if (url.indexOf('youtube.com') >= 0) {
-        webview.partition = 'persist:youtube';
-      } else if (url.indexOf('github.com') >= 0) {
-        webview.partition = 'persist:github';
-      } else if (url.indexOf('google.com') >= 0) {
-        webview.partition = 'persist:google';
-      } else if (url.includes('.pdf')) {
-        webview.partition = 'persist:pdf';
-      } else if (url.includes(window.location.hostname)) {
-        webview.partition = 'persist:jupyter';
-      } else if (url.includes('colab.research.google.com')) {
-        webview.partition = 'persist:colab';
-      } else {
-        // Unique partition for isolation
-        webview.partition = 'partition_' + props._id;
-      }
+      webview.partition = partitionForURL(url, props._id);
 
       // Callback when the webview is ready
       webview.addEventListener('dom-ready', domReadyCallback);

--- a/webstack/libs/frontend/src/lib/utils/strings.ts
+++ b/webstack/libs/frontend/src/lib/utils/strings.ts
@@ -81,77 +81,84 @@ export function zeroPad(num: number, places: number): string {
 }
 
 /**
- * Process a URL to be embedded
+ * Exact-or-subdomain hostname match (never a substring match, so lookalike
+ * hosts like evil-vimeo.com or vimeo.com.evil.net do not qualify)
+ */
+function hostMatches(host: string, domain: string): boolean {
+  return host === domain || host.endsWith('.' + domain);
+}
+
+/**
+ * Process a URL to be embedded: rewrite known services to their embed form.
+ * Services are identified by URL hostname; unknown or unparseable URLs are
+ * returned unchanged (this is a rewriter — isValidURL is the gate).
  *
  * @param {string} view_url
  * @returns {string} resulting url
  */
 export function processContentURL(view_url: string): string {
-  // A youtube URL with a 'watch' video
-  if (view_url.startsWith('https://www.youtube.com') && !view_url.includes('/channel/') && view_url !== 'https://www.youtube.com/') {
-    if (view_url.indexOf('embed') === -1 || view_url.indexOf('watch?v=') >= 0) {
-      // Search for the Youtube ID
-      let video_id = view_url.split('v=')[1];
-      const ampersandPosition = video_id.indexOf('&');
-      if (ampersandPosition !== -1) {
-        video_id = video_id.substring(0, ampersandPosition);
-      }
-      view_url = 'https://www.youtube.com/embed/' + video_id + '?autoplay=0';
+  let u: URL;
+  try {
+    u = new URL(view_url);
+  } catch {
+    return view_url;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return view_url;
+  const host = u.hostname.toLowerCase();
+
+  if (host === 'www.youtube.com' && !u.pathname.startsWith('/channel/') && u.pathname !== '/') {
+    // A youtube URL with a 'watch' video
+    const video_id = u.searchParams.get('v');
+    if (video_id && !u.pathname.startsWith('/embed')) {
+      view_url = 'https://www.youtube.com/embed/' + encodeURIComponent(video_id) + '?autoplay=0';
     }
-  } else if (view_url.startsWith('https://www.ted.com/talks')) {
+  } else if (host === 'www.ted.com' && u.pathname.startsWith('/talks')) {
     // Handler for TED talks
-    const talk = view_url.replace('https://www.ted.com/talks', 'https://embed.ted.com/talks');
-    view_url = talk;
-  } else if (view_url.startsWith('https://youtu.be')) {
+    view_url = view_url.replace('https://www.ted.com/talks', 'https://embed.ted.com/talks');
+  } else if (host === 'youtu.be') {
     // youtube short URL (used in sharing)
-    const video_id = view_url.split('/').pop();
-    view_url = 'https://www.youtube.com/embed/' + video_id + '?autoplay=0';
-  } else if (view_url.indexOf('vimeo') >= 0) {
-    // Search for the Vimeo ID
-    const m = view_url.match(/^.+vimeo.com\/(.*\/)?([^#?]*)/);
-    const vimeo_id = m ? m[2] || m[1] : null;
-    if (vimeo_id) {
-      view_url = 'https://player.vimeo.com/video/' + vimeo_id;
+    const video_id = u.pathname.split('/').pop();
+    if (video_id) {
+      view_url = 'https://www.youtube.com/embed/' + encodeURIComponent(video_id) + '?autoplay=0';
     }
-  } else if (view_url.indexOf('twitch.tv') >= 0) {
-    // Twitch video from:
-    //    https://go.twitch.tv/videos/180266596
-    // to embedded:
-    //    https://player.twitch.tv/?!autoplay&video=v180266596
-    // Search for the Twitch ID
-    const tw = view_url.match(/^.+twitch.tv\/(.*\/)?([^#?]*)/);
-    const twitch_id = tw ? tw[2] || tw[1] : null;
+  } else if (hostMatches(host, 'vimeo.com')) {
+    // Vimeo ID is the last path segment
+    const vimeo_id = u.pathname.split('/').filter(Boolean).pop();
+    if (vimeo_id) {
+      view_url = 'https://player.vimeo.com/video/' + encodeURIComponent(vimeo_id);
+    }
+  } else if (hostMatches(host, 'twitch.tv')) {
+    // Twitch video from: https://go.twitch.tv/videos/180266596
+    // to embedded:       https://player.twitch.tv/?!autoplay&video=v180266596
+    const twitch_id = u.pathname.split('/').filter(Boolean).pop();
     if (twitch_id) {
-      view_url = 'https://player.twitch.tv/?!autoplay&video=v' + twitch_id;
+      view_url = 'https://player.twitch.tv/?!autoplay&video=v' + encodeURIComponent(twitch_id);
     }
   } else if (
-    // TLDraw regex
-    // eslint-disable-next-line no-useless-escape
-    view_url.match(/https:\/\/([\w\.-]+\.)?figma.com\/(file|proto)\/([0-9a-zA-Z]{22,128})(?:\/.*)?$/) &&
+    hostMatches(host, 'figma.com') &&
+    u.pathname.match(/^\/(file|proto)\/([0-9a-zA-Z]{22,128})(\/.*)?$/) &&
     !view_url.includes('figma.com/embed')
   ) {
-    view_url = `https://www.figma.com/embed?embed_host=share&url=${view_url}`;
-  } else if (view_url.includes('docs.google.')) {
+    view_url = `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(view_url)}`;
+  } else if (host === 'docs.google.com') {
     // slides in presentation mode when published
-    const urlObj = new URL(view_url);
-    if (urlObj?.pathname.match(/^\/presentation/) && urlObj?.pathname.match(/\/pub\/?$/)) {
-      urlObj.pathname = urlObj.pathname.replace(/\/pub$/, '/embed');
-      const keys = Array.from(urlObj.searchParams.keys());
+    if (u.pathname.match(/^\/presentation/) && u.pathname.match(/\/pub\/?$/)) {
+      u.pathname = u.pathname.replace(/\/pub$/, '/embed');
+      const keys = Array.from(u.searchParams.keys());
       for (const key of keys) {
-        urlObj.searchParams.delete(key);
+        u.searchParams.delete(key);
       }
-      view_url = urlObj.href;
+      view_url = u.href;
     }
-  } else if (view_url.includes('observablehq.com')) {
-    const urlObj = new URL(view_url);
-    if (urlObj && urlObj.pathname.match(/^\/@([^/]+)\/([^/]+)\/?$/)) {
-      view_url = `${urlObj.origin}/embed${urlObj.pathname}?cell=*`;
+  } else if (hostMatches(host, 'observablehq.com')) {
+    if (u.pathname.match(/^\/@([^/]+)\/([^/]+)\/?$/)) {
+      view_url = `${u.origin}/embed${u.pathname}?cell=*`;
     }
-    if (urlObj && urlObj.pathname.match(/^\/d\/([^/]+)\/?$/)) {
-      const pathName = urlObj.pathname.replace(/^\/d/, '');
-      view_url = `${urlObj.origin}/embed${pathName}?cell=*`;
+    if (u.pathname.match(/^\/d\/([^/]+)\/?$/)) {
+      const pathName = u.pathname.replace(/^\/d/, '');
+      view_url = `${u.origin}/embed${pathName}?cell=*`;
     }
-  } else if (view_url.includes('twitter.com/')) {
+  } else if (hostMatches(host, 'twitter.com')) {
     view_url = `https://oembed.link/${view_url}`;
   }
   return view_url;
@@ -217,8 +224,10 @@ export function isValidURL(value: string): string | undefined {
   // eslint-disable-next-line no-useless-escape
   if (!/^[a-z][a-z0-9\+\-\.]*$/.test(scheme.toLowerCase())) return;
 
-  // Disable some protocols: chrome sage3
-  if (scheme === 'sage3' || scheme === 'chrome') {
+  // Only allow web protocols: rejects javascript:, data:, file:, chrome:,
+  // sage3:, etc. — validated URLs end up in webviews and links.
+  const lowScheme = scheme.toLowerCase();
+  if (lowScheme !== 'http' && lowScheme !== 'https') {
     return;
   }
 

--- a/webstack/libs/sagebase/package.json
+++ b/webstack/libs/sagebase/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "connect-redis": "^7.1.1",
     "express": "^4.21.0",
+    "express-rate-limit": "^8.6.2",
     "express-session": "^1.18.0",
     "openid-client": "^5.1.6",
     "passport": "^0.6.0",

--- a/webstack/libs/sagebase/src/index.ts
+++ b/webstack/libs/sagebase/src/index.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './lib/core/SAGEBase';
+export * from './lib/modules/auth/SBRateLimit';

--- a/webstack/libs/sagebase/src/lib/modules/auth/SBAuth.ts
+++ b/webstack/libs/sagebase/src/lib/modules/auth/SBAuth.ts
@@ -199,8 +199,8 @@ export class SBAuth {
 
     // Rate limiters on the routes flagged by code scanning: OAuth callbacks
     // are rare per client; verify/logout run on page loads
-    const loginLimiter = createRateLimiter(15, 30);
-    const sessionLimiter = createRateLimiter(5, 200);
+    const loginLimiter = createRateLimiter(2);
+    const sessionLimiter = createRateLimiter(40);
 
     if (config.strategies) {
       // Google Setup

--- a/webstack/libs/sagebase/src/lib/modules/auth/SBAuth.ts
+++ b/webstack/libs/sagebase/src/lib/modules/auth/SBAuth.ts
@@ -14,6 +14,7 @@ import session from 'express-session';
 import * as passport from 'passport';
 
 import { SBAuthDatabase, SBAuthDB, SBAuthSchema } from './SBAuthDatabase';
+import { createRateLimiter } from './SBRateLimit';
 export type { SBAuthSchema } from './SBAuthDatabase';
 export type { JWTPayload } from './adapters';
 import {
@@ -196,34 +197,39 @@ export class SBAuth {
     // Passport deserialize function in order to support login sessions.
     passport.deserializeUser(this.deserializeUser);
 
+    // Rate limiters: logins/callbacks are rare per client; verify/logout run on page loads
+    const loginLimiter = createRateLimiter(15, 30);
+    const sessionLimiter = createRateLimiter(5, 200);
+
     if (config.strategies) {
       // Google Setup
       if (config.strategies.includes('google') && config.googleConfig) {
         if (passportGoogleSetup(config.googleConfig)) {
           express.get(
             config.googleConfig.routeEndpoint,
+            loginLimiter,
             passport.authenticate('google', {
               prompt: 'select_account',
               scope: ['profile', 'email'],
               // Note: State parameter validation handled by passport strategy
             }),
           );
-          express.get(config.googleConfig.callbackURL, this.createOAuthCallbackHandler('google', 'google'));
+          express.get(config.googleConfig.callbackURL, loginLimiter, this.createOAuthCallbackHandler('google', 'google'));
         }
       }
 
       // Apple Setup
       if (config.strategies.includes('apple') && config.appleConfig) {
         if (passportAppleSetup(config.appleConfig)) {
-          express.get(config.appleConfig.routeEndpoint, passport.authenticate('apple'));
-          express.post(config.appleConfig.callbackURL, this.createOAuthCallbackHandler('apple', 'apple'));
+          express.get(config.appleConfig.routeEndpoint, loginLimiter, passport.authenticate('apple'));
+          express.post(config.appleConfig.callbackURL, loginLimiter, this.createOAuthCallbackHandler('apple', 'apple'));
         }
       }
 
       // JWT Setup
       if (config.strategies.includes('jwt') && config.jwtConfig) {
         if (passportJWTSetup(config.jwtConfig)) {
-          express.post(config.jwtConfig.routeEndpoint, passport.authenticate('jwt', { session: false }), (req, res) => {
+          express.post(config.jwtConfig.routeEndpoint, loginLimiter, passport.authenticate('jwt', { session: false }), (req, res) => {
             res.status(200).send({ success: true, message: 'logged in', user: req.user });
           });
         }
@@ -232,7 +238,7 @@ export class SBAuth {
       // Guest Setup
       if (config.strategies.includes('guest') && config.guestConfig) {
         if (passportGuestSetup()) {
-          express.post(config.guestConfig.routeEndpoint, passport.authenticate('guest', { successRedirect: '/', failureRedirect: '/' }));
+          express.post(config.guestConfig.routeEndpoint, loginLimiter, passport.authenticate('guest', { successRedirect: '/', failureRedirect: '/' }));
         }
       }
 
@@ -241,6 +247,7 @@ export class SBAuth {
         if (passportSpectatorSetup()) {
           express.post(
             config.spectatorConfig.routeEndpoint,
+            loginLimiter,
             passport.authenticate('spectator', { successRedirect: '/', failureRedirect: '/' }),
           );
         }
@@ -252,13 +259,14 @@ export class SBAuth {
         if (ready) {
           express.get(
             config.cilogonConfig.routeEndpoint,
+            loginLimiter,
             passport.authenticate('openidconnect', {
               prompt: 'consent',
               scope: ['openid', 'email', 'profile'],
               // Note: State parameter validation handled by OpenID Connect strategy
             }),
           );
-          express.get(config.cilogonConfig.callbackURL, this.createOAuthCallbackHandler('cilogon', 'openidconnect'));
+          express.get(config.cilogonConfig.callbackURL, loginLimiter, this.createOAuthCallbackHandler('cilogon', 'openidconnect'));
         }
       }
 
@@ -268,11 +276,12 @@ export class SBAuth {
         if (ready) {
           express.get(
             config.keycloakConfig.routeEndpoint,
+            loginLimiter,
             passport.authenticate('keycloak', {
               scope: ['openid', 'email', 'profile'],
             }),
           );
-          express.get(config.keycloakConfig.callbackURL, this.createOAuthCallbackHandler('keycloak', 'keycloak'));
+          express.get(config.keycloakConfig.callbackURL, loginLimiter, this.createOAuthCallbackHandler('keycloak', 'keycloak'));
         }
       }
 
@@ -280,7 +289,7 @@ export class SBAuth {
       if (config.strategies.includes('ldap') && config.ldapConfig) {
         const ready = passportLDAPSetup(config.ldapConfig);
         if (ready) {
-          express.post('/auth/ldap', makeLdapAuthHandler(passport));
+          express.post('/auth/ldap', loginLimiter, makeLdapAuthHandler(passport));
         } else {
           console.error('LDAP> Setup failed — /auth/ldap will not be registered. Check ldapConfig in the server config.');
         }
@@ -288,10 +297,10 @@ export class SBAuth {
     }
 
     // Route to logout
-    express.get('/auth/logout', (req, res, next) => this.logout(req, res, next));
+    express.get('/auth/logout', sessionLimiter, (req, res, next) => this.logout(req, res, next));
 
     // Route to quickly verify authentication
-    express.get('/auth/verify', this.authenticate, (req, res) => {
+    express.get('/auth/verify', sessionLimiter, this.authenticate, (req, res) => {
       const user = req.user as SBAuthSchema;
       // Get the expiration date from the session cookie
       const exp = req.session.cookie.expires || new Date();

--- a/webstack/libs/sagebase/src/lib/modules/auth/SBAuth.ts
+++ b/webstack/libs/sagebase/src/lib/modules/auth/SBAuth.ts
@@ -197,7 +197,8 @@ export class SBAuth {
     // Passport deserialize function in order to support login sessions.
     passport.deserializeUser(this.deserializeUser);
 
-    // Rate limiters: logins/callbacks are rare per client; verify/logout run on page loads
+    // Rate limiters on the routes flagged by code scanning: OAuth callbacks
+    // are rare per client; verify/logout run on page loads
     const loginLimiter = createRateLimiter(15, 30);
     const sessionLimiter = createRateLimiter(5, 200);
 
@@ -207,7 +208,6 @@ export class SBAuth {
         if (passportGoogleSetup(config.googleConfig)) {
           express.get(
             config.googleConfig.routeEndpoint,
-            loginLimiter,
             passport.authenticate('google', {
               prompt: 'select_account',
               scope: ['profile', 'email'],
@@ -221,7 +221,7 @@ export class SBAuth {
       // Apple Setup
       if (config.strategies.includes('apple') && config.appleConfig) {
         if (passportAppleSetup(config.appleConfig)) {
-          express.get(config.appleConfig.routeEndpoint, loginLimiter, passport.authenticate('apple'));
+          express.get(config.appleConfig.routeEndpoint, passport.authenticate('apple'));
           express.post(config.appleConfig.callbackURL, loginLimiter, this.createOAuthCallbackHandler('apple', 'apple'));
         }
       }
@@ -229,7 +229,7 @@ export class SBAuth {
       // JWT Setup
       if (config.strategies.includes('jwt') && config.jwtConfig) {
         if (passportJWTSetup(config.jwtConfig)) {
-          express.post(config.jwtConfig.routeEndpoint, loginLimiter, passport.authenticate('jwt', { session: false }), (req, res) => {
+          express.post(config.jwtConfig.routeEndpoint, passport.authenticate('jwt', { session: false }), (req, res) => {
             res.status(200).send({ success: true, message: 'logged in', user: req.user });
           });
         }
@@ -238,7 +238,7 @@ export class SBAuth {
       // Guest Setup
       if (config.strategies.includes('guest') && config.guestConfig) {
         if (passportGuestSetup()) {
-          express.post(config.guestConfig.routeEndpoint, loginLimiter, passport.authenticate('guest', { successRedirect: '/', failureRedirect: '/' }));
+          express.post(config.guestConfig.routeEndpoint, passport.authenticate('guest', { successRedirect: '/', failureRedirect: '/' }));
         }
       }
 
@@ -247,7 +247,6 @@ export class SBAuth {
         if (passportSpectatorSetup()) {
           express.post(
             config.spectatorConfig.routeEndpoint,
-            loginLimiter,
             passport.authenticate('spectator', { successRedirect: '/', failureRedirect: '/' }),
           );
         }
@@ -259,7 +258,6 @@ export class SBAuth {
         if (ready) {
           express.get(
             config.cilogonConfig.routeEndpoint,
-            loginLimiter,
             passport.authenticate('openidconnect', {
               prompt: 'consent',
               scope: ['openid', 'email', 'profile'],
@@ -276,7 +274,6 @@ export class SBAuth {
         if (ready) {
           express.get(
             config.keycloakConfig.routeEndpoint,
-            loginLimiter,
             passport.authenticate('keycloak', {
               scope: ['openid', 'email', 'profile'],
             }),
@@ -289,7 +286,7 @@ export class SBAuth {
       if (config.strategies.includes('ldap') && config.ldapConfig) {
         const ready = passportLDAPSetup(config.ldapConfig);
         if (ready) {
-          express.post('/auth/ldap', loginLimiter, makeLdapAuthHandler(passport));
+          express.post('/auth/ldap', makeLdapAuthHandler(passport));
         } else {
           console.error('LDAP> Setup failed — /auth/ldap will not be registered. Check ldapConfig in the server config.');
         }

--- a/webstack/libs/sagebase/src/lib/modules/auth/SBRateLimit.ts
+++ b/webstack/libs/sagebase/src/lib/modules/auth/SBRateLimit.ts
@@ -14,13 +14,12 @@ import rateLimit from 'express-rate-limit';
  * 'trust proxy' enabled, so req.ip is the real client address from
  * X-Forwarded-For.
  *
- * @param windowMinutes length of the sliding window
- * @param limit maximum requests per client IP within the window
+ * @param maxPerMinute maximum requests per client IP per minute
  */
-export function createRateLimiter(windowMinutes: number, limit: number) {
+export function createRateLimiter(maxPerMinute: number) {
   return rateLimit({
-    windowMs: windowMinutes * 60 * 1000,
-    limit,
+    windowMs: 60 * 1000,
+    limit: maxPerMinute,
     standardHeaders: 'draft-7',
     legacyHeaders: false,
     // 'trust proxy' is intentionally permissive: Traefik is the single

--- a/webstack/libs/sagebase/src/lib/modules/auth/SBRateLimit.ts
+++ b/webstack/libs/sagebase/src/lib/modules/auth/SBRateLimit.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+import rateLimit from 'express-rate-limit';
+
+/**
+ * Per-client-IP rate limiter for sensitive routes (logins, uploads,
+ * destructive operations). Both servers run behind Traefik with
+ * 'trust proxy' enabled, so req.ip is the real client address from
+ * X-Forwarded-For.
+ *
+ * @param windowMinutes length of the sliding window
+ * @param limit maximum requests per client IP within the window
+ */
+export function createRateLimiter(windowMinutes: number, limit: number) {
+  return rateLimit({
+    windowMs: windowMinutes * 60 * 1000,
+    limit,
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+    // 'trust proxy' is intentionally permissive: Traefik is the single
+    // ingress in production (the only published port), so X-Forwarded-For
+    // cannot be spoofed from outside. Silence the library's warning.
+    validate: { trustProxy: false },
+    message: { success: false, message: 'Too many requests, please try again later.' },
+  });
+}

--- a/webstack/package.json
+++ b/webstack/package.json
@@ -61,6 +61,7 @@
     "esri-leaflet-geocoder": "^3.1.3",
     "exiftool-vendored": "^37.2.0",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.6.2",
     "express-session": "^1.18.2",
     "extended-eventsource": "^1.4.9",
     "framer-motion": "^12.23.22",

--- a/webstack/yarn.lock
+++ b/webstack/yarn.lock
@@ -10579,6 +10579,14 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz#51cf92c1c0493c766053f9d3abee4434c244d2f6"
   integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
 
+express-rate-limit@^8.6.2:
+  version "8.6.2"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.6.2.tgz#1a6c7fb6c5f5a83883c14f1d198fcdff60087c5d"
+  integrity sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==
+  dependencies:
+    debug "^4.4.3"
+    ip-address "^10.2.0"
+
 express-session@^1.18.2:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.19.0.tgz#682139f6eec6c69db9febbe2362e8a85dd84af2f"
@@ -12179,6 +12187,11 @@ ioredis@^5.3.2:
     redis-errors "1.2.0"
     redis-parser "3.0.0"
     standard-as-callback "2.1.0"
+
+ip-address@^10.2.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.5.0.tgz#fcd6d7dfe9e68416b7cb71afe9bc960b3e38c13b"
+  integrity sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==
 
 ip-regex@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Brings the code-scanning branch (PR #1388) from dev into main — 37 CodeQL alerts addressed.

## URL sanitization
- **Webview session partitions**: hostname-based (exact-or-subdomain) matching instead of substring checks, so lookalike hosts can't join authenticated shared cookie partitions; non-http(s)/unparseable URLs isolated; fixes the shadowed Colab partition (8 alerts).
- **`strings.ts`**: `isValidURL` now allowlists http/https (previously `javascript:`/`data:`/`file:` passed and reached Electron webviews via the paste handler); `processContentURL` identifies services by parsed hostname, encodes extracted ids, and no longer crashes on YouTube URLs without `v=`.
- **Electron landing page**: hub navigation and the add-hub dialog validate http/https before `window.location` / bookmark storage (`js/xss-through-dom`).
- **OAuth error logging**: user-controlled query param removed from a `console.error` format string (`js/tainted-format-string`).

## Rate limiting (13 alerts)
New `createRateLimiter(maxPerMinute)` in sagebase (express-rate-limit, 1-minute window, per client IP behind Traefik). Applied strictly to the flagged handlers:

| Routes | Limit (per IP/min) |
|---|---|
| OAuth callbacks (google/apple/cilogon/keycloak) | 2 (shared) |
| `/auth/logout`, `/auth/verify` | 40 (shared) |
| homebase `/api/*` backstop | 400 |
| files server `/api/*` backstop | 600 |
| public token downloads | 60 |
| `/twilio/token` | 6 |
| plugin upload/remove | 4 (shared) |
| account deletion | 1 |

## Workflow token permissions (13 alerts)
Least-privilege `permissions` in every workflow: `contents: read` for CI/client builds, `contents: write` for tag releases, `packages: write` for ghcr pushes.

**Verified**: behavior test suites for the URL logic (16 + 23 + 7 cases), both servers build, sagebase tests pass, workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)