### PR TITLE
AI: personal API keys, generic image generation, and chat slash commands

### DIFF
--- a/doc/Applications.md
+++ b/doc/Applications.md
@@ -71,6 +71,26 @@ A messaging application for communicating with other users on the board **and wi
 
 Type a message to chat normally; the AI answers questions, brainstorms, and summarizes. The model used depends on your server's configuration and the model you select — see [AI Configuration](Server-Deployment.md#ai-configuration). The AI can only perform a task when the selected model has the matching capability (for example, image questions need a `vision`-capable model), and the Chat app will tell you when a request isn't supported by the current model.
 
+### Commands
+
+Typing a message that starts with **`/`** runs a command instead of sending the message to the conversation. Commands act for you alone — their results appear in a notification or on the board, never as a message everyone sees.
+
+| Command | Does |
+|---|---|
+| `/image <description>` | Generates an image from the description and opens it on the board. Also `/img`, `/draw`. |
+| `/help` | Lists the available commands. Also `/?`. |
+
+Command names are case-insensitive, and anything that only *looks* like a command — `http://example.com/page`, or `and/or` — is sent as an ordinary message. Mistyping a command shows the list rather than posting the typo to the conversation.
+
+### Generating images
+
+There are two ways to get an image:
+
+- **`/image <description>`** — the text you type is the prompt. Use this for anything you can describe.
+- **The "Generate Image" button**, shown when a Stickie is linked to the Chat, illustrates the linked note's text.
+
+Either way the image is generated, saved into the room's assets, and opened as an ImageViewer window on the board, linked back to the Chat that made it. Image generation needs a model that declares the `imagegen` capability — see [AI Configuration](Server-Deployment.md#ai-configuration) — so it is not available with a personal API key, which is assumed to cover text tasks only.
+
 ### Asking about content (images, PDFs, sticky notes)
 
 You can ask the AI about content already on the board:

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -169,20 +169,26 @@ webstack/apps/homebase-files/
 
 Seer is a Python FastAPI server that provides AI-powered features for SAGE3. It connects to external LLM providers and processes AI requests forwarded from Homebase.
 
-**Supported LLM providers:**
-- OpenAI (GPT-4 family)
-- Azure OpenAI
-- Llama (self-hosted via NVIDIA API, hosted at University of Illinois Chicago)
+**LLM providers** are not hard-coded. Seer reads the server's capability-driven model registry (`services.models`, see [AI Configuration](Server-Deployment.md#ai-configuration)) at start-up and picks a model by matching a request's **task** to a model's declared **capabilities**. How each provider is spoken to is inferred from its config: a `url` plus a model `api_version` means **Azure OpenAI**, a `url` alone means any **OpenAI-compatible** endpoint (LiteLLM, vLLM, Ollama, …), and no `url` means **openai.com**. Adding a provider is a configuration change, not a code change.
 
 **AI agents:**
 | Agent | Endpoint | Description |
 |---|---|---|
 | Chat | `POST /ask` | General LLM Q&A with message history |
+| Summary | `POST /summary` | Summarize the linked content |
 | Code | `POST /code` | Code assistance and explanation |
 | Image | `POST /image` | Image understanding and bounding box detection |
-| Web | `POST /web` | Web page scraping and summarization |
+| Image generation | `POST /image-generation` | Generic image generation; the prompt is used as written |
+| Web | `POST /web`, `POST /webshot` | Web page scraping, summarization and screenshots |
 | PDF | `POST /pdf` | PDF document analysis and Q&A |
 | Mesonet | `POST /mesonet` | Hawaii sensor / weather data queries |
+| Ideator | `POST /dimensions`, `/node`, `/abstract`, `/user-dimension`, `/summarize`, `/prose`, `/ideator/image` | Brainstorming support for the SageIdeator app |
+
+`GET /status` reports service health.
+
+> **Image generation vs. the Ideator.** `POST /image-generation` is the generic path used by any app: it sends the caller's prompt unchanged. `POST /ideator/image` is SageIdeator's, and *composes* a brainstorming prompt from ideator concepts (dimensions, the brainstorming prompt) before generating. They share the client-construction code but not the prompt, so the ideator's framing does not leak into ordinary image requests.
+
+**Per-request user credentials.** A request may carry a `userllm` block (`apiKey`, optional `baseUrl`, `modelId`) when the user has supplied their own key in the web app. When present it takes precedence over the configured providers for that one request. Such models are **never cached** — the model cache is keyed by provider name, which every user of a personal key shares, so caching would hand one user's client and key to the next request. The key is used and discarded; it is never persisted, and `UserLLM` carries a redacting representation so a log line that prints a request shows `apiKey='***'`. See [Users bringing their own key](Server-Deployment.md#users-bringing-their-own-key).
 
 Seer uses ChromaDB for semantic vector caching and communicates back to SAGE3 using the `pysage3` Python client library.
 

--- a/doc/Server-Deployment.md
+++ b/doc/Server-Deployment.md
@@ -809,6 +809,32 @@ Per-model fields: `model_id` (the provider's actual model name), `capabilities` 
 
 **`settings`** holds the `default_provider` (used when a user has not chosen one) plus `timeout_seconds`, `max_retries`, and `log_requests`.
 
+#### Users bringing their own key
+
+Alongside the providers configured above, a user can supply **their own OpenAI-compatible API key** from **Settings → Intelligence**, where it appears as an extra provider named `my-own-key` in the same list as the server's providers.
+
+The form takes three things:
+
+| Field | Meaning |
+|---|---|
+| **API key** | The user's key. Required. |
+| **Base URL** | Optional. Blank means `https://api.openai.com/v1`. Any OpenAI-compatible endpoint works; `/v1` is appended if missing, so `https://myhost` is enough. |
+| **Model** | The model to call. Chosen from a dropdown when the endpoint can be queried, typed by hand otherwise. |
+
+As soon as a key and base URL are entered, the browser calls `GET {baseUrl}/models` with the key and offers the result as a dropdown. The lookup is debounced, and any lookup still in flight is cancelled when either field changes again. If the endpoint does not answer — no `/models` route, a rejected key, or a network or CSP failure — the field falls back to free text so the model name can be typed instead.
+
+**Capabilities.** A user-supplied model is assumed to handle `chat`, `code`, and `vision`, which enables the *chat*, *coding*, *image* and *pdf_processing* tasks. It never advertises `imagegen` or `embeddings`: there is no way to ask an arbitrary endpoint what its model supports, so claiming those would light up UI that then fails at request time. Image generation therefore stays on the server's providers.
+
+**Where the key lives.** The key is stored **only in that browser**, under the `s3_user_llm` local-storage key — never in the SAGE3 database and never in the user's account record. It is sent with each AI request the user makes, used for that one request, and never persisted server-side. It is kept out of the `s3_user_settings` bundle deliberately, so that *Restore Default Settings* cannot silently delete it. Clearing the browser's site data removes it, and it does not follow the user to another machine.
+
+Two consequences worth stating plainly to users: requests made this way are **billed to their own account**, and anyone with access to their browser profile can read the key — the same exposure as any credential kept in a browser.
+
+**Who may use it.** Registered users and admins only. Guests and spectators are refused: they are transient, unverified accounts, and a key pasted into a shared guest session would outlive whoever pasted it. Opening Settings as a guest also clears any key a previous account left behind in that browser.
+
+**Which endpoints work.** A key with no base URL is spoken to as OpenAI; a base URL is treated as a generic OpenAI-compatible endpoint. **Azure OpenAI is not supported this way**, because it needs an `api_version` the form has no field for — Azure must be configured server-side. Note also that the browser contacts the endpoint directly for the model lookup, so an `http://` endpoint is blocked by the web app's content-security policy; use `https://`, or configure that endpoint server-side instead.
+
+**Turning it off.** There is no server switch for this today. Leaving `models.providers` empty disables AI entirely, including user-supplied keys.
+
 **To disable AI**, leave `models.providers` empty (or remove the `models` block).
 
 See the `models` block in the configuration listing above for a complete example.

--- a/seer/app/chat.py
+++ b/seer/app/chat.py
@@ -101,12 +101,12 @@ class ChatAgent:
             # provider and let process() return a clear per-request error.
             self.logger.warning("ChatAgent> no model configured; chat requests will fail until models are set")
 
-    def _get_session(self, provider: str):
+    def _get_session(self, provider: str, user_llm=None):
         """Build a prompt|llm|parser chain for a provider's chat-capable model,
         or None if the provider can't chat. The model itself is cached by
         LLMManager, so the chain is cheap to recompose per request."""
         # 'chat' task needs a chat-capable model
-        llm = self.manager.build_chat_model(provider, ["chat"])
+        llm = self.manager.build_chat_model(provider, ["chat"], user_llm=user_llm)
         return (self.prompt | llm | self.output_parser) if llm else None
 
     async def process(self, qq: Question):
@@ -122,7 +122,11 @@ class ChatAgent:
         ai_handler.setAI(qq.model)
 
         # Resolve a chat session for the requested provider
-        session = self._get_session(qq.model)
+        user_llm = LLMManager.user_credentials(qq)
+        self.logger.info(
+            f"Chat> provider={qq.model!r} own_key={'yes' if user_llm else 'no'}"
+        )
+        session = self._get_session(qq.model, user_llm)
         if session is None:
             # Defense in depth: the frontend gates this, but reject clearly here
             raise HTTPException(

--- a/seer/app/code.py
+++ b/seer/app/code.py
@@ -91,12 +91,12 @@ class CodeAgent:
             # provider and let process() return a clear per-request error.
             self.logger.warning("CodeAgent> no model configured; code requests will fail until models are set")
 
-    def _get_session(self, provider: str):
+    def _get_session(self, provider: str, user_llm=None):
         """Build a prompt|llm|parser chain for a provider's code-capable model,
         or None if the provider can't handle code. The model itself is cached by
         LLMManager, so the chain is cheap to recompose per request."""
         # 'coding' task prefers a 'code' model, falling back to chat
-        llm = self.manager.build_chat_model(provider, ["code", "chat"])
+        llm = self.manager.build_chat_model(provider, ["code", "chat"], user_llm=user_llm)
         return (self.prompt | llm | self.output_parser) if llm else None
 
     async def process(self, qq: CodeRequest):
@@ -108,7 +108,7 @@ class CodeAgent:
         today = time.asctime()
 
         # Resolve a code session for the requested provider
-        session = self._get_session(qq.model)
+        session = self._get_session(qq.model, LLMManager.user_credentials(qq))
         if session is None:
             raise HTTPException(
                 status_code=400,

--- a/seer/app/ideator.py
+++ b/seer/app/ideator.py
@@ -76,10 +76,13 @@ class IdeatorAgent:
         fall back to the configured default provider when empty."""
         return model or self.manager.default_provider() or ""
 
-    async def _chat(self, system: str, user: str, model: str, temperature: float = 0.7, image_base64: str | None = None) -> str:
+    async def _chat(self, system: str, user: str, model: str, temperature: float = 0.7, image_base64: str | None = None, user_llm=None) -> str:
         provider = self._resolve_provider(model)
         capability = "vision" if image_base64 else "chat"
-        llm = self.manager.build_chat_model(provider, [capability], temperature=temperature)
+        # `user` above is the prompt; `user_llm` is the caller's own credentials
+        llm = self.manager.build_chat_model(
+            provider, [capability], user_llm=user_llm, temperature=temperature
+        )
         if llm is None:
             raise HTTPException(
                 status_code=400,
@@ -96,11 +99,11 @@ class IdeatorAgent:
         )
         return str(response.content)
 
-    async def _json_chat(self, user: str, model: str, temperature: float = 0.7, image_base64: str | None = None) -> str:
-        return await self._chat(JSON_SYSTEM, user, model, temperature, image_base64)
+    async def _json_chat(self, user: str, model: str, temperature: float = 0.7, image_base64: str | None = None, user_llm=None) -> str:
+        return await self._chat(JSON_SYSTEM, user, model, temperature, image_base64, user_llm)
 
-    async def _prose_chat(self, user: str, model: str, temperature: float = 0.7, image_base64: str | None = None) -> str:
-        return await self._chat(PROSE_SYSTEM, user, model, temperature, image_base64)
+    async def _prose_chat(self, user: str, model: str, temperature: float = 0.7, image_base64: str | None = None, user_llm=None) -> str:
+        return await self._chat(PROSE_SYSTEM, user, model, temperature, image_base64, user_llm)
 
     # ─── Endpoints ───────────────────────────────────────────────────────────
 
@@ -130,8 +133,8 @@ class IdeatorAgent:
         )
 
         cat_raw, ord_raw = await asyncio.gather(
-            self._json_chat(cat_msg, req.model, 0.7, req.imageBase64),
-            self._json_chat(ord_msg, req.model, 0.7, req.imageBase64),
+            self._json_chat(cat_msg, req.model, 0.7, req.imageBase64, LLMManager.user_credentials(req)),
+            self._json_chat(ord_msg, req.model, 0.7, req.imageBase64, LLMManager.user_credentials(req)),
         )
 
         categorical = {}
@@ -157,7 +160,7 @@ class IdeatorAgent:
             "Describe one specific, actionable idea that satisfies all constraints in 1–2 natural paragraphs (up to 150 words). "
             "Be concrete and practical. Write as flowing prose, not lists or JSON."
         )
-        r = await self._prose_chat(msg, req.model, 0.8, req.imageBase64)
+        r = await self._prose_chat(msg, req.model, 0.8, req.imageBase64, LLMManager.user_credentials(req))
         return IdeatorNodeResponse(r=r)
 
     async def abstract(self, req: IdeatorAbstractRequest) -> IdeatorAbstractResponse:
@@ -167,7 +170,7 @@ class IdeatorAgent:
             "Return ONLY valid JSON:\n"
             '{"Title":"<title>","Summary":"<one sentence>","Steps":["Do X","Do Y","Do Z"],"Key Words":["w1","w2"]}'
         )
-        raw = await self._json_chat(msg, req.model, req.temperature)
+        raw = await self._json_chat(msg, req.model, req.temperature, None, LLMManager.user_credentials(req))
         try:
             j = json.loads(_extract_json(raw))
             return IdeatorAbstractResponse(
@@ -192,7 +195,7 @@ class IdeatorAgent:
             "Suggest exactly 4 values.\n"
             'Return ONLY valid JSON: {"type":"categorical","values":["v1","v2","v3","v4"]}'
         )
-        type_raw = await self._json_chat(type_msg, req.model, 0)
+        type_raw = await self._json_chat(type_msg, req.model, 0, None, LLMManager.user_credentials(req))
         dim_type = "categorical"
         values = []
         try:

--- a/seer/app/image.py
+++ b/seer/app/image.py
@@ -169,7 +169,9 @@ class ImageAgent:
             ai_handler.setPrompt(qq.q)
 
             # Resolve a vision-capable model for the requested provider
-            llm = self.manager.build_chat_model(qq.model, ["vision"])
+            llm = self.manager.build_chat_model(
+                qq.model, ["vision"], user_llm=LLMManager.user_credentials(qq)
+            )
             if llm is None:
                 from fastapi import HTTPException
 

--- a/seer/app/imagegen.py
+++ b/seer/app/imagegen.py
@@ -1,0 +1,98 @@
+#  Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+#  University of Hawaii, University of Illinois Chicago, Virginia Tech
+#
+#  Distributed under the terms of the SAGE3 License.  The full license is in
+#  the file LICENSE, distributed as part of this software.
+
+"""Generic image generation.
+
+The plain "make an image from this prompt" path, for any app that wants an
+image. The prompt is used exactly as the caller wrote it: no framing, no style
+is imposed here. Callers that want a particular style say so in their prompt.
+
+This is deliberately separate from IdeatorAgent.image(), which composes a
+brainstorming-specific prompt out of ideator concepts (dimensions, the
+brainstorming prompt) and only makes sense inside SageIdeator.
+"""
+
+from logging import Logger
+
+from fastapi import HTTPException
+from openai import AsyncOpenAI, AsyncAzureOpenAI
+
+from libs.localtypes import ImageGenerationRequest, ImageGenerationResponse
+from libs.llm_manager import LLMManager
+from libs.utils import getModelsInfo
+from pysage3 import PySage3
+
+
+class ImageGenAgent:
+    def __init__(self, logger: Logger, ps3: PySage3):
+        logger.info("Initializing ImageGenAgent")
+        self.logger = logger
+        self.ps3 = ps3
+        self.manager = LLMManager(getModelsInfo(ps3), logger)
+        # Raw OpenAI-SDK clients, keyed by (provider, model name). LLMManager
+        # only builds LangChain chat/embeddings clients, so image generation
+        # talks to the OpenAI SDK directly from the resolved config.
+        self._image_clients: dict = {}
+
+    def _client(self, provider: str) -> tuple:
+        """(client, model_id) for the provider's imagegen-capable model."""
+        info = self.manager.resolve_model(provider, "imagegen")
+        if not info:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Provider '{provider}' has no model capable of image generation",
+            )
+        key = (provider, info["name"])
+        if key in self._image_clients:
+            return self._image_clients[key]
+
+        api_key = info["api_key"] or "EMPTY"
+        if info["kind"] == "azure":
+            client = AsyncAzureOpenAI(
+                api_key=api_key,
+                azure_endpoint=info["url"],
+                api_version=info["api_version"],
+            )
+        elif info["kind"] == "openai_compat":
+            client = AsyncOpenAI(api_key=api_key, base_url=info["base_url"])
+        else:
+            client = AsyncOpenAI(api_key=api_key)
+        self._image_clients[key] = (client, info["model_id"])
+        return self._image_clients[key]
+
+    def _resolve_provider(self, model: str) -> str:
+        """Use the requested provider, falling back to the configured default."""
+        return model or self.manager.default_provider() or ""
+
+    async def generate(self, req: ImageGenerationRequest) -> ImageGenerationResponse:
+        provider = self._resolve_provider(req.model)
+        prompt = (req.prompt or "").strip()
+        if not prompt:
+            raise HTTPException(status_code=400, detail="An image prompt is required")
+
+        client, model_id = self._client(provider)
+        self.logger.info(
+            f"ImageGen> provider={provider} model={model_id} prompt={prompt[:200]}"
+        )
+
+        kwargs = {
+            "model": model_id,
+            "prompt": prompt,
+            "n": 1,
+            "size": req.size or "1024x1024",
+        }
+        # DALL-E returns URLs unless asked for base64; gpt-image models always
+        # return base64 and reject the response_format parameter.
+        if model_id.startswith("dall-e"):
+            kwargs["response_format"] = "b64_json"
+
+        try:
+            response = await client.images.generate(**kwargs)
+            b64 = response.data[0].b64_json
+            return ImageGenerationResponse(imageUrl=f"data:image/png;base64,{b64}")
+        except Exception as e:
+            self.logger.error(f"ImageGen> error from {provider}/{model_id}: {e}")
+            raise

--- a/seer/app/pdf.py
+++ b/seer/app/pdf.py
@@ -240,8 +240,6 @@ class PDFAgent:
             "Got PDF> from " + qq.user + ": " + qq.q + " using: " + qq.model
         )
 
-        self.logger.info(f"\n\nqq, {qq}\n\n")
-
         text = ""
         if qq.assetids:
             # Index each document once. Already-indexed docs are skipped entirely
@@ -275,7 +273,9 @@ class PDFAgent:
                 res = await self.vector_store.aadd_documents(documents=splits)
                 self.logger.info(f"pdf {assetid}: indexed {len(res)} chunks")
 
-            llm = self.manager.build_chat_model(qq.model, ["chat"])
+            llm = self.manager.build_chat_model(
+                qq.model, ["chat"], user_llm=LLMManager.user_credentials(qq)
+            )
             if llm is None:
                 raise HTTPException(
                     status_code=400,

--- a/seer/app/web.py
+++ b/seer/app/web.py
@@ -107,11 +107,11 @@ class WebAgent:
             # provider and let process() return a clear per-request error.
             self.logger.warning("WebAgent> no model configured; web requests will fail until models are set")
 
-    def _get_session(self, provider: str):
+    def _get_session(self, provider: str, user_llm=None):
         """Build a prompt|llm|parser chain for a provider's chat-capable model,
         or None if the provider can't chat. The model itself is cached by
         LLMManager, so the chain is cheap to recompose per request."""
-        llm = self.manager.build_chat_model(provider, ["chat"])
+        llm = self.manager.build_chat_model(provider, ["chat"], user_llm=user_llm)
         return (self.prompt | llm | self.output_parser) if llm else None
 
     async def init(self):
@@ -190,7 +190,7 @@ class WebAgent:
         ai_handler.setAI(qq.model)
 
         # Resolve a chat session for the requested provider
-        session = self._get_session(qq.model)
+        session = self._get_session(qq.model, LLMManager.user_credentials(qq))
         if session is None:
             raise HTTPException(
                 status_code=400,

--- a/seer/libs/llm_manager.py
+++ b/seer/libs/llm_manager.py
@@ -149,13 +149,69 @@ class LLMManager:
             url = url + "/v1"
         return url
 
+
+    @staticmethod
+    def user_credentials(req) -> Optional[dict]:
+        """The per-request credentials carried by a request model, or None.
+
+        Requests naming a server-configured provider have no `userllm` block,
+        so this returns None and every caller behaves exactly as before.
+        """
+        u = getattr(req, "userllm", None)
+        if not u:
+            return None
+        return u.model_dump() if hasattr(u, "model_dump") else dict(u)
+
     def resolve_model(
-        self, provider: str, capabilities: Union[str, List[Capability]]
+        self,
+        provider: str,
+        capabilities: Union[str, List[Capability]],
+        user_llm: Optional[dict] = None,
     ) -> Optional[dict]:
         """Return the raw connection details for the best matching model, or
-        None when the provider has no model with any of the capabilities."""
+        None when the provider has no model with any of the capabilities.
+
+        When `user_llm` is given it holds credentials supplied with the request
+        (apiKey / baseUrl / modelId) and takes precedence over the configured
+        providers: the model is built from those instead of from the config.
+        The capabilities are not checked against it — a user-supplied model is
+        assumed to handle chat, code, and vision, matching what the client
+        offers — but image generation and embeddings never route here.
+        """
         if isinstance(capabilities, str):
             capabilities = [capabilities]
+
+        if user_llm:
+            url = user_llm.get("baseUrl")
+            model_id = user_llm.get("modelId")
+            has_key = bool(user_llm.get("apiKey"))
+            if self.logger:
+                # Never log the key itself — only whether one arrived
+                self.logger.info(
+                    f"LLM> user-supplied credentials: model={model_id!r} "
+                    f"base_url={url or 'default (OpenAI)'} key_present={has_key}"
+                )
+            if not model_id or not has_key:
+                if self.logger:
+                    self.logger.warning(
+                        "LLM> user credentials incomplete (missing model or key)"
+                    )
+                return None
+            return {
+                # No url means plain OpenAI; a url means an OpenAI-compatible
+                # endpoint. Azure is never inferred here: it needs an
+                # api_version the client has no way to supply.
+                "kind": "openai_compat" if url else "openai",
+                "name": provider,
+                "model_id": model_id,
+                "api_key": user_llm.get("apiKey"),
+                "url": url,
+                "base_url": self._normalize_base_url(url) if url else None,
+                "api_version": None,
+                "max_tokens": None,
+                "context_window": None,
+            }
+
         p = self.get_provider(provider)
         if not p:
             return None
@@ -222,17 +278,27 @@ class LLMManager:
     #
 
     def build_chat_model(
-        self, provider: str, capabilities: Union[str, List[Capability]], **kwargs
+        self,
+        provider: str,
+        capabilities: Union[str, List[Capability]],
+        user_llm: Optional[dict] = None,
+        **kwargs,
     ):
         """Build (and cache) a LangChain chat model for the first model in
-        `provider` matching one of `capabilities`. Returns None if no match."""
+        `provider` matching one of `capabilities`. Returns None if no match.
+
+        A model built from per-request `user_llm` credentials is NEVER cached: the
+        cache is keyed by provider name, which every user of their own key would
+        share, so caching would hand one user's client — and their API key — to
+        the next request that named the same provider.
+        """
         if isinstance(capabilities, str):
             capabilities = [capabilities]
         cache_key = (provider, tuple(capabilities), tuple(sorted(kwargs.items())))
-        if cache_key in self._chat_cache:
+        if not user_llm and cache_key in self._chat_cache:
             return self._chat_cache[cache_key]
 
-        info = self.resolve_model(provider, capabilities)
+        info = self.resolve_model(provider, capabilities, user_llm)
         if not info:
             return None
 
@@ -259,7 +325,8 @@ class LLMManager:
         else:
             llm = ChatOpenAI(api_key=api_key, model=model_id, **kwargs)
 
-        self._chat_cache[cache_key] = llm
+        if not user_llm:
+            self._chat_cache[cache_key] = llm
         return llm
 
     def build_embeddings(self, provider: str):

--- a/seer/libs/localtypes.py
+++ b/seer/libs/localtypes.py
@@ -36,6 +36,19 @@ class UserLLM(BaseModel):
     __str__ = __repr__
 
 
+class ImageGenerationRequest(BaseModel):
+    """A plain image-generation request: the prompt is used as written."""
+
+    prompt: str  # the prompt, exactly as the caller wrote it
+    model: str  # provider name
+    size: Optional[str] = None  # e.g. "1024x1024"; None uses the default
+    userllm: Optional[UserLLM] = None  # reserved; imagegen is config-only today
+
+
+class ImageGenerationResponse(BaseModel):
+    imageUrl: str  # the generated image as a data URL
+
+
 class Context(BaseModel):
     previousQ: List[str]  # previous prompt
     previousA: List[str]  # previous answer

--- a/seer/libs/localtypes.py
+++ b/seer/libs/localtypes.py
@@ -7,11 +7,33 @@
 # -----------------------------------------------------------------------------
 
 # Models
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel, Json
 import io
 
 # Pydantic models: Question, Answer, Context
+
+
+class UserLLM(BaseModel):
+    """A user's own OpenAI-compatible credentials, supplied per request.
+
+    Present only when the request's `model` field names the user's own provider
+    (`my-own-key`); absent for the server's configured providers. Used for that
+    single request and never stored. `apiKey` is a bearer secret: it must be
+    redacted before any request is logged.
+    """
+
+    apiKey: str  # the user's API key, valid for this request only
+    baseUrl: Optional[str] = None  # OpenAI-compatible base URL; None = OpenAI
+    modelId: str  # the model to call, e.g. gpt-4o
+
+    def __repr__(self) -> str:
+        # Defence in depth: any log line that interpolates a request object
+        # prints this instead of the key. Does not affect model_dump(), which
+        # is what the manager reads to build the client.
+        return f"UserLLM(apiKey='***', baseUrl={self.baseUrl!r}, modelId={self.modelId!r})"
+
+    __str__ = __repr__
 
 
 class Context(BaseModel):
@@ -29,6 +51,7 @@ class Question(BaseModel):
     user: str  # user name
     location: str  # location
     model: str  # AI model: llama, openai, azure
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
     appIds: List[str] = []  # source apps whose content to read server-side
     intent: str = ""  # optional prompt template: summary|proscons|keywords|opinion|facts
 
@@ -47,6 +70,7 @@ class CodeRequest(BaseModel):
     user: str  # user name
     location: str  # location
     model: str  # AI model: llama, openai, azure
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
     method: str
     appIds: List[str] = []  # source CodeEditor apps to read server-side
 
@@ -63,6 +87,7 @@ class ImageQuery(BaseModel):
     assets: List[str]  # one or more image assets
     user: str  # user name
     model: str  # AI model: llama, openai, azure
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
     q: str  # question
 
 
@@ -97,6 +122,7 @@ class PDFQuery(BaseModel):
     assetids: List[str]  # pdfs in sage
     user: str  # user name
     model: str  # AI model: openai, azure
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
     q: str  # question
 
 
@@ -111,6 +137,7 @@ class WebQuery(BaseModel):
     url: str  # question
     user: str  # user name
     model: str  # AI model: llama, openai, azure
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
     q: str  # question
     extras: str  # extra request data: 'links' | 'text' | 'images' | 'pdfs'
 
@@ -156,6 +183,7 @@ class IdeatorDimensionsRequest(BaseModel):
     prompt: str
     numDims: int
     model: str
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
     imageBase64: str | None = None
     pdfContext: str | None = None
 
@@ -170,6 +198,7 @@ class IdeatorNodeRequest(BaseModel):
     prompt: str
     requirements: str
     model: str
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
     imageBase64: str | None = None
     pdfContext: str | None = None
 
@@ -182,6 +211,7 @@ class IdeatorNodeResponse(BaseModel):
 class IdeatorAbstractRequest(BaseModel):
     text: str
     model: str
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
     temperature: float = 0.0
 
 
@@ -198,6 +228,7 @@ class IdeatorUserDimensionRequest(BaseModel):
     prompt: str
     nodes: List[IdeatorNode]
     model: str
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
 
 
 class IdeatorUserDimensionResponse(BaseModel):
@@ -211,6 +242,7 @@ class IdeatorSummarizeRequest(BaseModel):
     nodes: List[IdeatorSummarizeNode]
     prompt: str
     model: str
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
 
 
 class IdeatorSummarizeResponse(BaseModel):
@@ -223,6 +255,7 @@ class IdeatorImageRequest(BaseModel):
     summary: str
     keywords: List[str]
     model: str
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
     brainstormingPrompt: str | None = None
     dimension: IdeatorDimension | None = None
     additionalContext: str | None = None
@@ -236,6 +269,7 @@ class IdeatorImageResponse(BaseModel):
 class IdeatorProseRequest(BaseModel):
     userPrompt: str
     model: str
+    userllm: Optional[UserLLM] = None  # the user's own credentials, when they chose their own provider
 
 
 class IdeatorProseResponse(BaseModel):

--- a/seer/main.py
+++ b/seer/main.py
@@ -8,6 +8,7 @@ from fluent import sender
 from libs.ai_logging import initFluent
 
 
+from app.imagegen import ImageGenAgent
 from libs.localtypes import (
     ImageQuery,
     Question,
@@ -22,6 +23,7 @@ from libs.localtypes import (
     IdeatorUserDimensionRequest,
     IdeatorSummarizeRequest,
     IdeatorImageRequest,
+    ImageGenerationRequest,
     IdeatorProseRequest,
 )
 
@@ -68,6 +70,7 @@ mesonetAG = None
 pdfAG = None
 webAG = None
 ideatorAG = None
+imagegenAG = None
 
 # Set to debug the queries into langchain
 # set_debug(True)
@@ -86,7 +89,7 @@ ideatorAG = None
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global chatAG, codeAG, imageAG, mesonetAG, pdfAG, webAG, ideatorAG
+    global chatAG, codeAG, imageAG, mesonetAG, pdfAG, webAG, ideatorAG, imagegenAG
 
     logger.info("FastAPI App started")
     web_config = getModelsInfo(ps3)
@@ -101,6 +104,7 @@ async def lifespan(app: FastAPI):
     pdfAG = PDFAgent(logger, ps3)
     webAG = WebAgent(logger, ps3)
     ideatorAG = IdeatorAgent(logger, ps3)
+    imagegenAG = ImageGenAgent(logger, ps3)
 
     await webAG.init()
     yield
@@ -313,13 +317,22 @@ async def ideator_summarize(qq: IdeatorSummarizeRequest):
 
 
 @app.post("/image-generation")
+async def image_generation(qq: ImageGenerationRequest):
+    """Generic image generation: the prompt is used as the caller wrote it."""
+    try:
+        return await asyncio.wait_for(imagegenAG.generate(qq), timeout=60)
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=408, detail="Image generation timed out")
+
+
+@app.post("/ideator/image")
 async def ideator_image(qq: IdeatorImageRequest):
+    """SageIdeator's image call: composes a brainstorming prompt from ideator
+    concepts, then generates. Only meaningful inside SageIdeator."""
     try:
         return await asyncio.wait_for(ideatorAG.image(qq), timeout=60)
     except asyncio.TimeoutError:
         raise HTTPException(status_code=408, detail="Image generation timed out")
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
 
 
 @app.post("/prose")

--- a/seer/main.py
+++ b/seer/main.py
@@ -8,7 +8,6 @@ from fluent import sender
 from libs.ai_logging import initFluent
 
 
-from app.imagegen import ImageGenAgent
 from libs.localtypes import (
     ImageQuery,
     Question,
@@ -53,6 +52,7 @@ from langchain.globals import set_debug, set_verbose
 # Modules
 from app.chat import ChatAgent
 from app.ideator import IdeatorAgent
+from app.imagegen import ImageGenAgent
 
 # from app.summary import SummaryAgent
 from app.web import WebAgent

--- a/seer/main.py
+++ b/seer/main.py
@@ -26,7 +26,8 @@ from libs.localtypes import (
 )
 
 # Web API
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 import uvicorn
 
 load_dotenv()  # take environment variables from .env.
@@ -112,6 +113,30 @@ app = FastAPI(
     description="A LangChain proxy for SAGE3.",
     version="0.1.0",
 )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    """Log the full traceback and return the actual error to the caller.
+
+    Without this an uncaught error becomes a bare 500 with no detail and no
+    traceback anywhere, which is indistinguishable from every other 500.
+    """
+    logger.exception(f"Unhandled error on {request.method} {request.url.path}")
+    return JSONResponse(
+        status_code=500,
+        content={"detail": f"{type(exc).__name__}: {exc}"},
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    """Keep the status code the handler chose instead of flattening it to 500,
+    and log it so refusals (bad provider, missing capability) are visible."""
+    logger.warning(
+        f"HTTP {exc.status_code} on {request.method} {request.url.path}: {exc.detail}"
+    )
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
 
 

--- a/webstack/apps/homebase/src/api/routers/custom/agent-router.ts
+++ b/webstack/apps/homebase/src/api/routers/custom/agent-router.ts
@@ -41,6 +41,8 @@ import {
   IdeatorProseRequest,
   IdeatorProseResponse,
   ImageGenerationRoutes,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
 } from '@sage3/shared';
 
 // Define a general RPC handler type
@@ -121,6 +123,9 @@ const ideatorUserDimensionHandler: RpcHandlerPost<IdeatorUserDimensionRequest, I
 const ideatorSummarizeHandler: RpcHandlerPost<IdeatorSummarizeRequest, IdeatorSummarizeResponse> = (req) =>
   fetchPost(`${config.agents.url}${IdeatorRoutes.summarize}`, req);
 const ideatorImageHandler: RpcHandlerPost<IdeatorImageRequest, IdeatorImageResponse> = (req) =>
+  fetchPost(`${config.agents.url}/ideator${IdeatorRoutes.image}`, req);
+// Generic image generation: the prompt is used as the caller wrote it
+const imageGenerationHandler: RpcHandlerPost<ImageGenerationRequest, ImageGenerationResponse> = (req) =>
   fetchPost(`${config.agents.url}${ImageGenerationRoutes.generate}`, req);
 const ideatorProseHandler: RpcHandlerPost<IdeatorProseRequest, IdeatorProseResponse> = (req) =>
   fetchPost(`${config.agents.url}${IdeatorRoutes.prose}`, req);
@@ -144,6 +149,8 @@ handlers[`/ideator${IdeatorRoutes.userDimension}`] = { func: ideatorUserDimensio
 handlers[`/ideator${IdeatorRoutes.summarize}`] = { func: ideatorSummarizeHandler, method: 'POST' };
 handlers[`/ideator${IdeatorRoutes.image}`] = { func: ideatorImageHandler, method: 'POST' };
 handlers[`/ideator${IdeatorRoutes.prose}`] = { func: ideatorProseHandler, method: 'POST' };
+// Generic image generation, available to any app (not ideator-specific)
+handlers[ImageGenerationRoutes.generate] = { func: imageGenerationHandler, method: 'POST' };
 
 /*
  * Create an express router for the agent API

--- a/webstack/libs/applications/src/lib/apps/Chat/Chat.tsx
+++ b/webstack/libs/applications/src/lib/apps/Chat/Chat.tsx
@@ -42,7 +42,7 @@ import {
   useAssetStore,
   apiUrls,
   useConfigStore,
-  seerIdeator,
+  seerImage,
   dataURLtoBlob,
   withUserProvider,
 } from '@sage3/frontend';
@@ -1213,7 +1213,7 @@ function AppComponent(props: App): JSX.Element {
       return;
     }
     const label = 'Generate an image from the text';
-    const [firstLine, ...rest] = text.split('\n').filter((l) => l.trim());
+    const [firstLine] = text.split('\n').filter((l) => l.trim());
     const now = await serverTime();
     const placeholder = {
       id: genId(),
@@ -1227,10 +1227,11 @@ function AppComponent(props: App): JSX.Element {
     updateState(props._id, { ...s, messages: [...s.messages, placeholder] });
     setProcessing(true);
     try {
-      const result = await seerIdeator.image({
-        title: (firstLine ?? text).slice(0, 80),
-        summary: (rest.join(' ') || firstLine || text).slice(0, 600),
-        keywords: [],
+      // Generic image generation: the linked text becomes the prompt as-is.
+      // The Ideator's image call is not used here — it composes a
+      // brainstorming-specific prompt that is only meaningful in SageIdeator.
+      const result = await seerImage.generate({
+        prompt: text.slice(0, 1000),
         model: selectedModel || '',
       });
       if ('message' in result) throw new Error(result.message);

--- a/webstack/libs/applications/src/lib/apps/Chat/Chat.tsx
+++ b/webstack/libs/applications/src/lib/apps/Chat/Chat.tsx
@@ -55,6 +55,7 @@ import { AppWindow } from '../../components';
 
 import { callImage, callPDF, callAsk, callCode, callWeb, callWebshot, callMesonet } from './tRPC';
 import { OperationMode, MODE_TASK, MAX_IMAGES, MAX_PDFS } from './constants';
+import { parseCommand, commandHelp, ParsedCommand } from './commands';
 import { ToolbarComponent, GroupedToolbarComponent } from './Toolbar';
 import { MessageItem } from './MessageItem';
 import { PromptBars } from './PromptBars';
@@ -173,8 +174,59 @@ function AppComponent(props: App): JSX.Element {
     setInput(value);
   };
 
+  /**
+   * Run a slash command. Commands act for the person who typed them: their
+   * results go to a toast or to the board, not into the shared transcript.
+   */
+  const runCommand = async (parsed: ParsedCommand) => {
+    const { command, args } = parsed;
+
+    if (command.name === '/help') {
+      toast({ title: 'Chat commands', description: commandHelp(), status: 'info', duration: 8000, isClosable: true });
+      return;
+    }
+
+    if (command.name === '/image') {
+      if (!args) {
+        toast({
+          title: 'Describe the image',
+          description: command.usage,
+          status: 'warning',
+          duration: 4000,
+          isClosable: true,
+        });
+        return;
+      }
+      // canPerform reports an uncapable model; generateImage re-checks too
+      if (command.task && !canPerform(command.task)) return;
+      await generateImage(args, args);
+      return;
+    }
+  };
+
   const sendMessage = async () => {
     const text = input.trim();
+
+    // Slash commands are handled locally and never posted to the shared
+    // transcript: their output is feedback for the person who typed them, not
+    // part of the conversation everyone sees.
+    const parsed = parseCommand(text);
+    if (parsed === 'unknown') {
+      toast({
+        title: `Unknown command "${text.split(/\s+/)[0]}"`,
+        description: commandHelp(),
+        status: 'warning',
+        duration: 6000,
+        isClosable: true,
+      });
+      return;
+    }
+    if (parsed) {
+      setInput('');
+      await runCommand(parsed);
+      return;
+    }
+
     setInput('');
     if (mode === 'image') {
       // Image
@@ -1202,17 +1254,35 @@ function AppComponent(props: App): JSX.Element {
   // Generate an image from the linked text app (e.g. a Stickie): the text is
   // sent to the image-generation endpoint, the result is uploaded as an asset,
   // and an ImageViewer is placed next to the chat window.
+  /** The "Generate Image" prompt button: illustrate the linked text. */
   const onImageGeneration = async () => {
-    if (!user || processing) return;
-    if (!canPerform('image_generation')) return;
     const apps = useAppStore.getState().apps.filter((app) => sourceApps.includes(app._id));
     const textApp = apps.find((a) => typeof (a.data.state as { text?: string }).text === 'string');
     const text = ((textApp?.data.state as { text?: string })?.text ?? s.context ?? '').trim();
     if (!text) {
-      toast({ title: 'No text to illustrate', description: 'Link a Stickie with some text first.', status: 'warning', duration: 4000, isClosable: true });
+      toast({
+        title: 'No text to illustrate',
+        description: 'Link a Stickie with some text first, or type /image <description>.',
+        status: 'warning',
+        duration: 4000,
+        isClosable: true,
+      });
       return;
     }
-    const label = 'Generate an image from the text';
+    await generateImage(text, 'Generate an image from the text');
+  };
+
+  /**
+   * Generate an image from `text`, used as the prompt as written.
+   *
+   * Shared by the "Generate Image" prompt button (which illustrates a linked
+   * Stickie) and the /image command (where the typed text is the prompt), so
+   * both take the same path through generation, upload and window creation.
+   */
+  const generateImage = async (text: string, label: string) => {
+    if (!user || processing) return;
+    if (!canPerform('image_generation')) return;
+    if (!text) return;
     const [firstLine] = text.split('\n').filter((l) => l.trim());
     const now = await serverTime();
     const placeholder = {
@@ -1567,7 +1637,7 @@ function AppComponent(props: App): JSX.Element {
         {/* Input Text */}
         <InputGroup bg={'blackAlpha.100'} maxHeight={'120px'}>
           <Textarea
-            placeholder={'Chat with friends or ask SAGE with @S' + (selectedModel ? ' (' + selectedModel + ' model)' : '')}
+            placeholder={'Chat, ask SAGE with @S, or type / for commands' + (selectedModel ? ' (' + selectedModel + ' model)' : '')}
             size="md"
             variant="outline"
             _placeholder={{ color: 'inherit' }}

--- a/webstack/libs/applications/src/lib/apps/Chat/Chat.tsx
+++ b/webstack/libs/applications/src/lib/apps/Chat/Chat.tsx
@@ -44,6 +44,7 @@ import {
   useConfigStore,
   seerIdeator,
   dataURLtoBlob,
+  withUserProvider,
 } from '@sage3/frontend';
 import { genId, AskRequest, ImageQuery, PDFQuery, CodeRequest, WebQuery, WebScreenshot, isGeoJSON } from '@sage3/shared';
 import { LLMConfigManager, TaskType } from '@sage3/shared/types';
@@ -104,7 +105,11 @@ function AppComponent(props: App): JSX.Element {
   // AI capability config (no secrets) used to gate requests by capability.
   // Built from the server config; the manager mirrors the backend's matching.
   const serverConfig = useConfigStore((state) => state.config);
-  const llmManager = useMemo(() => (serverConfig?.models ? new LLMConfigManager(serverConfig.models) : undefined), [serverConfig]);
+  const llmManager = useMemo(
+    // Include the user's own provider so its capabilities gate tasks like any other
+    () => (serverConfig?.models ? new LLMConfigManager(withUserProvider(serverConfig.models)) : undefined),
+    [serverConfig]
+  );
 
   // Input text for query
   const [input, setInput] = useState<string>('');

--- a/webstack/libs/applications/src/lib/apps/Chat/commands.ts
+++ b/webstack/libs/applications/src/lib/apps/Chat/commands.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+// Slash commands typed into the chat box.
+//
+// A command names an operation the message should go to, instead of the mode
+// being inferred from the linked source app. Adding a command is a matter of
+// adding a row to COMMANDS: the parser, the unknown-command help, and the
+// `/help` listing are all driven from this table.
+
+import { TaskType } from '@sage3/shared/types';
+
+export type ChatCommand = {
+  /** The command as typed, without arguments. Always lower case. */
+  name: string;
+  /** Alternative spellings, also lower case. */
+  aliases?: string[];
+  /** One line, shown by `/help` and when an unknown command is typed. */
+  description: string;
+  /** How the argument is described in help, e.g. "/image <description>". */
+  usage: string;
+  /**
+   * The AI task this command performs, so the caller can check the selected
+   * model's capabilities before sending. Omitted for commands that are purely
+   * local (help), which need no model.
+   */
+  task?: TaskType;
+};
+
+export const COMMANDS: ChatCommand[] = [
+  {
+    name: '/image',
+    aliases: ['/img', '/draw'],
+    description: 'Generate an image from a description',
+    usage: '/image <description>',
+    task: 'image_generation',
+  },
+  {
+    name: '/help',
+    aliases: ['/?'],
+    description: 'List the available commands',
+    usage: '/help',
+  },
+];
+
+export type ParsedCommand = {
+  /** The matched command. */
+  command: ChatCommand;
+  /** Everything after the command word, trimmed. May be empty. */
+  args: string;
+};
+
+/**
+ * Parse a chat input as a slash command.
+ *
+ * Returns the matched command and its arguments; `'unknown'` when the text
+ * looks like a command but names none; and `null` when it is an ordinary
+ * message. Distinguishing "unknown" from "not a command" is what lets the
+ * caller answer a typo with the command list instead of posting `/imagg` to
+ * everyone in the conversation.
+ */
+export function parseCommand(input: string): ParsedCommand | 'unknown' | null {
+  const text = input.trim();
+  // A bare "/" or text not starting with one is an ordinary message
+  if (!text.startsWith('/') || text.length < 2) return null;
+
+  const [word, ...rest] = text.split(/\s+/);
+  const name = word.toLowerCase();
+  const command = COMMANDS.find((c) => c.name === name || c.aliases?.includes(name));
+  if (!command) return 'unknown';
+  return { command, args: rest.join(' ').trim() };
+}
+
+/** The command list, formatted for display in the transcript. */
+export function commandHelp(): string {
+  return COMMANDS.map(
+    (c) => `${c.usage} — ${c.description}${c.aliases?.length ? ` (also ${c.aliases.join(', ')})` : ''}`
+  ).join('\n');
+}

--- a/webstack/libs/applications/src/lib/apps/Chat/tRPC.ts
+++ b/webstack/libs/applications/src/lib/apps/Chat/tRPC.ts
@@ -9,7 +9,7 @@
 // Ky for HTTP requests
 import ky, { HTTPError } from 'ky';
 
-import { apiUrls } from '@sage3/frontend';
+import { apiUrls, withUserCredentials, toSError } from '@sage3/frontend';
 import {
   SError,
   AgentRoutes,
@@ -37,15 +37,16 @@ import {
 const makeRpcPost = async (mth: string, data: object) => {
   try {
     const base = apiUrls.ai.agents.base;
-    const response = await ky.post<Response>(`${base}${mth}`, { json: data, timeout: 120 * 1000 }).json();
+    // withUserCredentials attaches the user's own key only when the request
+    // names their own provider; every other request is sent unchanged
+    const response = await ky.post<Response>(`${base}${mth}`, { json: withUserCredentials(data), timeout: 120 * 1000 }).json();
     return response;
   } catch (e) {
     const error = e as HTTPError<Response>;
     if (error.name === 'HTTPError') {
-      const err: SError = await error.response.json();
-      return err;
+      return await toSError(error);
     } else {
-      return { message: 'Unknown error' };
+      return { message: e instanceof Error ? e.message : 'Unknown error' };
     }
   }
 };
@@ -57,10 +58,9 @@ const makeRpcGet = async (mth: string) => {
   } catch (e) {
     const error = e as HTTPError<Response>;
     if (error.name === 'HTTPError') {
-      const err: SError = await error.response.json();
-      return err;
+      return await toSError(error);
     } else {
-      return { message: 'Unknown error' };
+      return { message: e instanceof Error ? e.message : 'Unknown error' };
     }
   }
 };

--- a/webstack/libs/applications/src/lib/apps/SageIdeator/useAiProvider.ts
+++ b/webstack/libs/applications/src/lib/apps/SageIdeator/useAiProvider.ts
@@ -8,7 +8,7 @@
 
 import { useMemo } from 'react';
 
-import { useConfigStore, useUserSettings } from '@sage3/frontend';
+import { useConfigStore, useUserSettings, withUserProvider } from '@sage3/frontend';
 import { LLMConfigManager } from '@sage3/shared/types';
 
 /**
@@ -19,7 +19,11 @@ import { LLMConfigManager } from '@sage3/shared/types';
  */
 export function useAiProvider() {
   const serverConfig = useConfigStore((state) => state.config);
-  const llmManager = useMemo(() => (serverConfig?.models ? new LLMConfigManager(serverConfig.models) : undefined), [serverConfig]);
+  const llmManager = useMemo(
+    // Include the user's own provider so its capabilities gate tasks like any other
+    () => (serverConfig?.models ? new LLMConfigManager(withUserProvider(serverConfig.models)) : undefined),
+    [serverConfig]
+  );
   const { settings } = useUserSettings();
   const aiProvider = settings.aiModel || serverConfig?.models?.settings?.default_provider || '';
   return { aiProvider, llmManager };

--- a/webstack/libs/frontend/src/lib/api/seer.ts
+++ b/webstack/libs/frontend/src/lib/api/seer.ts
@@ -9,6 +9,7 @@
 import ky, { HTTPError } from 'ky';
 
 import { apiUrls } from '../config/urls';
+import { USER_PROVIDER_NAME, userLLMPayload } from '../utils/userllm';
 import {
   SError,
   AgentRoutes,
@@ -45,19 +46,52 @@ import {
 const AGENT_TIMEOUT_MS = 120 * 1000;
 const IDEATOR_TIMEOUT_MS = 60 * 1000;
 
+/**
+ * Attach the user's own credentials when — and only when — the request names
+ * their own provider. Every request carries a `model` field holding a provider
+ * name; if it is anything other than the user's own, the payload is returned
+ * untouched, so requests against server-configured providers are unchanged.
+ */
+export function withUserCredentials<T extends object>(data: T): T {
+  if ((data as { model?: string }).model !== USER_PROVIDER_NAME) return data;
+  const userllm = userLLMPayload();
+  // Selected but no credentials stored: send as-is and let the backend report
+  // the failure rather than silently pretending a different provider was meant
+  if (!userllm) return data;
+  return { ...data, userllm };
+}
+
+/**
+ * Turn a failed response into a readable SError.
+ *
+ * The backend reports failures as `{ detail: ... }` (FastAPI's convention)
+ * while SError carries `message`, so reading only `message` silently discards
+ * the reason and leaves the caller with a bare status code.
+ */
+export async function toSError(error: HTTPError<Response>): Promise<SError> {
+  try {
+    const body = (await error.response.json()) as { message?: string; detail?: unknown };
+    const detail = typeof body?.detail === 'string' ? body.detail : body?.detail ? JSON.stringify(body.detail) : undefined;
+    const message = body?.message || detail;
+    if (message) return { message };
+  } catch (e) {
+    // Body was not JSON — fall through to the status line
+  }
+  return { message: `${error.response.status} ${error.response.statusText}`.trim() };
+}
+
 async function agentPost<T>(path: string, data: object, timeoutMs = AGENT_TIMEOUT_MS, signal?: AbortSignal): Promise<T | SError> {
   try {
-    return await ky.post<T>(path, { json: data, timeout: timeoutMs, signal }).json();
+    return await ky.post<T>(path, { json: withUserCredentials(data), timeout: timeoutMs, signal }).json();
   } catch (e) {
     if (e instanceof Error && e.name === 'AbortError') {
       return { message: 'Cancelled' };
     }
     const error = e as HTTPError<Response>;
     if (error.name === 'HTTPError') {
-      const err: SError = await error.response.json();
-      return err;
+      return await toSError(error);
     }
-    return { message: 'Unknown error' };
+    return { message: e instanceof Error ? e.message : 'Unknown error' };
   }
 }
 
@@ -67,10 +101,9 @@ async function agentGet<T>(path: string): Promise<T | SError> {
   } catch (e) {
     const error = e as HTTPError<Response>;
     if (error.name === 'HTTPError') {
-      const err: SError = await error.response.json();
-      return err;
+      return await toSError(error);
     }
-    return { message: 'Unknown error' };
+    return { message: e instanceof Error ? e.message : 'Unknown error' };
   }
 }
 

--- a/webstack/libs/frontend/src/lib/api/seer.ts
+++ b/webstack/libs/frontend/src/lib/api/seer.ts
@@ -41,6 +41,9 @@ import {
   IdeatorImageResponse,
   IdeatorProseRequest,
   IdeatorProseResponse,
+  ImageGenerationRoutes,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
 } from '@sage3/shared';
 
 const AGENT_TIMEOUT_MS = 120 * 1000;
@@ -118,6 +121,23 @@ export const seerAgents = {
   image: (data: ImageQuery) => agentPost<ImageAnswer>(`${apiUrls.ai.agents.base}${AgentRoutes.image}`, data),
   pdf: (data: PDFQuery) => agentPost<PDFAnswer>(`${apiUrls.ai.agents.base}${AgentRoutes.pdf}`, data),
   mesonet: (data: MesonetRequest) => agentPost<MesonetResponse>(`${apiUrls.ai.agents.base}${AgentRoutes.mesonet}`, data),
+};
+
+// ─── Image generation ─────────────────────────────────────────────────────────
+
+/**
+ * Generic image generation, for any app that wants an image. The prompt is
+ * sent as written. SageIdeator's brainstorming-specific image call is
+ * seerIdeator.image below, and is not for general use.
+ */
+export const seerImage = {
+  generate: (data: ImageGenerationRequest, signal?: AbortSignal) =>
+    agentPost<ImageGenerationResponse>(
+      `${apiUrls.ai.agents.base}${ImageGenerationRoutes.generate}`,
+      data,
+      IDEATOR_TIMEOUT_MS,
+      signal
+    ),
 };
 
 // ─── Ideator endpoints ────────────────────────────────────────────────────────

--- a/webstack/libs/frontend/src/lib/ui/components/modals/EditUserSettingsModal.tsx
+++ b/webstack/libs/frontend/src/lib/ui/components/modals/EditUserSettingsModal.tsx
@@ -35,14 +35,30 @@ import {
   TabPanel,
   useColorMode,
   HStack,
+  Input,
+  InputGroup,
+  InputRightElement,
+  IconButton,
+  FormHelperText,
+  useToast,
 } from '@chakra-ui/react';
-import { MdInfo } from 'react-icons/md';
+import { MdInfo, MdVisibility, MdVisibilityOff } from 'react-icons/md';
 
 // SAGE Imports
 import { LLMConfiguration, LLMConfigManager, TaskType, TASK_TYPES } from '@sage3/shared/types';
-import { useUserSettings } from '../../../providers';
+import { useUserSettings, useUser } from '../../../providers';
 import { useConfigStore } from '../../../stores';
-import { isElectron } from '../../../utils';
+import {
+  isElectron,
+  getUserLLM,
+  setUserLLM,
+  clearUserLLM,
+  maskApiKey,
+  fetchAvailableModels,
+  withUserProvider,
+  USER_PROVIDER_NAME,
+  USER_MODEL_CAPABILITIES,
+} from '../../../utils';
 
 interface EditUserSettingsModalProps {
   isOpen: boolean;
@@ -99,17 +115,159 @@ export function EditUserSettingsModal(props: EditUserSettingsModalProps): JSX.El
   const [selectedModel, setSelectedModel] = useState(userSettings.aiModel);
   const [manager, setManager] = useState<LLMConfigManager>();
 
+  // The user's own OpenAI-compatible credentials, held in this browser only.
+  // Guests and spectators may not supply one: they are transient, unverified
+  // accounts, and a key pasted into a shared guest session would outlive the
+  // person who pasted it. They keep using the hub's configured providers.
+  const { user } = useUser();
+  const userRole = user?.data.userRole;
+  const canUseOwnKey = userRole !== 'guest' && userRole !== 'spectator';
+  const toast = useToast();
+  const [userKey, setUserKey] = useState('');
+  const [userBaseUrl, setUserBaseUrl] = useState('');
+  const [userModelId, setUserModelId] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  // The credentials as last saved, so the form can show what is stored
+  const [savedUserLLM, setSavedUserLLM] = useState(() => getUserLLM());
+  // Models offered by the endpoint, looked up whenever the key or URL changes
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
+  const [modelsError, setModelsError] = useState('');
+
+  // Load the stored credentials into the form each time the modal opens
+  useEffect(() => {
+    if (!props.isOpen) return;
+    if (!canUseOwnKey) {
+      // A key left behind by a previous account in this browser must not be
+      // usable by a guest: drop it rather than merely hiding the form
+      clearUserLLM();
+      setSavedUserLLM(undefined);
+      return;
+    }
+    const stored = getUserLLM();
+    setSavedUserLLM(stored);
+    setUserBaseUrl(stored?.baseUrl ?? '');
+    setUserModelId(stored?.modelId ?? '');
+    // The key itself is never put back on screen — only its masked form is shown
+    setUserKey('');
+    setShowKey(false);
+  }, [props.isOpen, canUseOwnKey]);
+
+  // Look up the endpoint's models whenever the key or the base URL changes.
+  // Typing is debounced so a request is not made per keystroke, and any lookup
+  // already in flight is aborted the moment either value changes again.
+  useEffect(() => {
+    if (!props.isOpen || !canUseOwnKey) return;
+    // An untouched key field means "keep the saved key", so look that one up
+    const key = userKey.trim() || savedUserLLM?.apiKey || '';
+    if (!key) {
+      setAvailableModels([]);
+      setModelsError('');
+      setModelsLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setModelsLoading(true);
+    setModelsError('');
+
+    const timer = setTimeout(() => {
+      fetchAvailableModels(key, userBaseUrl, controller.signal)
+        .then((ids) => {
+          setAvailableModels(ids);
+          setModelsLoading(false);
+        })
+        .catch((e: unknown) => {
+          // A cancelled lookup is not a failure: a newer one has replaced it
+          if (e instanceof DOMException && e.name === 'AbortError') return;
+          setAvailableModels([]);
+          // Drop the model too: it belonged to an endpoint we could not reach,
+          // so leaving it in place would suggest a choice that was confirmed
+          setUserModelId('');
+          setModelsError(e instanceof Error ? e.message : 'Lookup failed');
+          setModelsLoading(false);
+        });
+    }, 600);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [userKey, userBaseUrl, canUseOwnKey, props.isOpen, savedUserLLM]);
+
+  const handleSaveUserLLM = () => {
+    if (!canUseOwnKey) return;
+    const key = userKey.trim();
+    const modelId = userModelId.trim();
+    // Re-saving without retyping the key keeps the stored one
+    const effectiveKey = key || savedUserLLM?.apiKey || '';
+    if (!effectiveKey) {
+      toast({ title: 'Enter an API key', status: 'warning', duration: 3000, isClosable: true });
+      return;
+    }
+    if (!modelId) {
+      toast({
+        title: availableModels.length > 0 ? 'Select a model' : 'Enter a model name',
+        status: 'warning',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+    try {
+      setUserLLM({ apiKey: effectiveKey, baseUrl: userBaseUrl, modelId });
+      setSavedUserLLM(getUserLLM());
+      setUserKey('');
+      setShowKey(false);
+      // Configuring it is the act of choosing it: select it rather than
+      // leaving the user to click the radio that was disabled until now
+      setSelectedModel(USER_PROVIDER_NAME);
+      setAIModel(USER_PROVIDER_NAME);
+      toast({ title: 'Key saved — now using your own key', status: 'success', duration: 3000, isClosable: true });
+    } catch (e) {
+      toast({ title: 'Could not save the key', status: 'error', duration: 4000, isClosable: true });
+    }
+  };
+
+  const handleClearUserLLM = () => {
+    clearUserLLM();
+    setSavedUserLLM(undefined);
+    setUserKey('');
+    setUserBaseUrl('');
+    setUserModelId('');
+    setAvailableModels([]);
+    setModelsError('');
+    setModelsLoading(false);
+    setShowKey(false);
+    // Fall back to a server provider if this one was selected
+    if (selectedModel === USER_PROVIDER_NAME) {
+      const fallback = Object.keys(models?.providers || {})[0] || '';
+      setSelectedModel(fallback);
+      setAIModel(fallback);
+    }
+    toast({ title: 'Key removed from this browser', status: 'info', duration: 3000, isClosable: true });
+  };
+
   useEffect(() => {
     if (config) {
       setModels(config.models);
-      const mgr = new LLMConfigManager(config.models);
-      setManager(mgr);
+      // Include the user's own provider so its tasks are computed the same way
+      setManager(new LLMConfigManager(withUserProvider(config.models)));
     }
-  }, [config]);
+  }, [config, savedUserLLM]);
 
   useEffect(() => {
     // Wait for the provider list to load before validating the saved model
     if (!models) return;
+    // The user's own key is not a server provider, so validate it separately:
+    // it stays selected as long as credentials are stored in this browser
+    if (userSettings.aiModel === USER_PROVIDER_NAME) {
+      if (savedUserLLM) {
+        setSelectedModel(USER_PROVIDER_NAME);
+        return;
+      }
+      // Credentials were cleared elsewhere: fall through to a server provider
+    }
     const providerKeys = Object.keys(models.providers || {});
     if (userSettings.aiModel && providerKeys.includes(userSettings.aiModel)) {
       // Saved provider still exists in the config: keep it
@@ -121,7 +279,7 @@ export function EditUserSettingsModal(props: EditUserSettingsModalProps): JSX.El
       setSelectedModel(val);
       setAIModel(val);
     }
-  }, [userSettings.aiModel, models]);
+  }, [userSettings.aiModel, models, savedUserLLM]);
 
   return (
     <Modal
@@ -134,7 +292,7 @@ export function EditUserSettingsModal(props: EditUserSettingsModalProps): JSX.El
       size="xl"
     >
       <ModalOverlay />
-      <ModalContent height={"550px"}>
+      <ModalContent height={'650px'}>
         <ModalHeader fontSize="3xl" pb="0">
           User Settings
         </ModalHeader>
@@ -247,54 +405,200 @@ export function EditUserSettingsModal(props: EditUserSettingsModalProps): JSX.El
               </TabPanel>
 
               <TabPanel>
-                <VStack>
-                  <VStack p={1} pt={1} w="100%" align={'left'}>
-                    <Text fontSize="lg" mb={1} fontWeight={'bold'}>
-                      AI Providers and Models
-                    </Text>
-                    <RadioGroup defaultValue={selectedModel} onChange={setAIModel} colorScheme="purple">
-                      <Stack maxHeight="300px" overflowY="auto">
-                        {models?.providers &&
-                          Object.entries(models.providers).map(([provider, providerData]) => {
-
-                            const availableTasks = manager
-                              ? TASK_TYPES.filter((task) => {
+                <VStack p={1} pt={1} w="100%" align={'left'}>
+                  <Text fontSize="lg" mb={1} fontWeight={'bold'}>
+                    AI Providers and Models
+                  </Text>
+                  {/* Controlled, so removing the key can move the selection off it */}
+                  <RadioGroup
+                    value={selectedModel}
+                    onChange={(val) => {
+                      setSelectedModel(val);
+                      setAIModel(val);
+                    }}
+                    colorScheme="purple"
+                  >
+                    <Stack maxHeight="400px" overflowY="auto">
+                      {models?.providers &&
+                        Object.entries(models.providers).map(([provider, providerData]) => {
+                          const availableTasks = manager
+                            ? TASK_TYPES.filter((task) => {
                                 const cando = manager.canProviderPerformTask(provider, task);
                                 return cando;
-                              }) : [];
+                              })
+                            : [];
 
-                            return (
-                              <VStack key={provider} align="start" spacing={1} p={1} borderWidth="1px" borderRadius="md" w="100%">
-                                <Radio value={provider}>
-                                  <Text fontWeight="bold">{provider}</Text>
-                                </Radio>
-                                {availableTasks.length > 0 && (
-                                  <Text pl={6} fontSize="sm" color={colorMode === 'light' ? 'gray.600' : 'gray.300'}>
-                                    Tasks enabled: {availableTasks.join(', ')}
+                          return (
+                            <VStack key={provider} align="start" spacing={1} p={1} borderWidth="1px" borderRadius="md" w="100%">
+                              <Radio value={provider}>
+                                <Text fontWeight="bold">{provider}</Text>
+                              </Radio>
+                              {availableTasks.length > 0 && (
+                                <Text pl={6} fontSize="sm" color={colorMode === 'light' ? 'gray.600' : 'gray.300'}>
+                                  Tasks enabled: {availableTasks.join(', ')}
+                                </Text>
+                              )}
+
+                              {providerData.models && (
+                                <VStack align="start" pl={8} spacing={1}>
+                                  {Object.entries(providerData.models).map(([modelName, modelData]) => (
+                                    <VStack key={modelName} align="start" spacing={0}>
+                                      <HStack>
+                                        {' '}
+                                        <Text fontSize="sm" fontWeight="semibold">
+                                          - {modelName}
+                                        </Text>
+                                        <Text fontSize="sm">({modelData.model_id})</Text>
+                                      </HStack>
+                                      {modelData.capabilities && (
+                                        <Text fontSize="sm" pl={2} color={colorMode === 'light' ? 'gray.600' : 'gray.300'}>
+                                          capabilities:{' '}
+                                          {Array.isArray(modelData.capabilities)
+                                            ? modelData.capabilities.join(', ')
+                                            : String(modelData.capabilities)}
+                                        </Text>
+                                      )}
+                                    </VStack>
+                                  ))}
+                                </VStack>
+                              )}
+                            </VStack>
+                          );
+                        })}
+
+                      {/* The user's own key: a provider in the list, with its
+                          form inline so it can be configured where it is chosen */}
+                      <VStack align="start" spacing={1} p={1} borderWidth="1px" borderRadius="md" w="100%">
+                        <Radio value={USER_PROVIDER_NAME} isDisabled={!canUseOwnKey || !savedUserLLM}>
+                          <Text fontWeight="bold">your own model</Text>
+                        </Radio>
+                        {savedUserLLM && manager && (
+                          <Text pl={6} fontSize="sm" color={colorMode === 'light' ? 'gray.600' : 'gray.300'}>
+                            Tasks enabled:{' '}
+                            {TASK_TYPES.filter((task) => manager.canProviderPerformTask(USER_PROVIDER_NAME, task)).join(', ')}
+                          </Text>
+                        )}
+
+                        {!canUseOwnKey ? (
+                          <Text pl={6} fontSize="sm" color={colorMode === 'light' ? 'gray.600' : 'gray.300'}>
+                            Guest accounts cannot add their own API key. Sign in with a full account to use one.
+                          </Text>
+                        ) : (
+                          <VStack align="start" spacing={2} pl={6} w="100%">
+                            <Text fontSize="sm" color={colorMode === 'light' ? 'gray.600' : 'gray.300'}>
+                              An OpenAI-compatible service billed to you. The key stays in this browser and is never stored on the SAGE3
+                              server.
+                            </Text>
+
+                            {savedUserLLM && (
+                              <VStack align="start" spacing={0}>
+                                <HStack>
+                                  <Text fontSize="sm" fontWeight="semibold">
+                                    - {savedUserLLM.modelId}
                                   </Text>
-                                )}
-
-
-                                {providerData.models && (
-                                  <VStack align="start" pl={8} spacing={1}>
-                                    {Object.entries(providerData.models).map(([modelName, modelData]) => (
-                                      <VStack key={modelName} align="start" spacing={0}>
-                                        <HStack> <Text fontSize="sm" fontWeight="semibold">- {modelName}</Text><Text fontSize="sm" >({modelData.model_id})</Text></HStack>
-                                        {modelData.capabilities && (
-                                          <Text fontSize="sm" pl={2} color={colorMode === 'light' ? "gray.600" : "gray.300"}>
-                                            capabilities: {Array.isArray(modelData.capabilities) ? modelData.capabilities.join(", ") : String(modelData.capabilities)}
-                                          </Text>
-                                        )}
-                                      </VStack>
-                                    ))}
-                                  </VStack>
-                                )}
+                                  <Text fontSize="sm">({maskApiKey(savedUserLLM.apiKey)})</Text>
+                                </HStack>
+                                <Text fontSize="sm" pl={2} color={colorMode === 'light' ? 'gray.600' : 'gray.300'}>
+                                  capabilities: {USER_MODEL_CAPABILITIES.join(', ')}
+                                </Text>
                               </VStack>
-                            );
-                          })}
-                      </Stack>
-                    </RadioGroup>
-                  </VStack>
+                            )}
+
+                            <FormControl>
+                              <FormLabel fontSize="sm" mb={1}>
+                                API key
+                              </FormLabel>
+                              <InputGroup size="sm">
+                                <Input
+                                  type={showKey ? 'text' : 'password'}
+                                  value={userKey}
+                                  onChange={(e) => setUserKey(e.target.value)}
+                                  placeholder={savedUserLLM ? 'Saved — leave blank to keep it' : 'sk-...'}
+                                  _placeholder={{ opacity: 1, color: 'gray.400' }}
+                                  autoComplete="off"
+                                  borderRadius="md"
+                                />
+                                <InputRightElement>
+                                  <IconButton
+                                    aria-label={showKey ? 'Hide key' : 'Show key'}
+                                    icon={showKey ? <MdVisibilityOff /> : <MdVisibility />}
+                                    size="xs"
+                                    variant="ghost"
+                                    onClick={() => setShowKey(!showKey)}
+                                  />
+                                </InputRightElement>
+                              </InputGroup>
+                            </FormControl>
+
+                            <FormControl>
+                              <FormLabel fontSize="sm" mb={1}>
+                                Base URL (optional)
+                              </FormLabel>
+                              <Input
+                                size="sm"
+                                value={userBaseUrl}
+                                onChange={(e) => setUserBaseUrl(e.target.value)}
+                                placeholder="https://api.openai.com/v1"
+                                autoComplete="off"
+                                borderRadius="md"
+                              />
+                              <FormHelperText fontSize="xs">Leave blank for OpenAI.</FormHelperText>
+                            </FormControl>
+
+                            <FormControl>
+                              <FormLabel fontSize="sm" mb={1}>
+                                Model
+                              </FormLabel>
+                              {availableModels.length > 0 ? (
+                                <Select
+                                  size="sm"
+                                  value={userModelId}
+                                  onChange={(e) => setUserModelId(e.target.value)}
+                                  placeholder="Select a model"
+                                  borderRadius="md"
+                                >
+                                  {availableModels.map((id) => (
+                                    <option key={id} value={id}>
+                                      {id}
+                                    </option>
+                                  ))}
+                                </Select>
+                              ) : (
+                                /* No list to choose from: let the model be typed
+                                   so endpoints without /models still work */
+                                <Input
+                                  size="sm"
+                                  value={userModelId}
+                                  onChange={(e) => setUserModelId(e.target.value)}
+                                  placeholder="gpt-4o"
+                                  autoComplete="off"
+                                  borderRadius="md"
+                                />
+                              )}
+                              <FormHelperText fontSize="xs">
+                                {modelsLoading
+                                  ? 'Checking the endpoint for available models…'
+                                  : modelsError
+                                    ? `${modelsError}. Type the model name instead.`
+                                    : availableModels.length > 0
+                                      ? `${availableModels.length} models at this endpoint. Assumed to handle chat, code, and vision.`
+                                      : 'Assumed to handle chat, code, and vision. Image generation is not available.'}
+                              </FormHelperText>
+                            </FormControl>
+
+                            <HStack spacing={2} pb={1}>
+                              <Button size="sm" colorScheme="purple" onClick={handleSaveUserLLM}>
+                                {savedUserLLM ? 'Update' : 'Save'}
+                              </Button>
+                              <Button size="sm" colorScheme="red" variant="outline" onClick={handleClearUserLLM} isDisabled={!savedUserLLM}>
+                                Remove
+                              </Button>
+                            </HStack>
+                          </VStack>
+                        )}
+                      </VStack>
+                    </Stack>
+                  </RadioGroup>
                 </VStack>
               </TabPanel>
             </TabPanels>

--- a/webstack/libs/frontend/src/lib/utils/index.ts
+++ b/webstack/libs/frontend/src/lib/utils/index.ts
@@ -15,3 +15,4 @@ export * from './copyboardurl';
 export * from './isElectron';
 export * from './browserType';
 export * from './setupAppForFiles';
+export * from './userllm';

--- a/webstack/libs/frontend/src/lib/utils/userllm.ts
+++ b/webstack/libs/frontend/src/lib/utils/userllm.ts
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+// A user's own OpenAI-compatible credentials, kept in this browser only.
+//
+// These are deliberately NOT part of the `s3_user_settings` bundle: that blob
+// is designed to be reset wholesale by "Restore Default Settings", and a key
+// should never disappear as a side effect of resetting an unrelated preference.
+// They are never sent to the SAGE3 server for storage — only attached to the
+// AI requests that need them.
+
+import { LLMCapability, LLMConfiguration } from '@sage3/shared/types';
+import { USER_LLM_PROVIDER, UserLLMPayload } from '@sage3/shared';
+
+/**
+ * Storage backend for the key.
+ *
+ * `localStorage` keeps the key across sessions, which is what a user pasting
+ * their own key expects. Switch this one line to `sessionStorage` to have the
+ * key live only until the tab closes — never written to disk — at the cost of
+ * re-pasting it each session.
+ */
+const backend = (): Storage | undefined => (typeof window === 'undefined' ? undefined : window.localStorage);
+
+const STORAGE_KEY = 's3_user_llm';
+
+/**
+ * The provider name a user's own credentials appear under. This is the value
+ * stored in the `aiModel` setting and sent as the `model` field of an AI
+ * request when the user has chosen their own key, so it must not collide with
+ * a provider name from the server configuration.
+ *
+ * Defined in the shared wire contract so the frontend and the backend cannot
+ * drift apart on the name.
+ */
+export const USER_PROVIDER_NAME = USER_LLM_PROVIDER;
+
+/**
+ * What a user-supplied model is assumed to be able to do. Unlike server
+ * providers — which declare capabilities per model in the server config —
+ * there is no way to ask an arbitrary OpenAI-compatible endpoint what its
+ * model supports, so we assume the common text-model set. Image generation
+ * and embeddings are deliberately excluded: claiming them would light up UI
+ * that then fails at request time.
+ */
+export const USER_MODEL_CAPABILITIES: LLMCapability[] = ['chat', 'code', 'vision'];
+
+export type UserLLMCredentials = {
+  /** The API key. Sent with each AI request; never stored server-side. */
+  apiKey: string;
+  /** Optional OpenAI-compatible base URL. Empty means api.openai.com. */
+  baseUrl?: string;
+  /** The model id to request, e.g. `gpt-4o`. */
+  modelId: string;
+};
+
+/** Read the stored credentials, or undefined when none are set. */
+export function getUserLLM(): UserLLMCredentials | undefined {
+  try {
+    const raw = backend()?.getItem(STORAGE_KEY);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<UserLLMCredentials>;
+    // Both fields are required for the credentials to be usable at all
+    if (!parsed.apiKey || !parsed.modelId) return undefined;
+    return {
+      apiKey: parsed.apiKey,
+      baseUrl: parsed.baseUrl || undefined,
+      modelId: parsed.modelId,
+    };
+  } catch (e) {
+    // Corrupt or unreadable storage (private mode, cleared data): behave as unset
+    return undefined;
+  }
+}
+
+/** True when usable credentials are stored. */
+export function hasUserLLM(): boolean {
+  return getUserLLM() !== undefined;
+}
+
+/**
+ * Store the credentials. Values are trimmed; a trailing slash is removed from
+ * the base URL so it composes predictably on the backend.
+ */
+export function setUserLLM(creds: UserLLMCredentials): void {
+  const clean: UserLLMCredentials = {
+    apiKey: creds.apiKey.trim(),
+    baseUrl: creds.baseUrl?.trim().replace(/\/+$/, '') || undefined,
+    modelId: creds.modelId.trim(),
+  };
+  try {
+    backend()?.setItem(STORAGE_KEY, JSON.stringify(clean));
+  } catch (e) {
+    // Storage unavailable or full — the caller reports failure to the user
+    throw new Error('Could not save the key in this browser');
+  }
+}
+
+/** Remove the stored credentials. */
+export function clearUserLLM(): void {
+  try {
+    backend()?.removeItem(STORAGE_KEY);
+  } catch (e) {
+    // Nothing to do: unreadable storage is already effectively cleared
+  }
+}
+
+/**
+ * A display form of the key: last 4 characters only, for confirming which key
+ * is stored without putting the secret back on screen.
+ */
+export function maskApiKey(apiKey: string): string {
+  const tail = apiKey.slice(-4);
+  return tail ? `••••••••${tail}` : '';
+}
+
+/**
+ * Add the user's own credentials to an LLM configuration as an ordinary
+ * provider, so everything that reasons about providers — capability gating,
+ * the settings list, task availability — treats it like any other.
+ *
+ * Without this the user's provider is absent from the configuration, and
+ * `canProviderPerformTask` returns false for *every* task, blocking even plain
+ * chat. The key is deliberately left out: the manager never needs it, and
+ * omitting it keeps the secret out of anything that serializes the config.
+ *
+ * Returns the configuration unchanged when no credentials are stored.
+ */
+export function withUserProvider(config: LLMConfiguration): LLMConfiguration {
+  const creds = getUserLLM();
+  if (!config || !creds) return config;
+  return {
+    ...config,
+    providers: {
+      ...config.providers,
+      [USER_PROVIDER_NAME]: {
+        models: {
+          [creds.modelId]: {
+            model_id: creds.modelId,
+            capabilities: USER_MODEL_CAPABILITIES,
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
+ * The credentials in the shape the backend expects on the wire, or undefined
+ * when none are stored. The base URL is normalized here so the backend receives
+ * a value it can use directly.
+ */
+export function userLLMPayload(): UserLLMPayload | undefined {
+  const creds = getUserLLM();
+  if (!creds) return undefined;
+  return {
+    apiKey: creds.apiKey,
+    baseUrl: creds.baseUrl ? normalizeBaseUrl(creds.baseUrl) : undefined,
+    modelId: creds.modelId,
+  };
+}
+
+/** The endpoint used when no base URL is given. */
+export const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+
+/**
+ * Normalize a base URL the way the backend does: strip trailing slashes and
+ * append `/v1` when it is not already there, so a user can paste either
+ * `https://host` or `https://host/v1` and get the same result.
+ */
+export function normalizeBaseUrl(url?: string): string {
+  const trimmed = (url || '').trim().replace(/\/+$/, '');
+  if (!trimmed) return DEFAULT_BASE_URL;
+  return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+}
+
+/**
+ * Ask an OpenAI-compatible endpoint which models it offers (`GET /models`).
+ *
+ * Returns the model ids, sorted. Throws with a readable message on failure —
+ * callers should let an `AbortError` pass through untouched, since that means
+ * the caller cancelled the request rather than the endpoint refusing it.
+ *
+ * @param apiKey the key to authenticate with
+ * @param baseUrl optional base URL; defaults to OpenAI
+ * @param signal abort signal, so an in-flight lookup can be cancelled
+ */
+export async function fetchAvailableModels(apiKey: string, baseUrl: string | undefined, signal: AbortSignal): Promise<string[]> {
+  const url = `${normalizeBaseUrl(baseUrl)}/models`;
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { Authorization: `Bearer ${apiKey}` }, signal });
+  } catch (e) {
+    // Let cancellation propagate so the caller can ignore it
+    if (e instanceof DOMException && e.name === 'AbortError') throw e;
+    // A network-level failure here is usually CORS, a bad host, or (for an
+    // http:// endpoint) the page's own content-security policy
+    throw new Error('Could not reach that endpoint');
+  }
+  if (res.status === 401 || res.status === 403) {
+    throw new Error('That key was rejected');
+  }
+  if (!res.ok) {
+    throw new Error(`Endpoint returned ${res.status}`);
+  }
+  const body = (await res.json()) as { data?: { id?: string }[] };
+  const ids = (body?.data || []).map((m) => m?.id).filter((id): id is string => typeof id === 'string' && id.length > 0);
+  if (ids.length === 0) throw new Error('No models returned');
+  // Returned unfiltered: capable chat models are not reliably identifiable by
+  // name (o-series, chatgpt-*, and every non-OpenAI endpoint's own naming), so
+  // filtering would hide working models rather than only unusable ones
+  return ids.sort((a, b) => a.localeCompare(b));
+}

--- a/webstack/libs/shared/src/lib/ai/agents-api.ts
+++ b/webstack/libs/shared/src/lib/ai/agents-api.ts
@@ -11,6 +11,32 @@ export type SError = {
   message: string;
 };
 
+/**
+ * The provider name used when a request carries the user's own credentials
+ * rather than naming one of the server's configured providers. A request whose
+ * `model` field holds this value is expected to carry a `userllm` block.
+ */
+export const USER_LLM_PROVIDER = 'my-own-key';
+
+/**
+ * A user's own OpenAI-compatible credentials, attached to an AI request when
+ * they have chosen their own provider instead of one configured on the server.
+ *
+ * Present ONLY on those requests: a request naming a server provider is sent
+ * exactly as before, with no `userllm` field at all.
+ *
+ * The backend should use these for that single request and never persist them.
+ * `apiKey` is a bearer secret — it must be redacted from any request logging.
+ */
+export type UserLLMPayload = {
+  /** The user's API key, valid for this request only. */
+  apiKey: string;
+  /** Optional OpenAI-compatible base URL; absent means the OpenAI default. */
+  baseUrl?: string;
+  /** The model to call, e.g. `gpt-4o`. */
+  modelId: string;
+};
+
 // Request Types
 
 // Health check request

--- a/webstack/libs/shared/src/lib/ai/ideator-api.ts
+++ b/webstack/libs/shared/src/lib/ai/ideator-api.ts
@@ -108,7 +108,3 @@ export const IdeatorRoutes = {
   image: '/image',
   prose: '/prose',
 } as const;
-
-export const ImageGenerationRoutes = {
-  generate: '/image-generation',
-} as const;

--- a/webstack/libs/shared/src/lib/ai/image-api.ts
+++ b/webstack/libs/shared/src/lib/ai/image-api.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) SAGE3 Development Team 2026. All Rights Reserved
+ * University of Hawaii, University of Illinois Chicago, Virginia Tech
+ *
+ * Distributed under the terms of the SAGE3 License.  The full license is in
+ * the file LICENSE, distributed as part of this software.
+ */
+
+// Generic image generation.
+//
+// This is the plain "make an image from this prompt" path, used by any app that
+// wants an image. It is deliberately separate from the Ideator's image call,
+// which composes a brainstorming-specific prompt from ideator concepts
+// (dimensions, brainstorming prompt) and is only meaningful inside SageIdeator.
+
+/** Where the generic image-generation endpoint lives. */
+export const ImageGenerationRoutes = {
+  generate: '/image-generation',
+} as const;
+
+export type ImageGenerationRequest = {
+  /** The prompt, used as given. The caller decides how to phrase it. */
+  prompt: string;
+  /** Provider name, as for every other AI request. */
+  model: string;
+  /** Optional square size; defaults to 1024x1024 when omitted. */
+  size?: string;
+};
+
+export type ImageGenerationResponse = {
+  /** The generated image as a data URL. */
+  imageUrl: string;
+};

--- a/webstack/libs/shared/src/lib/ai/index.ts
+++ b/webstack/libs/shared/src/lib/ai/index.ts
@@ -9,3 +9,4 @@
 export * from './ai-api';
 export * from './agents-api';
 export * from './ideator-api';
+export * from './image-api';


### PR DESCRIPTION
Three related pieces of AI work. They landed together because each uncovered the next, but they are reviewable as separate commits.

| Commit | What |
|---|---|
| `ea0db022d` | Users can supply their own OpenAI-compatible API key |
| `c77183bac` | Image generation gets its own path, off the Ideator |
| `c7c2cca4a` | Fix: import the new agent after `load_dotenv()` |
| `b884c268c` | Chat slash commands, with `/image` |
| `2df58a945` | Docs |

26 files, +1240/−126.

---

## 1. Bring your own API key

A per-user provider, `my-own-key`, in **Settings → Intelligence**, so someone can run AI against their own OpenAI-compatible endpoint instead of the hub's. **Requests naming a server provider are byte-identical to before** — credentials are attached only when the request names the user's own provider, and that guard lives in one place rather than at each call site.

The card sits in the provider list with its form inline: API key (masked, never redisplayed), optional base URL, and a model. Entering a key or URL calls `GET {baseUrl}/models` to populate a dropdown — debounced, and any in-flight lookup aborted when either field changes. Endpoints without `/models` fall back to a typed model name.

**Decisions worth reviewing:**

- **Browser-only storage.** Its own `s3_user_llm` key, never in the database or the account record. Deliberately outside the `s3_user_settings` bundle so *Restore Default Settings* cannot delete a key as a side effect. Backend is one named line if `sessionStorage` is preferred.
- **Capabilities are assumed, not discovered** — `chat`, `code`, `vision`. Never `imagegen` or `embeddings`: an arbitrary endpoint can't be asked what it supports, and claiming them would enable UI that then fails at request time.
- **Request-supplied models are never cached.** The cache is keyed by provider name, which every personal-key user shares, so caching would hand one user's client *and key* to the next request naming that provider.
- **Guests and spectators refused** in the form, the radio and the save handler; opening Settings as a guest also clears a key a previous account left in that browser.
- **Azure is never inferred** — it needs an `api_version` the form has no field for.

**Secret handling:** removed a live leak (`pdf.py` did `logger.info(f"{qq}")`, which would have written the key verbatim on the first request), and `UserLLM` carries a redacting `__repr__` so future log lines print `apiKey='***'`. Verified `ai_logging.py` and homebase's morgan logging never touch bodies.

## 2. Image generation off the Ideator

Chat's image button called `seerIdeator.image()`, which ignores any caller prompt and composes a brainstorming one — *"Conceptual illustration for a brainstorming idea about…"*, *"Abstract, minimal, clean design. No text, labels, or words."* Chat could only pass title/summary/keywords, so **every Chat image was forced through a brainstorming frame and hard-coded to abstract/no-text**. Asking Chat to illustrate a Stickie could not produce a photo, a diagram, or anything with text in it.

The split was already half-done — `ImageGenerationRoutes` existed and seer exposed a neutral `/image-generation` — but the handler still lived in `IdeatorAgent` and the frontend still reached it through the ideator client.

| Layer | Generic | Ideator |
|---|---|---|
| shared | new `ai/image-api.ts` — `{ prompt, model, size? }` | `IdeatorImageRequest` unchanged |
| frontend | `seerImage.generate()` | `seerIdeator.image()` unchanged |
| homebase | `/agents/image-generation` | `/agents/ideator/image` → seer `/ideator/image` |
| seer | `/image-generation` → new `ImageGenAgent` | `/ideator/image` → `IdeatorAgent.image()` |

**SageIdeator is untouched** — same call, same composed prompt, same result; only the seer path behind it moved.

## 3. Chat slash commands

`/image <description>` generates from the typed prompt. Built as a **registry** (`Chat/commands.ts`) since more commands are expected: `COMMANDS` drives the parser, `/help`, and the unknown-command response, so adding `/web` or `/code` is a row plus a case.

- **`parseCommand` returns three outcomes** — a match, `'unknown'`, and `null`. That middle case is what makes this safe in a *shared* chat: a typo shows the command list instead of broadcasting `/imagg` to everyone. `"/IMAGE a bike"` matches; `"http://x/y"`, `"and/or this"` and a bare `"/"` stay ordinary messages.
- **Commands never touch the shared transcript** — output goes to a toast or the board. Every write to `messages` currently risks the last-write-wins overwrite noted below.
- **One shared image path**: the "Generate Image" button (linked Stickie) and `/image` (typed prompt) both go through `generateImage(text, label)`.
- `/image` is one-shot and doesn't change `mode`, sidestepping the derived-vs-chosen mode conflict at `Chat.tsx:273-290`. A future command that needs to *stay* in a mode is where that must be resolved.

Discoverability is the known weakness of slash commands; mitigated by the placeholder hint and by wrong commands surfacing the list.

---

## Pre-existing bugs fixed to make this diagnosable

Hit while debugging a bare 500; worth reviewing on their own merit:

1. **Seer flattened every error to 500** — routes caught only `HTTPException` and re-raised with `status_code=500`, discarding the chosen status; anything else became a detail-less 500 with no traceback. App-level handlers now preserve the status and log the traceback.
2. **The frontend discarded every backend error message** — it read `{message}` while FastAPI reports `{detail}`. `toSError()` reads both.
3. **Chat posts through its own `Chat/tRPC.ts`**, not the `seerAgents` client in `api/seer.ts` — which is dead code. Both now share `withUserCredentials`/`toSError`.

That third point is the one to watch: six endpoints have two client implementations, one unused, which is exactly how they drifted. Deleting `seerAgents` is a worthwhile follow-up, kept out of this PR.

## Docs

- **`Applications.md` (Chat)** — Commands, and Generating images.
- **`Architecture.md` (Seer)** — the provider list was stale (named OpenAI/Azure/Llama as though hard-coded); replaced with the capability registry Seer actually reads. The agent table was missing Summary, Ideator, image generation and `/webshot`. Added the `/image-generation` vs `/ideator/image` split and per-request `userllm`.
- **`Server-Deployment.md`** — *Users bringing their own key* under AI Configuration.

## Not covered

- **Mesonet** builds its chat model once at init, so it still uses the server's provider.
- **No server switch** to disable personal keys independently of AI as a whole.
- **`http://` endpoints** are blocked by the app's CSP during the model lookup; use `https://` or configure server-side.

## Testing

Typechecks clean across `shared`, `frontend`, `applications`, `homebase`; all touched Python parses; route wiring verified end to end on both image chains; the command parser verified against the cases that trip naive implementations.

**Not yet exercised against a live key or a live image model.** That is the one real gap: the first check is a chat request with a personal key (expect `own_key=yes` in the seer log and `***` where the key would be), and an `/image` request against a configured `imagegen` model.